### PR TITLE
# PR #11 — Sound & Light Machine: Testing & Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration for [Nanit
 | Nanit Pro | Fully supported |
 | Nanit Plus | Fully supported |
 | Nanit Pro Camera (standalone) | Supported (no sound machine features) |
+| Nanit Sound & Light Machine | Supported (local WebSocket or cloud relay) |
 
 > [!NOTE]
 > All Nanit cameras that work with the official Nanit app should work with this integration. If you have a model not listed above, please [open an issue](https://github.com/wealthystudent/ha-nanit/issues/new?template=bug_report.yml) to help us update this list.
@@ -41,6 +42,25 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration for [Nanit
 | Switch | Night Light | Toggle the camera's built-in night light. | Yes |
 | Switch | Camera Power | Toggle camera on/off (sleep mode). | Yes |
 | Number | Volume | Camera speaker volume (0–100%). | No |
+
+### Sound & Light Machine entities
+
+If a Nanit Sound & Light Machine is linked to a camera, these additional entities appear on a separate device:
+
+| Platform | Entity | Description | Enabled |
+|----------|--------|-------------|---------|
+| Switch | Power | Device power on/off. | Yes |
+| Switch | Sound | Toggle sound playback. | Yes |
+| Switch | Light | Toggle night light. | Yes |
+| Select | Sound Track | Choose from available sound tracks. | Yes |
+| Number | Volume | Sound volume (0–100%). | Yes |
+| Number | Brightness | Light brightness (0–100%). | Yes |
+| Sensor | Temperature | Device temperature in °C. | Yes |
+| Sensor | Humidity | Relative humidity (%). | Yes |
+| Sensor | Connection Mode | Diagnostic — shows Local, Cloud, or Unavailable. | No |
+| Binary Sensor | S&L Connectivity | WebSocket connection status. | No |
+
+S&L entities retain their last-known values when the WebSocket disconnects, rather than going "unavailable." This is an intentional design choice — it prevents entities from flashing "unavailable" during brief reconnection windows (e.g., the ~3-second hourly token refresh). The dedicated S&L Connectivity binary sensor and Connection Mode sensor report the actual connection state separately, so you can monitor connectivity without losing entity values.
 
 Entities marked "No" under Enabled are created but disabled by default. Enable them in **Settings → Devices & Services → Nanit → Entities**.
 
@@ -93,6 +113,7 @@ For faster LAN-first connectivity, configure a local IP per camera:
 |-------|----------|-------------|
 | Camera | Yes (multi-camera only) | Which camera to configure. Skipped if you only have one. |
 | Camera IP Address | No | Local IP (port 442). Leave blank for cloud-only mode. |
+| Speaker IP Address | No | Local IP of a linked Sound & Light Machine (port 442). Leave blank to use cloud relay. |
 
 When a camera IP is set, the integration connects directly over your LAN for sensor data and controls, using the cloud only for authentication and event detection. Clear the IP to return to cloud-only mode.
 
@@ -107,6 +128,8 @@ The integration uses two update mechanisms — no unnecessary polling for real-t
 | Camera connection status | **WebSocket push** | Instant (on change) | Camera (local or cloud) |
 | Motion and sound events | **Cloud polling** | Every 30 seconds | Nanit cloud API |
 | Live video stream | **On demand** | When viewed | RTMPS via Nanit media server |
+| S&L state (light, sound, power) | **WebSocket push** | Instant (on change) | S&L device (local or cloud relay) |
+| S&L temperature, humidity | **WebSocket push** | Instant (on change) | S&L device (local or cloud relay) |
 
 Push data arrives via a persistent WebSocket connection to the camera. If the connection drops, it reconnects automatically and logs the event.
 
@@ -188,7 +211,8 @@ automation:
 | **Self-signed TLS (local)** | Local camera connections use self-signed certificates. The integration accepts these automatically. |
 | **RTMPS streaming** | Live video uses `rtmps://media-secured.nanit.com`. Your HA instance must be able to reach this address. |
 | **Motion/sound is cloud-polled** | Motion and sound detection comes from the Nanit cloud API (polled every 30s), not from the camera directly. There may be up to ~30s delay. |
-| **No sound machine control** | Sound machine / white noise features are not yet supported. |
+| **S&L stale values when offline** | Sound & Light entities show their last-known values when the device is disconnected, rather than going "unavailable." Check the S&L Connectivity binary sensor to confirm the device is actually reachable. This is intentional — it avoids disruptive flickers during brief reconnection windows. |
+| **Cloud relay cannot detect S&L power-off** | When the Sound & Light Machine is connected via cloud relay (no local IP), powering off the device does not drop the WebSocket. The connectivity sensor continues showing "connected / cloud" until the connection times out. Local connections detect power-off immediately. |
 | **Session expiry** | Nanit access tokens expire. The integration refreshes them automatically, but if refresh fails, a re-authentication notification will appear. |
 
 ## Troubleshooting

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -131,11 +131,17 @@ def _async_remove_stale_devices(
     device_reg = dr.async_get(hass)
     known_camera_uids = {baby.camera_uid for baby in hub.babies}
 
+    # Build the set of valid device identifiers: raw camera UIDs and
+    # derived S&L identifiers ("{camera_uid}_sound_light").
+    valid_uids = set(known_camera_uids)
+    for uid in known_camera_uids:
+        valid_uids.add(f"{uid}_sound_light")
+
     for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
         device_uids = {
             identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN
         }
-        if device_uids and not device_uids & known_camera_uids:
+        if device_uids and not device_uids & valid_uids:
             LOGGER.info(
                 "Removing stale device %s (camera no longer on account)",
                 device.name,

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -326,6 +326,28 @@ def is_cloud_relay_forbidden(data: bytes) -> bool:
         return False
 
 
+def is_cloud_relay_error(data: bytes) -> bool:
+    """Check if a message is a non-200 error response in field 2 envelope.
+
+    The device (and cloud relay) may return error responses such as
+    400 "Failed to parse request". These use the same field 2 envelope
+    as cloud relay messages but with a non-200 status code.
+    """
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return False
+        inner = decode_fields(f2.value)
+        f_status = get_field(inner, 2)
+        if f_status is None or f_status.wire_type != VARINT:
+            return False
+        # Any status code that isn't 200 (success) or 403 (handled separately)
+        return f_status.value not in (200, 403)
+    except Exception:
+        return False
+
+
 def is_cloud_relay_ack(data: bytes) -> bool:
     """Check if a message is a cloud relay command acknowledgment.
 
@@ -569,18 +591,6 @@ def _encode_varint_field(field_number: int, value: int) -> bytes:
 def _encode_fixed32_field(field_number: int, data: bytes) -> bytes:
     """Encode a FIXED32 field."""
     return _encode_tag(field_number, FIXED32) + data
-
-
-def build_sl_keepalive() -> bytes:
-    """Build a minimal keepalive message for the S&L device.
-
-    We send a minimal valid protobuf message. The actual keepalive format
-    may differ — this is our best guess and will be refined in testing.
-    """
-    # Try an empty message — just a valid protobuf wrapper
-    # field 1 { } — empty submessage
-    inner = b""
-    return _encode_length_delimited(1, inner)
 
 
 def build_power_cmd(on: bool) -> bytes:

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -150,6 +150,98 @@ class SLDecodedState:
     timezone_rule: str | None = None
 
 
+def _parse_state_fields(state_fields: list[ProtoField]) -> SLDecodedState:
+    """Parse state fields into an SLDecodedState.
+
+    Shared by both local and cloud relay decoders. The state field structure
+    is identical in both framing formats.
+    """
+    result = SLDecodedState()
+
+    # Field 1: brightness (FIXED32 float)
+    f_brightness = get_field(state_fields, 1)
+    if f_brightness is not None and f_brightness.wire_type == FIXED32:
+        result.brightness = fixed32_to_float(f_brightness.value)
+
+    # Field 2: light config submessage { 1: light_enabled, 2: color_a, 3: color_b }
+    f_light = get_field(state_fields, 2)
+    if f_light is not None and f_light.wire_type == LENGTH_DELIMITED:
+        light_fields = decode_fields(f_light.value)
+        # Sub-1: light enabled flag (varint, INVERTED convention!)
+        # Device uses: absent or 0 = ON, 1 = OFF
+        f_light_en = get_field(light_fields, 1)
+        if f_light_en is not None and f_light_en.wire_type == VARINT:
+            result.light_enabled = f_light_en.value == 0
+        else:
+            result.light_enabled = True  # absent means ON
+        # Sub-2: color param A (hue)
+        f_color_a = get_field(light_fields, 2)
+        if f_color_a is not None and f_color_a.wire_type == FIXED32:
+            result.color_r = fixed32_to_float(f_color_a.value)
+        # Sub-3: color param B (saturation)
+        f_color_b = get_field(light_fields, 3)
+        if f_color_b is not None and f_color_b.wire_type == FIXED32:
+            result.color_g = fixed32_to_float(f_color_b.value)
+
+    # Field 3: VOLUME (FIXED32 float, 0.0-1.0)
+    f_vol = get_field(state_fields, 3)
+    if f_vol is not None and f_vol.wire_type == FIXED32:
+        result.volume = fixed32_to_float(f_vol.value)
+
+    # Field 4: sound config submessage { 1: sound_on, 2: track_name }
+    f_sound = get_field(state_fields, 4)
+    if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
+        sound_fields = decode_fields(f_sound.value)
+        # Sub-1: sound enabled flag (varint, INVERTED convention!)
+        f_sound_en = get_field(sound_fields, 1)
+        if f_sound_en is not None and f_sound_en.wire_type == VARINT:
+            result.sound_on = f_sound_en.value == 0
+        else:
+            result.sound_on = True  # absent means ON
+        # Sub-2: track name
+        f_name = get_field(sound_fields, 2)
+        if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
+            result.current_track = try_decode_string(f_name.value)
+
+    # Field 5: power on/off (varint, 0 or 1)
+    f_power = get_field(state_fields, 5)
+    if f_power is not None and f_power.wire_type == VARINT:
+        result.power_on = bool(f_power.value)
+
+    # Field 6: available sounds (submessage with repeated field 1 = strings)
+    f_sounds = get_field(state_fields, 6)
+    if f_sounds is not None and f_sounds.wire_type == LENGTH_DELIMITED:
+        sounds_fields = decode_fields(f_sounds.value)
+        tracks = []
+        for f in get_fields(sounds_fields, 1):
+            if f.wire_type == LENGTH_DELIMITED:
+                name = try_decode_string(f.value)
+                if name:
+                    tracks.append(name)
+        if tracks:
+            result.available_tracks = tracks
+
+    # Field 7: temperature (FIXED32 float)
+    f_temp = get_field(state_fields, 7)
+    if f_temp is not None and f_temp.wire_type == FIXED32:
+        result.temperature_c = fixed32_to_float(f_temp.value)
+
+    # Field 8: humidity (FIXED32 float)
+    f_hum = get_field(state_fields, 8)
+    if f_hum is not None and f_hum.wire_type == FIXED32:
+        result.humidity_pct = fixed32_to_float(f_hum.value)
+
+    # Field 11: timezone info
+    f_tz = get_field(state_fields, 11)
+    if f_tz is not None and f_tz.wire_type == LENGTH_DELIMITED:
+        tz_fields = decode_fields(f_tz.value)
+        f_tz_rule = get_field(tz_fields, 2)
+        if f_tz_rule is not None and f_tz_rule.wire_type == LENGTH_DELIMITED:
+            result.timezone_rule = try_decode_string(f_tz_rule.value)
+
+    return result
+
+
 def decode_full_state(data: bytes) -> SLDecodedState | None:
     """Decode message type 0 — full device state.
 
@@ -176,100 +268,62 @@ def decode_full_state(data: bytes) -> SLDecodedState | None:
                 return None  # This is a routines message
 
         state_fields = decode_fields(f6.value)
-        result = SLDecodedState()
-
-        # Field 1: brightness (FIXED32 float)
-        f_brightness = get_field(state_fields, 1)
-        if f_brightness is not None and f_brightness.wire_type == FIXED32:
-            result.brightness = fixed32_to_float(f_brightness.value)
-
-        # Field 2: light config submessage { 1: light_enabled, 2: color_a, 3: color_b }
-        f_light = get_field(state_fields, 2)
-        if f_light is not None and f_light.wire_type == LENGTH_DELIMITED:
-            light_fields = decode_fields(f_light.value)
-            # Sub-1: light enabled flag (varint, INVERTED convention!)
-            # Device uses: absent or 0 = ON, 1 = OFF
-            # Original capture had no sub-1 and light was ON.
-            # User confirmed: sending sub-1=1 turns light OFF.
-            f_light_en = get_field(light_fields, 1)
-            if f_light_en is not None and f_light_en.wire_type == VARINT:
-                result.light_enabled = f_light_en.value == 0
-            else:
-                result.light_enabled = True  # absent means ON
-            # Sub-2: color param A (hue)
-            f_color_a = get_field(light_fields, 2)
-            if f_color_a is not None and f_color_a.wire_type == FIXED32:
-                result.color_r = fixed32_to_float(f_color_a.value)
-            # Sub-3: color param B (saturation)
-            f_color_b = get_field(light_fields, 3)
-            if f_color_b is not None and f_color_b.wire_type == FIXED32:
-                result.color_g = fixed32_to_float(f_color_b.value)
-
-        # Field 3: VOLUME (FIXED32 float, 0.0-1.0)
-        # Confirmed by user testing: setting color accidentally sent
-        # saturation as field 3, which changed the device volume.
-        f_vol = get_field(state_fields, 3)
-        if f_vol is not None and f_vol.wire_type == FIXED32:
-            result.volume = fixed32_to_float(f_vol.value)
-
-        # Field 4: sound config submessage { 1: sound_on, 2: track_name }
-        f_sound = get_field(state_fields, 4)
-        if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
-            sound_fields = decode_fields(f_sound.value)
-            # Sub-1: sound enabled flag (varint, INVERTED convention!)
-            # Device uses: absent or 0 = ON, 1 = OFF (same as light)
-            f_sound_en = get_field(sound_fields, 1)
-            if f_sound_en is not None and f_sound_en.wire_type == VARINT:
-                result.sound_on = f_sound_en.value == 0
-            else:
-                result.sound_on = True  # absent means ON
-            # Sub-2: track name
-            f_name = get_field(sound_fields, 2)
-            if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
-                result.current_track = try_decode_string(f_name.value)
-
-        # Field 5: power on/off (varint, 0 or 1)
-        # User confirmed: this is the device power switch, not sound on/off.
-        f_power = get_field(state_fields, 5)
-        if f_power is not None and f_power.wire_type == VARINT:
-            result.power_on = bool(f_power.value)
-
-        # Field 6: available sounds (submessage with repeated field 1 = strings)
-        f_sounds = get_field(state_fields, 6)
-        if f_sounds is not None and f_sounds.wire_type == LENGTH_DELIMITED:
-            sounds_fields = decode_fields(f_sounds.value)
-            tracks = []
-            for f in get_fields(sounds_fields, 1):
-                if f.wire_type == LENGTH_DELIMITED:
-                    name = try_decode_string(f.value)
-                    if name:
-                        tracks.append(name)
-            if tracks:
-                result.available_tracks = tracks
-
-        # Field 7: temperature (FIXED32 float)
-        f_temp = get_field(state_fields, 7)
-        if f_temp is not None and f_temp.wire_type == FIXED32:
-            result.temperature_c = fixed32_to_float(f_temp.value)
-
-        # Field 8: humidity (FIXED32 float)
-        f_hum = get_field(state_fields, 8)
-        if f_hum is not None and f_hum.wire_type == FIXED32:
-            result.humidity_pct = fixed32_to_float(f_hum.value)
-
-        # Field 11: timezone info
-        f_tz = get_field(state_fields, 11)
-        if f_tz is not None and f_tz.wire_type == LENGTH_DELIMITED:
-            tz_fields = decode_fields(f_tz.value)
-            f_tz_rule = get_field(tz_fields, 2)
-            if f_tz_rule is not None and f_tz_rule.wire_type == LENGTH_DELIMITED:
-                result.timezone_rule = try_decode_string(f_tz_rule.value)
-
-        return result
+        return _parse_state_fields(state_fields)
 
     except Exception as err:
         _LOGGER.debug("Failed to decode S&L full state: %s", err)
         return None
+
+
+def decode_cloud_relay(data: bytes) -> SLDecodedState | None:
+    """Decode a cloud relay message — state wrapped in HTTP-like envelope.
+
+    Cloud relay structure: field 2 { field 2=status, field 3=text, field 4 { state } }
+    The state fields inside field 4 are the same format as local field 1.6.
+    """
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return None
+
+        inner = decode_fields(f2.value)
+
+        # Check for HTTP status (field 2 varint)
+        f_status = get_field(inner, 2)
+        if f_status is None or f_status.wire_type != VARINT:
+            return None
+
+        status_code = f_status.value
+        if status_code != 200:
+            # Non-200 (e.g. 403 Forbidden) — ignore silently
+            return None
+
+        # Extract state payload from field 4
+        f_payload = get_field(inner, 4)
+        if f_payload is None or f_payload.wire_type != LENGTH_DELIMITED:
+            return None
+
+        state_fields = decode_fields(f_payload.value)
+        return _parse_state_fields(state_fields)
+
+    except Exception as err:
+        _LOGGER.debug("Failed to decode S&L cloud relay message: %s", err)
+        return None
+
+
+def is_cloud_relay_forbidden(data: bytes) -> bool:
+    """Check if a message is a cloud relay 403 Forbidden (periodic, ignorable)."""
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return False
+        inner = decode_fields(f2.value)
+        f_status = get_field(inner, 2)
+        return f_status is not None and f_status.wire_type == VARINT and f_status.value == 403
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -508,6 +562,20 @@ def build_sl_keepalive() -> bytes:
     # field 1 { } — empty submessage
     inner = b""
     return _encode_length_delimited(1, inner)
+
+
+def build_state_request() -> bytes:
+    """Build a state request probe to prompt the device to send its full state.
+
+    Sends: 1 { 6 { } }  — an empty state body inside the command wrapper.
+
+    On a local WebSocket the device sends full state on connect, but the
+    cloud relay does not forward that initial dump. Sending this probe
+    after a cloud relay connect (and periodically thereafter) triggers the
+    device to echo back its current state.
+    """
+    field_6 = _encode_length_delimited(6, b"")
+    return _encode_length_delimited(1, field_6)
 
 
 def build_power_cmd(on: bool) -> bytes:

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -326,6 +326,20 @@ def is_cloud_relay_forbidden(data: bytes) -> bool:
         return False
 
 
+def is_cloud_relay_ack(data: bytes) -> bool:
+    """Check if a message is a cloud relay command acknowledgment.
+
+    Cloud relay sends back field 3 { field 1 { field 1: 1 } } after
+    receiving a command. These are safe to ignore.
+    """
+    try:
+        outer = decode_fields(data)
+        f3 = get_field(outer, 3)
+        return f3 is not None and f3.wire_type == LENGTH_DELIMITED
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Sensor decoding — Message type 1
 # ---------------------------------------------------------------------------
@@ -481,6 +495,7 @@ def classify_message(data: bytes) -> int | None:
         1 = sensor data (has field 1.10)
         2 = routine set A (type field = 2)
         3 = routine set B (type field = 3)
+        -1 = network info / ignorable (field 1 with large varint type indicator)
         None = unknown
     """
     try:
@@ -497,6 +512,10 @@ def classify_message(data: bytes) -> int | None:
             val = f1_inner.value
             if val in (2, 3):
                 return val
+            # Large varint values (e.g. timestamps) indicate network info
+            # or other device metadata messages — safe to ignore.
+            if val > 3:
+                return -1
 
         # Check for sensor data (field 10)
         f10 = get_field(inner, 10)

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -583,20 +583,6 @@ def build_sl_keepalive() -> bytes:
     return _encode_length_delimited(1, inner)
 
 
-def build_state_request() -> bytes:
-    """Build a state request probe to prompt the device to send its full state.
-
-    Sends: 1 { 6 { } }  — an empty state body inside the command wrapper.
-
-    On a local WebSocket the device sends full state on connect, but the
-    cloud relay does not forward that initial dump. Sending this probe
-    after a cloud relay connect (and periodically thereafter) triggers the
-    device to echo back its current state.
-    """
-    field_6 = _encode_length_delimited(6, b"")
-    return _encode_length_delimited(1, field_6)
-
-
 def build_power_cmd(on: bool) -> bytes:
     """Build command to turn device power on/off.
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -258,11 +258,30 @@ class NanitSoundLight:
     # ------------------------------------------------------------------
 
     async def _async_fetch_device_token(self) -> None:
-        """Fetch the RS256 device token from /speakers/{uid}/udtokens."""
+        """Fetch the RS256 device token from /speakers/{uid}/udtokens.
+
+        Uses the rest client's method if available, otherwise makes the
+        API call directly (for compatibility with aionanit < 1.1).
+        """
         access_token = await self._token_manager.async_get_access_token()
-        self._device_token = await self._rest.async_get_device_token(
-            access_token, self._speaker_uid
-        )
+
+        if hasattr(self._rest, "async_get_device_token"):
+            self._device_token = await self._rest.async_get_device_token(
+                access_token, self._speaker_uid
+            )
+        else:
+            # Inline fallback for aionanit versions without this method
+            resp = await self._session.post(
+                f"{self._rest._base_url}/speakers/{self._speaker_uid}/udtokens",
+                headers={"Authorization": access_token},
+            )
+            if resp.status == 401:
+                from aionanit import NanitAuthError
+                raise NanitAuthError("Access token invalid for device token request")
+            resp.raise_for_status()
+            body = await resp.json()
+            self._device_token = body["token"]
+
         _LOGGER.debug(
             "Fetched device token for speaker %s (len=%d)",
             self._speaker_uid,

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -30,12 +30,15 @@ from .sl_protocol import (
     build_power_cmd,
     build_sl_keepalive,
     build_sound_on_cmd,
+    build_state_request,
     build_track_cmd,
     build_volume_cmd,
     classify_message,
+    decode_cloud_relay,
     decode_full_state,
     decode_routines,
     decode_sensors,
+    is_cloud_relay_forbidden,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,19 +68,22 @@ class NanitSoundLight:
     Receives push state updates (protobuf) and provides command methods.
     """
 
-    # TODO: com6056's reference implementation uses a cloud relay at
-    # wss://remote.nanit.com/speakers/{uid}/user_connect/ with Bearer token
-    # instead of a direct local WebSocket. This would eliminate the need for
-    # a speaker IP and significantly improve UX. Not implemented yet — it's
-    # a different connection model that needs its own design.
+    # Connection strategy:
+    # - When a speaker IP is configured: prefer local WebSocket (wss://{ip}:442)
+    #   which provides full state on connect + temperature/humidity data.
+    #   Falls back to cloud relay if local connection fails.
+    # - When no IP is configured: use cloud relay
+    #   (wss://remote.nanit.com/speakers/{uid}/user_connect/) with Bearer token.
+    #   Cloud relay doesn't send initial state or temp/humidity, so we send
+    #   a state request probe after connecting.
 
     def __init__(
         self,
         speaker_uid: str,
-        device_ip: str,
         token_manager: TokenManager,
         rest_client: NanitRestClient,
         session: aiohttp.ClientSession,
+        device_ip: str | None = None,
     ) -> None:
         self._speaker_uid = speaker_uid
         self._device_ip = device_ip
@@ -90,6 +96,9 @@ class NanitSoundLight:
         self._connected: bool = False
         self._stopped: bool = False
         self._device_token: str | None = None
+        # Prefer local WebSocket when IP is configured (sends full state on
+        # connect, includes temp/humidity).  Fall back to cloud relay otherwise.
+        self._use_cloud_relay: bool = device_ip is None
 
         # WebSocket state
         self._ws: aiohttp.ClientWebSocketResponse | None = None
@@ -148,12 +157,16 @@ class NanitSoundLight:
     async def async_start(self) -> None:
         """Start the S&L connection.
 
-        1. Fetch device token from cloud API
-        2. Connect WebSocket to local device
-        3. Start recv loop, keepalive, and token refresh tasks
+        When a local IP is configured, connects via local WebSocket first
+        (wss://{ip}:442) — this provides full state on connect and includes
+        temperature/humidity data.  Falls back to cloud relay if local fails.
+
+        When no IP is configured, connects via cloud relay
+        (wss://remote.nanit.com) directly.
         """
         self._stopped = False
-        await self._async_fetch_device_token()
+        # Reset preference based on whether IP is available
+        self._use_cloud_relay = self._device_ip is None
         await self._async_connect()
 
     async def async_stop(self) -> None:
@@ -308,7 +321,11 @@ class NanitSoundLight:
     # ------------------------------------------------------------------
 
     async def _async_connect(self, *, silent: bool = False) -> None:
-        """Connect WebSocket to the local S&L device.
+        """Connect WebSocket to the S&L device.
+
+        Connection order depends on ``_use_cloud_relay``:
+        - False (IP configured): try local first, fall back to cloud relay.
+        - True  (no IP):         try cloud relay first, fall back to local.
 
         Args:
             silent: If True, suppress CONNECTION_CHANGE events during the
@@ -318,36 +335,87 @@ class NanitSoundLight:
         async with self._connect_lock:
             await self._async_close_ws()
 
-            if not self._device_token:
-                raise NanitConnectionError("No device token available")
-
             if self._ssl_ctx is None:
                 self._ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                 self._ssl_ctx.check_hostname = False
                 self._ssl_ctx.verify_mode = ssl.CERT_NONE
 
-            url = f"wss://{self._device_ip}:442/"
-            headers = {
-                "Authorization": f"token {self._device_token}",
-                "User-Agent": "NanitLite/1.8.0",
-            }
-
             if not silent:
                 self._connected = False
                 self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
 
-            try:
-                self._ws = await self._session.ws_connect(
-                    url,
-                    headers=headers,
-                    heartbeat=_HEARTBEAT_INTERVAL,
-                    timeout=_HANDSHAKE_TIMEOUT,
-                    ssl=self._ssl_ctx,
-                )
-            except Exception as err:
+            # ----- attempt local WebSocket first when preferred -----
+            if not self._use_cloud_relay and self._device_ip:
+                if not self._device_token:
+                    try:
+                        await self._async_fetch_device_token()
+                    except Exception as err:
+                        _LOGGER.debug(
+                            "Device token fetch failed for S&L %s: %s",
+                            self._speaker_uid,
+                            err,
+                        )
+
+                if self._device_token:
+                    url = f"wss://{self._device_ip}:442/"
+                    headers = {
+                        "Authorization": f"token {self._device_token}",
+                        "User-Agent": "NanitLite/1.8.0",
+                    }
+                    _LOGGER.debug(
+                        "Connecting S&L %s via local WebSocket at %s",
+                        self._speaker_uid,
+                        self._device_ip,
+                    )
+                    try:
+                        self._ws = await self._session.ws_connect(
+                            url,
+                            headers=headers,
+                            heartbeat=_HEARTBEAT_INTERVAL,
+                            timeout=_HANDSHAKE_TIMEOUT,
+                            ssl=self._ssl_ctx,
+                        )
+                    except Exception as err:
+                        _LOGGER.debug(
+                            "Local WebSocket failed for S&L %s: %s; trying cloud relay",
+                            self._speaker_uid,
+                            err,
+                        )
+                        self._ws = None
+
+            # ----- cloud relay (primary when no IP, fallback when local failed) -----
+            if self._ws is None:
+                try:
+                    access_token = await self._token_manager.async_get_access_token()
+                    url = f"wss://remote.nanit.com/speakers/{self._speaker_uid}/user_connect/"
+                    headers = {
+                        "Authorization": f"Bearer {access_token}",
+                        "User-Agent": "NanitLite/1.8.0",
+                    }
+                    _LOGGER.debug(
+                        "Connecting S&L %s via cloud relay", self._speaker_uid
+                    )
+                    self._ws = await self._session.ws_connect(
+                        url,
+                        headers=headers,
+                        heartbeat=_HEARTBEAT_INTERVAL,
+                        timeout=_HANDSHAKE_TIMEOUT,
+                        ssl=self._ssl_ctx,
+                    )
+                    # Track that we ended up on cloud relay (affects poll strategy)
+                    self._use_cloud_relay = True
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Cloud relay failed for S&L %s: %s",
+                        self._speaker_uid,
+                        err,
+                    )
+                    self._ws = None
+
+            if self._ws is None:
                 raise NanitConnectionError(
-                    f"S&L WebSocket connect failed: {err}"
-                ) from err
+                    f"S&L {self._speaker_uid}: all connection methods failed"
+                )
 
             self._connected = True
             loop = asyncio.get_running_loop()
@@ -370,10 +438,21 @@ class NanitSoundLight:
             self._poll_task = loop.create_task(self._poll_loop())
 
             self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+
+            # Cloud relay doesn't send a state dump on connect (local WS does).
+            # Send a state request probe to prompt the device to respond with
+            # its current state. This populates entities immediately on startup.
+            if self._use_cloud_relay and self._ws is not None:
+                try:
+                    await self._async_send(build_state_request())
+                    _LOGGER.debug("S&L sent state request probe after cloud relay connect")
+                except NanitTransportError:
+                    _LOGGER.debug("S&L state request probe failed (non-fatal)")
+
             _LOGGER.info(
-                "S&L device %s connected at %s:442",
+                "S&L device %s connected via %s",
                 self._speaker_uid,
-                self._device_ip,
+                "cloud relay" if self._use_cloud_relay else f"local ({self._device_ip}:442)",
             )
 
     async def _async_close_ws(self) -> None:
@@ -433,44 +512,61 @@ class NanitSoundLight:
         if not self._stopped:
             asyncio.get_running_loop().create_task(self._reconnect_loop())
 
+    def _apply_state(self, decoded: Any) -> None:
+        """Merge a decoded state into the current state and fire event."""
+        self._state = dataclasses.replace(
+            self._state,
+            brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
+            light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
+            color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
+            color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
+            volume=decoded.volume if decoded.volume is not None else self._state.volume,
+            current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
+            sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
+            power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
+            available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
+            temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
+            humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
+            timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
+        )
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+        _LOGGER.debug(
+            "S&L state: brightness=%.2f volume=%.2f track=%s power=%s light=%s sound=%s temp=%.1f hum=%.1f",
+            self._state.brightness or 0,
+            self._state.volume or 0,
+            self._state.current_track,
+            self._state.power_on,
+            self._state.light_enabled,
+            self._state.sound_on,
+            self._state.temperature_c or 0,
+            self._state.humidity_pct or 0,
+        )
+
     def _on_message(self, data: bytes) -> None:
-        """Handle a raw binary protobuf message from the S&L device."""
+        """Handle a raw binary protobuf message from the S&L device.
+
+        Supports both local WebSocket framing (field 1 envelope) and
+        cloud relay framing (field 2 envelope with HTTP status).
+        """
+        # Try cloud relay decoding first (field 2 envelope with status 200)
+        cloud_state = decode_cloud_relay(data)
+        if cloud_state is not None:
+            self._apply_state(cloud_state)
+            return
+
+        # Silently ignore cloud relay 403 Forbidden (periodic keepalive noise)
+        if is_cloud_relay_forbidden(data):
+            return
+
+        # Try local protocol decoding
         msg_type = classify_message(data)
 
         if msg_type == 0:
-            # Full state update
             decoded = decode_full_state(data)
             if decoded is not None:
-                self._state = dataclasses.replace(
-                    self._state,
-                    brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
-                    light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
-                    color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
-                    color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
-                    volume=decoded.volume if decoded.volume is not None else self._state.volume,
-                    current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
-                    sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
-                    power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
-                    available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
-                    temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
-                    humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
-                    timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
-                )
-                self._fire_event(SoundLightEventKind.STATE_UPDATE)
-                _LOGGER.debug(
-                    "S&L state: brightness=%.2f volume=%.2f track=%s power=%s light=%s sound=%s temp=%.1f hum=%.1f",
-                    self._state.brightness or 0,
-                    self._state.volume or 0,
-                    self._state.current_track,
-                    self._state.power_on,
-                    self._state.light_enabled,
-                    self._state.sound_on,
-                    self._state.temperature_c or 0,
-                    self._state.humidity_pct or 0,
-                )
+                self._apply_state(decoded)
 
         elif msg_type == 1:
-            # Sensor update
             decoded_sensors = decode_sensors(data)
             if decoded_sensors is not None:
                 self._state = dataclasses.replace(
@@ -481,7 +577,6 @@ class NanitSoundLight:
                 self._fire_event(SoundLightEventKind.SENSOR_UPDATE)
 
         elif msg_type in (2, 3):
-            # Routines update
             decoded_routines = decode_routines(data)
             if decoded_routines:
                 new_routines = tuple(
@@ -493,7 +588,6 @@ class NanitSoundLight:
                     )
                     for r in decoded_routines
                 )
-                # Merge with existing routines (type 2 and 3 are different sets)
                 existing = {r.name: r for r in self._state.routines}
                 for r in new_routines:
                     existing[r.name] = r
@@ -530,23 +624,38 @@ class NanitSoundLight:
             return
 
     async def _poll_loop(self) -> None:
-        """Periodically reconnect to refresh state from the device.
+        """Periodically request fresh state from the device.
 
-        The S&L device sends a full state dump on each WebSocket connect.
-        By reconnecting every _POLL_INTERVAL seconds we pick up any changes
-        made via the Nanit app (which communicates through the cloud, not
-        the local WebSocket).
+        For local WebSocket: the device sends a full state dump on each
+        connect, so we reconnect to refresh.
+
+        For cloud relay: reconnecting does NOT trigger a state dump.
+        Instead we send a state request probe on the existing connection.
         """
         try:
             while not self._stopped:
                 await asyncio.sleep(_POLL_INTERVAL)
                 if self._stopped:
                     return
-                _LOGGER.debug("S&L poll: reconnecting to refresh state")
-                try:
-                    await self._async_connect(silent=True)
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("S&L poll reconnect failed: %s", err)
+
+                if self._use_cloud_relay and self._ws is not None and not self._ws.closed:
+                    # Cloud relay: send probe on existing connection
+                    _LOGGER.debug("S&L poll: sending state request probe")
+                    try:
+                        await self._async_send(build_state_request())
+                    except NanitTransportError:
+                        _LOGGER.debug("S&L poll probe failed, triggering reconnect")
+                        try:
+                            await self._async_connect(silent=True)
+                        except Exception as err:  # noqa: BLE001
+                            _LOGGER.debug("S&L poll reconnect failed: %s", err)
+                else:
+                    # Local WebSocket: reconnect to get fresh state dump
+                    _LOGGER.debug("S&L poll: reconnecting to refresh state")
+                    try:
+                        await self._async_connect(silent=True)
+                    except Exception as err:  # noqa: BLE001
+                        _LOGGER.debug("S&L poll reconnect failed: %s", err)
         except asyncio.CancelledError:
             return
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -170,11 +170,22 @@ class NanitSoundLight:
 
         When no IP is configured, connects via cloud relay
         (wss://remote.nanit.com) directly.
+
+        If the initial connection fails, a background reconnect loop is
+        started so the coordinator can still set up entities (they will
+        show as unavailable until the connection succeeds).
         """
         self._stopped = False
         # Reset preference based on whether IP is available
         self._use_cloud_relay = self._device_ip is None
-        await self._async_connect()
+        try:
+            await self._async_connect()
+        except (NanitTransportError, NanitConnectionError):
+            _LOGGER.warning(
+                "S&L %s initial connection failed; will retry in background",
+                self._speaker_uid,
+            )
+            asyncio.get_running_loop().create_task(self._reconnect_loop())
 
     async def async_stop(self) -> None:
         """Stop the S&L connection gracefully."""
@@ -434,7 +445,7 @@ class NanitSoundLight:
                     # Track that we ended up on cloud relay (affects poll strategy)
                     self._use_cloud_relay = True
                 except Exception as err:
-                    _LOGGER.debug(
+                    _LOGGER.warning(
                         "Cloud relay failed for S&L %s: %s",
                         self._speaker_uid,
                         err,

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -28,7 +28,6 @@ from .sl_protocol import (
     build_color_cmd,
     build_light_enabled_cmd,
     build_power_cmd,
-    build_sl_keepalive,
     build_sound_on_cmd,
     build_track_cmd,
     build_volume_cmd,
@@ -38,12 +37,12 @@ from .sl_protocol import (
     decode_routines,
     decode_sensors,
     is_cloud_relay_ack,
+    is_cloud_relay_error,
     is_cloud_relay_forbidden,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-_KEEPALIVE_INTERVAL: float = 25.0
 _HEARTBEAT_INTERVAL: float = 60.0
 _HANDSHAKE_TIMEOUT: float = 15.0
 _INITIAL_BACKOFF: float = 1.85
@@ -103,7 +102,6 @@ class NanitSoundLight:
         # WebSocket state
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._recv_task: asyncio.Task[None] | None = None
-        self._keepalive_task: asyncio.Task[None] | None = None
         self._poll_task: asyncio.Task[None] | None = None
         self._token_refresh_task: asyncio.Task[None] | None = None
         self._ssl_ctx: ssl.SSLContext | None = None
@@ -451,7 +449,6 @@ class NanitSoundLight:
             self._connected = True
             loop = asyncio.get_running_loop()
             self._recv_task = loop.create_task(self._recv_loop())
-            self._keepalive_task = loop.create_task(self._keepalive_loop())
 
             # Start token refresh task if not already running
             if self._token_refresh_task is None or self._token_refresh_task.done():
@@ -477,16 +474,14 @@ class NanitSoundLight:
             )
 
     async def _async_close_ws(self) -> None:
-        """Close WebSocket and cancel recv/keepalive tasks."""
-        for task in (self._recv_task, self._keepalive_task):
-            if task is not None and not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        """Close WebSocket and cancel recv task."""
+        if self._recv_task is not None and not self._recv_task.done():
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
         self._recv_task = None
-        self._keepalive_task = None
 
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
@@ -575,8 +570,12 @@ class NanitSoundLight:
             self._apply_state(cloud_state)
             return
 
-        # Silently ignore cloud relay 403 Forbidden (periodic keepalive noise)
+        # Silently ignore cloud relay 403 Forbidden (periodic noise)
         if is_cloud_relay_forbidden(data):
+            return
+
+        # Silently ignore other error responses (e.g. 400 "Failed to parse request")
+        if is_cloud_relay_error(data):
             return
 
         # Silently ignore cloud relay command acknowledgments (field 3 envelope)
@@ -634,23 +633,8 @@ class NanitSoundLight:
             )
 
     # ------------------------------------------------------------------
-    # Internal — keepalive and reconnect
+    # Internal — poll and reconnect
     # ------------------------------------------------------------------
-
-    async def _keepalive_loop(self) -> None:
-        """Send keepalive messages periodically."""
-        try:
-            while True:
-                await asyncio.sleep(_KEEPALIVE_INTERVAL)
-                if self._ws is None or self._ws.closed:
-                    break
-                try:
-                    await self._async_send(build_sl_keepalive())
-                except NanitTransportError:
-                    _LOGGER.warning("S&L keepalive failed, triggering reconnect")
-                    break
-        except asyncio.CancelledError:
-            return
 
     async def _poll_loop(self) -> None:
         """Periodically reconnect to refresh state from the device.

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -7,7 +7,6 @@ import dataclasses
 import logging
 import ssl
 from collections.abc import Callable
-from typing import Any
 
 import aiohttp
 
@@ -102,9 +101,10 @@ class NanitSoundLight:
         # WebSocket state
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._recv_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
         self._poll_task: asyncio.Task[None] | None = None
         self._token_refresh_task: asyncio.Task[None] | None = None
-        self._ssl_ctx: ssl.SSLContext | None = None
+        self._local_ssl_ctx: ssl.SSLContext | None = None
         self._connect_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
@@ -122,6 +122,10 @@ class NanitSoundLight:
     @property
     def connected(self) -> bool:
         return self._connected
+
+    def restore_state(self, state: SoundLightFullState) -> None:
+        """Restore persisted state (used by coordinator on startup)."""
+        self._state = state
 
     @property
     def connection_mode(self) -> str:
@@ -185,14 +189,16 @@ class NanitSoundLight:
                 "S&L %s initial connection failed; will retry in background",
                 self._speaker_uid,
             )
-            asyncio.get_running_loop().create_task(self._reconnect_loop())
+            self._reconnect_task = asyncio.get_running_loop().create_task(
+                self._reconnect_loop()
+            )
 
     async def async_stop(self) -> None:
         """Stop the S&L connection gracefully."""
         self._stopped = True
         await self._async_close_ws()
 
-        for task_attr in ("_poll_task", "_token_refresh_task"):
+        for task_attr in ("_reconnect_task", "_poll_task", "_token_refresh_task"):
             task = getattr(self, task_attr, None)
             if task is not None and not task.done():
                 task.cancel()
@@ -300,11 +306,11 @@ class NanitSoundLight:
         """
         access_token = await self._token_manager.async_get_access_token()
 
-        if hasattr(self._rest, "async_get_device_token"):
+        try:
             self._device_token = await self._rest.async_get_device_token(
                 access_token, self._speaker_uid
             )
-        else:
+        except AttributeError:
             # Inline implementation matching the NanitLite app's exact request
             headers = {
                 "accept": "application/json",
@@ -315,7 +321,7 @@ class NanitSoundLight:
                 "x-nanit-service": "1.8.0 (168)",
             }
             async with self._session.get(
-                f"{self._rest._base_url}/speakers/{self._speaker_uid}/udtokens",
+                f"{self._rest.base_url}/speakers/{self._speaker_uid}/udtokens",
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=15),
             ) as resp:
@@ -375,10 +381,12 @@ class NanitSoundLight:
         async with self._connect_lock:
             await self._async_close_ws()
 
-            if self._ssl_ctx is None:
-                self._ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-                self._ssl_ctx.check_hostname = False
-                self._ssl_ctx.verify_mode = ssl.CERT_NONE
+            # Local connections use self-signed certs → CERT_NONE.
+            # Cloud relay (remote.nanit.com) uses default TLS verification (ssl=None).
+            if self._local_ssl_ctx is None:
+                self._local_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                self._local_ssl_ctx.check_hostname = False
+                self._local_ssl_ctx.verify_mode = ssl.CERT_NONE
 
             if not silent:
                 self._connected = False
@@ -413,7 +421,7 @@ class NanitSoundLight:
                             headers=headers,
                             heartbeat=_HEARTBEAT_INTERVAL,
                             timeout=_HANDSHAKE_TIMEOUT,
-                            ssl=self._ssl_ctx,
+                            ssl=self._local_ssl_ctx,
                         )
                     except Exception as err:
                         _LOGGER.debug(
@@ -440,7 +448,7 @@ class NanitSoundLight:
                         headers=headers,
                         heartbeat=_HEARTBEAT_INTERVAL,
                         timeout=_HANDSHAKE_TIMEOUT,
-                        ssl=self._ssl_ctx,
+                        # Cloud relay uses default TLS verification (no ssl= override)
                     )
                     # Track that we ended up on cloud relay (affects poll strategy)
                     self._use_cloud_relay = True
@@ -485,14 +493,16 @@ class NanitSoundLight:
             )
 
     async def _async_close_ws(self) -> None:
-        """Close WebSocket and cancel recv task."""
-        if self._recv_task is not None and not self._recv_task.done():
-            self._recv_task.cancel()
-            try:
-                await self._recv_task
-            except asyncio.CancelledError:
-                pass
-        self._recv_task = None
+        """Close WebSocket and cancel recv/reconnect tasks."""
+        for task_attr in ("_recv_task", "_reconnect_task"):
+            task = getattr(self, task_attr, None)
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            setattr(self, task_attr, None)
 
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
@@ -537,9 +547,11 @@ class NanitSoundLight:
         self._connected = False
         self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
         if not self._stopped:
-            asyncio.get_running_loop().create_task(self._reconnect_loop())
+            self._reconnect_task = asyncio.get_running_loop().create_task(
+                self._reconnect_loop()
+            )
 
-    def _apply_state(self, decoded: Any) -> None:
+    def _apply_state(self, decoded: SLDecodedState) -> None:
         """Merge a decoded state into the current state and fire event."""
         self._state = dataclasses.replace(
             self._state,

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -30,7 +30,6 @@ from .sl_protocol import (
     build_power_cmd,
     build_sl_keepalive,
     build_sound_on_cmd,
-    build_state_request,
     build_track_cmd,
     build_volume_cmd,
     classify_message,
@@ -75,8 +74,8 @@ class NanitSoundLight:
     #   Falls back to cloud relay if local connection fails.
     # - When no IP is configured: use cloud relay
     #   (wss://remote.nanit.com/speakers/{uid}/user_connect/) with Bearer token.
-    #   Cloud relay doesn't send initial state or temp/humidity, so we send
-    #   a state request probe after connecting.
+    #   Cloud relay doesn't send initial state on connect, so we restore
+    #   the last known state from HA Store on startup.
 
     def __init__(
         self,
@@ -125,6 +124,15 @@ class NanitSoundLight:
     @property
     def connected(self) -> bool:
         return self._connected
+
+    @property
+    def connection_mode(self) -> str:
+        """Return the current connection mode: 'local', 'cloud', or 'unavailable'."""
+        if not self._connected:
+            return "unavailable"
+        if self._use_cloud_relay:
+            return "cloud"
+        return "local"
 
     # ------------------------------------------------------------------
     # Subscription
@@ -297,26 +305,26 @@ class NanitSoundLight:
                 "user-agent": "NanitLite/1.8.0 (com.udisense.nanitlite; build:168; homeassistant)",
                 "x-nanit-service": "1.8.0 (168)",
             }
-            resp = await self._session.get(
+            async with self._session.get(
                 f"{self._rest._base_url}/speakers/{self._speaker_uid}/udtokens",
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=15),
-            )
-            if resp.status == 401:
-                from aionanit import NanitAuthError
-                raise NanitAuthError("Access token invalid for udtokens")
-            if resp.status != 200:
-                body = await resp.text()
-                raise NanitConnectionError(
-                    f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {body[:200]}"
-                )
-            body = await resp.json(content_type=None)
-            token = body.get("user_device_token", {}).get("token")
-            if not token:
-                raise NanitConnectionError(
-                    f"No token in udtokens response for speaker {self._speaker_uid}"
-                )
-            self._device_token = token
+            ) as resp:
+                if resp.status == 401:
+                    from aionanit import NanitAuthError
+                    raise NanitAuthError("Access token invalid for udtokens")
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise NanitConnectionError(
+                        f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {body[:200]}"
+                    )
+                body = await resp.json(content_type=None)
+                token = body.get("user_device_token", {}).get("token")
+                if not token:
+                    raise NanitConnectionError(
+                        f"No token in udtokens response for speaker {self._speaker_uid}"
+                    )
+                self._device_token = token
 
         _LOGGER.debug(
             "Fetched device token for speaker %s (len=%d)",
@@ -461,17 +469,6 @@ class NanitSoundLight:
             self._poll_task = loop.create_task(self._poll_loop())
 
             self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
-
-            # Cloud relay doesn't send a state dump on connect (local WS does).
-            # Send a state request probe — the device may respond with current
-            # state. The coordinator also restores last known state from disk
-            # so entities aren't "unknown" while waiting for the first update.
-            if self._use_cloud_relay and self._ws is not None:
-                try:
-                    await self._async_send(build_state_request())
-                    _LOGGER.debug("S&L sent state request probe after cloud relay connect")
-                except NanitTransportError:
-                    _LOGGER.debug("S&L state request probe failed (non-fatal)")
 
             _LOGGER.info(
                 "S&L device %s connected via %s",
@@ -656,38 +653,22 @@ class NanitSoundLight:
             return
 
     async def _poll_loop(self) -> None:
-        """Periodically request fresh state from the device.
+        """Periodically reconnect to refresh state from the device.
 
-        For local WebSocket: the device sends a full state dump on each
-        connect, so we reconnect to refresh.
-
-        For cloud relay: reconnecting does NOT trigger a state dump.
-        Instead we send a state request probe on the existing connection.
+        The local WebSocket sends a full state dump on each connect.
+        For cloud relay, state is pushed on changes and restored from
+        disk on startup — reconnecting keeps the connection healthy.
         """
         try:
             while not self._stopped:
                 await asyncio.sleep(_POLL_INTERVAL)
                 if self._stopped:
                     return
-
-                if self._use_cloud_relay and self._ws is not None and not self._ws.closed:
-                    # Cloud relay: send state request probe on existing connection
-                    _LOGGER.debug("S&L poll: sending state request probe")
-                    try:
-                        await self._async_send(build_state_request())
-                    except NanitTransportError:
-                        _LOGGER.debug("S&L poll probe failed, triggering reconnect")
-                        try:
-                            await self._async_connect(silent=True)
-                        except Exception as err:  # noqa: BLE001
-                            _LOGGER.debug("S&L poll reconnect failed: %s", err)
-                else:
-                    # Local WebSocket: reconnect to get fresh state dump
-                    _LOGGER.debug("S&L poll: reconnecting to refresh state")
-                    try:
-                        await self._async_connect(silent=True)
-                    except Exception as err:  # noqa: BLE001
-                        _LOGGER.debug("S&L poll reconnect failed: %s", err)
+                _LOGGER.debug("S&L poll: reconnecting to refresh state")
+                try:
+                    await self._async_connect(silent=True)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug("S&L poll reconnect failed: %s", err)
         except asyncio.CancelledError:
             return
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -38,6 +38,7 @@ from .sl_protocol import (
     decode_full_state,
     decode_routines,
     decode_sensors,
+    is_cloud_relay_ack,
     is_cloud_relay_forbidden,
 )
 
@@ -271,10 +272,14 @@ class NanitSoundLight:
     # ------------------------------------------------------------------
 
     async def _async_fetch_device_token(self) -> None:
-        """Fetch the RS256 device token from /speakers/{uid}/udtokens.
+        """Fetch the RS256 device token via GET /speakers/{uid}/udtokens.
+
+        The NanitLite app uses specific headers for this endpoint.
+        Returns a short-lived RS256 JWT used to authenticate the local
+        WebSocket connection (wss://{ip}:442/).
 
         Uses the rest client's method if available, otherwise makes the
-        API call directly (for compatibility with aionanit < 1.1).
+        API call directly (the installed aionanit package may not have it).
         """
         access_token = await self._token_manager.async_get_access_token()
 
@@ -283,17 +288,35 @@ class NanitSoundLight:
                 access_token, self._speaker_uid
             )
         else:
-            # Inline fallback for aionanit versions without this method
-            resp = await self._session.post(
+            # Inline implementation matching the NanitLite app's exact request
+            headers = {
+                "accept": "application/json",
+                "authorization": f"token {access_token}",
+                "accept-charset": "UTF-8",
+                "x-nanit-platform": "homeassistant",
+                "user-agent": "NanitLite/1.8.0 (com.udisense.nanitlite; build:168; homeassistant)",
+                "x-nanit-service": "1.8.0 (168)",
+            }
+            resp = await self._session.get(
                 f"{self._rest._base_url}/speakers/{self._speaker_uid}/udtokens",
-                headers={"Authorization": access_token},
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
             )
             if resp.status == 401:
                 from aionanit import NanitAuthError
-                raise NanitAuthError("Access token invalid for device token request")
-            resp.raise_for_status()
-            body = await resp.json()
-            self._device_token = body["token"]
+                raise NanitAuthError("Access token invalid for udtokens")
+            if resp.status != 200:
+                body = await resp.text()
+                raise NanitConnectionError(
+                    f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {body[:200]}"
+                )
+            body = await resp.json(content_type=None)
+            token = body.get("user_device_token", {}).get("token")
+            if not token:
+                raise NanitConnectionError(
+                    f"No token in udtokens response for speaker {self._speaker_uid}"
+                )
+            self._device_token = token
 
         _LOGGER.debug(
             "Fetched device token for speaker %s (len=%d)",
@@ -440,8 +463,9 @@ class NanitSoundLight:
             self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
 
             # Cloud relay doesn't send a state dump on connect (local WS does).
-            # Send a state request probe to prompt the device to respond with
-            # its current state. This populates entities immediately on startup.
+            # Send a state request probe — the device may respond with current
+            # state. The coordinator also restores last known state from disk
+            # so entities aren't "unknown" while waiting for the first update.
             if self._use_cloud_relay and self._ws is not None:
                 try:
                     await self._async_send(build_state_request())
@@ -558,6 +582,10 @@ class NanitSoundLight:
         if is_cloud_relay_forbidden(data):
             return
 
+        # Silently ignore cloud relay command acknowledgments (field 3 envelope)
+        if is_cloud_relay_ack(data):
+            return
+
         # Try local protocol decoding
         msg_type = classify_message(data)
 
@@ -596,6 +624,10 @@ class NanitSoundLight:
                     routines=tuple(existing.values()),
                 )
                 self._fire_event(SoundLightEventKind.ROUTINES_UPDATE)
+
+        elif msg_type == -1:
+            # Network info / device metadata — safe to ignore
+            pass
 
         else:
             _LOGGER.debug(
@@ -639,7 +671,7 @@ class NanitSoundLight:
                     return
 
                 if self._use_cloud_relay and self._ws is not None and not self._ws.closed:
-                    # Cloud relay: send probe on existing connection
+                    # Cloud relay: send state request probe on existing connection
                     _LOGGER.debug("S&L poll: sending state request probe")
                     try:
                         await self._async_send(build_state_request())

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -390,11 +390,11 @@ class NanitOptionsFlow(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_CAMERA_IP,
-                        default=current_ip,
+                        description={"suggested_value": current_ip},
                     ): cv.string,
                     vol.Optional(
                         CONF_SPEAKER_IP,
-                        default=current_speaker_ip,
+                        description={"suggested_value": current_speaker_ip},
                     ): cv.string,
                 }
             ),

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -223,6 +223,10 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
     Persists the last known state to HA storage so that entities show
     their previous values on restart (instead of "unknown") until the
     first live update arrives from the device.
+
+    Uses a grace period for disconnections so brief reconnections
+    (e.g. during hourly access-token refresh) do not flash entities
+    as "Unavailable" in HA.
     """
 
     config_entry: NanitConfigEntry
@@ -248,16 +252,19 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
             _SL_STORE_VERSION,
             f"{DOMAIN}_sl_state_{sound_light.speaker_uid}",
         )
+        self._sl_connected: bool = False
+        self._availability_timer: CALLBACK_TYPE | None = None
 
     @property
     def connected(self) -> bool:
-        """Derive connection state from the underlying S&L device."""
-        return self.sound_light.connected
+        """Return debounced connection state (survives brief reconnections)."""
+        return self._sl_connected
 
     async def async_setup(self) -> None:
         """Start the S&L device and subscribe to push events."""
         self._unsubscribe = self.sound_light.subscribe(self._on_sl_event)
         await self.sound_light.async_start()
+        self._sl_connected = self.sound_light.connected
 
         # If the device hasn't sent initial state yet (cloud relay),
         # restore the last known state from disk so entities aren't "unknown".
@@ -318,11 +325,30 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
     @callback
     def _on_sl_event(self, event: SoundLightEvent) -> None:
         """Handle a push event from NanitSoundLight.subscribe()."""
-        if event.kind == SoundLightEventKind.CONNECTION_CHANGE and not self.connected:
-            _LOGGER.debug(
-                "S&L %s disconnected",
-                self.sound_light.speaker_uid,
-            )
+        if event.kind == SoundLightEventKind.CONNECTION_CHANGE:
+            transport_connected = self.sound_light.connected
+            if transport_connected:
+                # Connection is up — cancel any pending unavailability timer
+                # and mark connected immediately.
+                self._cancel_availability_timer()
+                if not self._sl_connected:
+                    _LOGGER.info(
+                        "S&L %s reconnected",
+                        self.sound_light.speaker_uid,
+                    )
+                self._sl_connected = True
+            elif self._sl_connected:
+                # Connection just dropped — start the grace period.
+                # Don't mark unavailable yet; give the transport time to reconnect.
+                _LOGGER.debug(
+                    "S&L %s disconnected (grace period %.0fs)",
+                    self.sound_light.speaker_uid,
+                    _AVAILABILITY_GRACE_SECONDS,
+                )
+                self._start_availability_timer()
+            # If already disconnected and transport still disconnected,
+            # do nothing — timer is already running or fired.
+
         self.async_set_updated_data(event.state)
 
         # Save state to disk on every meaningful update so it survives restarts
@@ -332,8 +358,35 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         ):
             self.hass.async_create_task(self._async_save_state(event.state))
 
+    @callback
+    def _on_availability_timeout(self, _now: object) -> None:
+        """Grace period expired — mark S&L entities unavailable."""
+        self._availability_timer = None
+        if not self.sound_light.connected:
+            _LOGGER.warning(
+                "S&L %s still disconnected after %.0fs grace period",
+                self.sound_light.speaker_uid,
+                _AVAILABILITY_GRACE_SECONDS,
+            )
+            self._sl_connected = False
+            self.async_update_listeners()
+
+    def _start_availability_timer(self) -> None:
+        """Start (or restart) the grace period timer."""
+        self._cancel_availability_timer()
+        self._availability_timer = async_call_later(
+            self.hass, _AVAILABILITY_GRACE_SECONDS, self._on_availability_timeout
+        )
+
+    def _cancel_availability_timer(self) -> None:
+        """Cancel the grace period timer if running."""
+        if self._availability_timer is not None:
+            self._availability_timer()
+            self._availability_timer = None
+
     async def async_shutdown(self) -> None:
         """Stop the S&L device and unsubscribe."""
+        self._cancel_availability_timer()
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -22,9 +22,12 @@ from collections.abc import Callable
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import dataclasses
+
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from aionanit import NanitAuthError, NanitCamera, NanitConnectionError
@@ -201,12 +204,25 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
             ) from err
 
 
+_SL_STORE_VERSION = 1
+# Fields from SoundLightFullState that we persist across restarts.
+_SL_PERSIST_FIELDS = (
+    "brightness", "light_enabled", "color_r", "color_g",
+    "sound_on", "current_track", "volume",
+    "power_on", "temperature_c", "humidity_pct",
+)
+
+
 class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
     """Push-based coordinator for the Nanit Sound & Light Machine.
 
     Wraps NanitSoundLight.subscribe() — receives state updates from
-    the S&L device's local WebSocket (raw protobuf over wss://{ip}:442).
+    the S&L device via WebSocket (cloud relay or local).
     No polling — all state is pushed by the device.
+
+    Persists the last known state to HA storage so that entities show
+    their previous values on restart (instead of "unknown") until the
+    first live update arrives from the device.
     """
 
     config_entry: NanitConfigEntry
@@ -227,6 +243,11 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         self.sound_light = sound_light
         self.baby: Baby = None  # type: ignore[assignment]  # Set by hub._setup_camera before use
         self._unsubscribe: Callable[[], None] | None = None
+        self._store: Store = Store(
+            hass,
+            _SL_STORE_VERSION,
+            f"{DOMAIN}_sl_state_{sound_light.speaker_uid}",
+        )
 
     @property
     def connected(self) -> bool:
@@ -237,7 +258,62 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         """Start the S&L device and subscribe to push events."""
         self._unsubscribe = self.sound_light.subscribe(self._on_sl_event)
         await self.sound_light.async_start()
-        self.async_set_updated_data(self.sound_light.state)
+
+        # If the device hasn't sent initial state yet (cloud relay),
+        # restore the last known state from disk so entities aren't "unknown".
+        state = self.sound_light.state
+        if state.power_on is None:
+            restored = await self._async_restore_state()
+            if restored is not None:
+                # Feed restored state into the sound_light instance so
+                # entities and coordinator data are consistent.
+                self.sound_light._state = restored
+                state = restored
+                _LOGGER.debug(
+                    "S&L %s: restored saved state (power=%s, track=%s, vol=%s)",
+                    self.sound_light.speaker_uid,
+                    restored.power_on,
+                    restored.current_track,
+                    restored.volume,
+                )
+
+        self.async_set_updated_data(state)
+
+    async def _async_restore_state(self) -> SoundLightFullState | None:
+        """Load persisted S&L state from HA storage."""
+        try:
+            data = await self._store.async_load()
+            if not data or not isinstance(data, dict):
+                return None
+            kwargs = {}
+            for field in _SL_PERSIST_FIELDS:
+                if field in data and data[field] is not None:
+                    kwargs[field] = data[field]
+            if not kwargs:
+                return None
+            # Convert available_tracks if present
+            if "available_tracks" in data and data["available_tracks"]:
+                kwargs["available_tracks"] = tuple(data["available_tracks"])
+            return SoundLightFullState(**kwargs)
+        except Exception:
+            _LOGGER.debug("Failed to restore S&L state", exc_info=True)
+            return None
+
+    async def _async_save_state(self, state: SoundLightFullState) -> None:
+        """Persist current S&L state to HA storage."""
+        try:
+            data = {}
+            for field in _SL_PERSIST_FIELDS:
+                val = getattr(state, field, None)
+                if val is not None:
+                    data[field] = val
+            # Also save available_tracks
+            if state.available_tracks:
+                data["available_tracks"] = list(state.available_tracks)
+            if data:
+                await self._store.async_save(data)
+        except Exception:
+            _LOGGER.debug("Failed to save S&L state", exc_info=True)
 
     @callback
     def _on_sl_event(self, event: SoundLightEvent) -> None:
@@ -249,10 +325,19 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
             )
         self.async_set_updated_data(event.state)
 
+        # Save state to disk on every meaningful update so it survives restarts
+        if event.kind in (
+            SoundLightEventKind.STATE_UPDATE,
+            SoundLightEventKind.SENSOR_UPDATE,
+        ):
+            self.hass.async_create_task(self._async_save_state(event.state))
+
     async def async_shutdown(self) -> None:
         """Stop the S&L device and unsubscribe."""
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None
+        # Save final state before stopping
+        await self._async_save_state(self.sound_light.state)
         await self.sound_light.async_stop()
         await super().async_shutdown()

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -254,6 +254,8 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         )
         self._sl_connected: bool = False
         self._availability_timer: CALLBACK_TYPE | None = None
+        self._save_timer: CALLBACK_TYPE | None = None
+        self._pending_save_state: SoundLightFullState | None = None
 
     @property
     def connected(self) -> bool:
@@ -274,7 +276,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
             if restored is not None:
                 # Feed restored state into the sound_light instance so
                 # entities and coordinator data are consistent.
-                self.sound_light._state = restored
+                self.sound_light.restore_state(restored)
                 state = restored
                 _LOGGER.debug(
                     "S&L %s: restored saved state (power=%s, track=%s, vol=%s)",
@@ -351,12 +353,33 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
 
         self.async_set_updated_data(event.state)
 
-        # Save state to disk on every meaningful update so it survives restarts
+        # Debounce state saves — at most every 5 seconds to avoid
+        # overlapping writes from rapid state/sensor updates.
         if event.kind in (
             SoundLightEventKind.STATE_UPDATE,
             SoundLightEventKind.SENSOR_UPDATE,
         ):
-            self.hass.async_create_task(self._async_save_state(event.state))
+            self._schedule_save(event.state)
+
+    @callback
+    def _schedule_save(self, state: SoundLightFullState) -> None:
+        """Schedule a debounced state save (at most every 5 seconds)."""
+        self._pending_save_state = state
+        if self._save_timer is not None:
+            # Timer already running — it will pick up the latest state
+            return
+        self._save_timer = async_call_later(
+            self.hass, 5, self._do_save
+        )
+
+    @callback
+    def _do_save(self, _now: object) -> None:
+        """Execute the debounced state save."""
+        self._save_timer = None
+        if self._pending_save_state is not None:
+            state = self._pending_save_state
+            self._pending_save_state = None
+            self.hass.async_create_task(self._async_save_state(state))
 
     @callback
     def _on_availability_timeout(self, _now: object) -> None:
@@ -387,6 +410,11 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
     async def async_shutdown(self) -> None:
         """Stop the S&L device and unsubscribe."""
         self._cancel_availability_timer()
+        # Cancel debounced save timer and flush final state
+        if self._save_timer is not None:
+            self._save_timer()
+            self._save_timer = None
+        self._pending_save_state = None
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -71,9 +71,13 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return True when the coordinator has data and S&L device is connected."""
+        """Return True when the coordinator has received data.
+
+        Does NOT require an active connection — entities retain their last
+        known values when the WebSocket drops. Connection state is reported
+        separately by the S&L connectivity binary sensor.
+        """
         return (
             self.coordinator.last_update_success
             and self.coordinator.data is not None
-            and self.coordinator.connected
         )

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -223,10 +223,11 @@ class NanitHub:
             except NanitAuthError:
                 raise
             except Exception:
-                _LOGGER.info(
+                _LOGGER.warning(
                     "Sound & Light Machine coordinator for %s failed to start; "
                     "sound/light entities disabled",
                     baby.name,
+                    exc_info=True,
                 )
                 sound_light_coordinator = None
         else:
@@ -277,7 +278,7 @@ class NanitHub:
             device_ip=device_ip,
             token_manager=self._client.token_manager,
             rest_client=self._client.rest_client,
-            session=self._client.session,
+            session=getattr(self._client, "session", self._client._session),
         )
         self._sound_lights[speaker_uid] = sl
         return sl

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -212,7 +212,7 @@ class NanitHub:
         if not speaker_uid:
             speaker_uid = getattr(baby, "speaker_uid", None)
 
-        if speaker_uid and speaker_ip:
+        if speaker_uid:
             try:
                 sound_light = self.get_sound_light(speaker_uid, speaker_ip)
                 sound_light_coordinator = NanitSoundLightCoordinator(
@@ -232,11 +232,8 @@ class NanitHub:
                 sound_light_coordinator = None
         else:
             _LOGGER.debug(
-                "No speaker UID/IP for %s; Sound & Light Machine entities skipped "
-                "(speaker_uid=%s, speaker_ip=%s)",
+                "No speaker UID for %s; Sound & Light Machine entities skipped",
                 baby.name,
-                speaker_uid,
-                speaker_ip,
             )
 
         ir.async_delete_issue(self._hass, DOMAIN, f"camera_connection_failed_{baby.camera_uid}")
@@ -264,7 +261,7 @@ class NanitHub:
     def get_sound_light(
         self,
         speaker_uid: str,
-        device_ip: str,
+        device_ip: str | None = None,
     ) -> NanitSoundLight:
         """Get or create a NanitSoundLight instance."""
         if speaker_uid in self._sound_lights:
@@ -275,10 +272,10 @@ class NanitHub:
 
         sl = NanitSoundLight(
             speaker_uid=speaker_uid,
-            device_ip=device_ip,
             token_manager=self._client.token_manager,
             rest_client=self._client.rest_client,
             session=getattr(self._client, "session", self._client._session),
+            device_ip=device_ip,
         )
         self._sound_lights[speaker_uid] = sl
         return sl

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -111,19 +111,32 @@ class NanitHub:
             _LOGGER.warning("No babies/cameras found on Nanit account")
             return
 
-        # Discover speaker UIDs from the raw /babies API response.
-        # The installed aionanit package may not have speaker_uid on the Baby
-        # dataclass yet, so we fetch it ourselves as a fallback.
-        speaker_uid_map: dict[str, str] = {}
-        for baby in babies:
-            uid = getattr(baby, "speaker_uid", None)
-            if uid:
-                speaker_uid_map[baby.camera_uid] = uid
+        # Discover speaker UIDs — try persisted data first, then aionanit,
+        # then raw /babies API as final fallback.
+        speaker_uid_map: dict[str, str] = dict(
+            self._entry.data.get("speaker_uid_map", {})
+        )
+        if not speaker_uid_map:
+            for baby in babies:
+                uid = getattr(baby, "speaker_uid", None)
+                if uid:
+                    speaker_uid_map[baby.camera_uid] = uid
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
             except Exception:
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+
+        # Persist discovered speaker UIDs so they survive restarts
+        stored_map = self._entry.data.get("speaker_uid_map", {})
+        if speaker_uid_map and speaker_uid_map != stored_map:
+            self._hass.config_entries.async_update_entry(
+                self._entry,
+                data={**self._entry.data, "speaker_uid_map": speaker_uid_map},
+            )
+            _LOGGER.info(
+                "Persisted speaker UID map: %s", speaker_uid_map
+            )
 
         # Per-camera IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
@@ -316,7 +329,9 @@ class NanitHub:
         result: dict[str, str] = {}
         for baby in body.get("babies", []):
             camera_uid = baby.get("camera_uid")
-            speaker_uid = baby.get("speaker", {}).get("speaker", {}).get("uid")
+            speaker_data = baby.get("speaker", {})
+            speaker_obj = speaker_data.get("speaker", {})
+            speaker_uid = speaker_obj.get("uid")
             if camera_uid and speaker_uid:
                 result[camera_uid] = speaker_uid
                 _LOGGER.debug(

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -111,6 +111,20 @@ class NanitHub:
             _LOGGER.warning("No babies/cameras found on Nanit account")
             return
 
+        # Discover speaker UIDs from the raw /babies API response.
+        # The installed aionanit package may not have speaker_uid on the Baby
+        # dataclass yet, so we fetch it ourselves as a fallback.
+        speaker_uid_map: dict[str, str] = {}
+        for baby in babies:
+            uid = getattr(baby, "speaker_uid", None)
+            if uid:
+                speaker_uid_map[baby.camera_uid] = uid
+        if not speaker_uid_map:
+            try:
+                speaker_uid_map = await self._discover_speaker_uids()
+            except Exception:
+                _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+
         # Per-camera IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
         speaker_ips: dict[str, str] = self._entry.options.get(CONF_SPEAKER_IPS, {})
@@ -119,7 +133,12 @@ class NanitHub:
         failed_cameras: list[str] = []
         for baby in babies:
             try:
-                await self._setup_camera(baby, camera_ips.get(baby.camera_uid), speaker_ips.get(baby.camera_uid))
+                await self._setup_camera(
+                    baby,
+                    camera_ips.get(baby.camera_uid),
+                    speaker_ips.get(baby.camera_uid),
+                    speaker_uid_map.get(baby.camera_uid),
+                )
             except NanitAuthError:
                 # Auth errors are account-level — propagate immediately
                 raise
@@ -161,6 +180,7 @@ class NanitHub:
         baby: Baby,
         camera_ip: str | None,
         speaker_ip: str | None,
+        speaker_uid: str | None = None,
     ) -> None:
         """Create a camera instance and its coordinators for a single baby."""
         camera = self._client.camera(
@@ -188,7 +208,9 @@ class NanitHub:
 
         # Sound & Light Machine coordinator (optional — local WebSocket push)
         sound_light_coordinator: NanitSoundLightCoordinator | None = None
-        speaker_uid = baby.speaker_uid
+        # Use speaker_uid passed from the discovery map; fall back to Baby attr
+        if not speaker_uid:
+            speaker_uid = getattr(baby, "speaker_uid", None)
 
         if speaker_uid and speaker_ip:
             try:
@@ -274,3 +296,32 @@ class NanitHub:
             except Exception:
                 _LOGGER.debug("Error stopping S&L during close")
         self._sound_lights.clear()
+
+    async def _discover_speaker_uids(self) -> dict[str, str]:
+        """Fetch speaker UIDs from the raw /babies API response.
+
+        Fallback for when the installed aionanit package's Baby dataclass
+        does not yet include the speaker_uid field.
+        """
+        tm = self._client.token_manager
+        if tm is None:
+            return {}
+        access_token = await tm.async_get_access_token()
+        rest = self._client.rest_client
+        resp = await rest._session.get(
+            f"{rest._base_url}/babies",
+            headers={"Authorization": access_token},
+        )
+        resp.raise_for_status()
+        body = await resp.json()
+
+        result: dict[str, str] = {}
+        for baby in body.get("babies", []):
+            camera_uid = baby.get("camera_uid")
+            speaker_uid = baby.get("speaker", {}).get("speaker", {}).get("uid")
+            if camera_uid and speaker_uid:
+                result[camera_uid] = speaker_uid
+                _LOGGER.debug(
+                    "Discovered speaker UID %s for camera %s", speaker_uid, camera_uid
+                )
+        return result

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -287,7 +287,7 @@ class NanitHub:
             speaker_uid=speaker_uid,
             token_manager=self._client.token_manager,
             rest_client=self._client.rest_client,
-            session=getattr(self._client, "session", self._client._session),
+            session=self._client.session,
             device_ip=device_ip,
         )
         self._sound_lights[speaker_uid] = sl
@@ -319,8 +319,8 @@ class NanitHub:
             return {}
         access_token = await tm.async_get_access_token()
         rest = self._client.rest_client
-        resp = await rest._session.get(
-            f"{rest._base_url}/babies",
+        resp = await rest.session.get(
+            f"{rest.base_url}/babies",
             headers={"Authorization": access_token},
         )
         resp.raise_for_status()

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .aionanit_sl.exceptions import NanitTransportError
 
 from . import NanitConfigEntry
-from .const import CONF_CAMERA_UID
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -34,7 +33,7 @@ async def async_setup_entry(
     for cam_data in entry.runtime_data.cameras.values():
         sl_coordinator = cam_data.sound_light_coordinator
         if sl_coordinator is not None:
-            entities.append(NanitSoundLightLight(sl_coordinator, entry))
+            entities.append(NanitSoundLightLight(sl_coordinator))
 
     async_add_entities(entities)
 
@@ -49,15 +48,11 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
     def __init__(
         self,
         coordinator: NanitSoundLightCoordinator,
-        entry: NanitConfigEntry,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._entry = entry
-        self._attr_unique_id = (
-            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
-            "_sound_light_light"
-        )
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_light_light"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -30,11 +30,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Nanit Sound & Light Machine light entity."""
-    coordinator = entry.runtime_data.sound_light_coordinator
-    if coordinator is None:
-        return
+    entities: list[LightEntity] = []
+    for cam_data in entry.runtime_data.cameras.values():
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSoundLightLight(sl_coordinator, entry))
 
-    async_add_entities([NanitSoundLightLight(coordinator, entry)])
+    async_add_entities(entities)
 
 
 class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -24,11 +24,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Nanit Sound & Light Machine sound selector."""
-    coordinator = entry.runtime_data.sound_light_coordinator
-    if coordinator is None:
-        return
+    entities: list[SelectEntity] = []
+    for cam_data in entry.runtime_data.cameras.values():
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSoundSelect(sl_coordinator, entry))
 
-    async_add_entities([NanitSoundSelect(coordinator, entry)])
+    async_add_entities(entities)
 
 
 class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .aionanit_sl.exceptions import NanitTransportError
 
 from . import NanitConfigEntry
-from .const import CONF_CAMERA_UID, DEFAULT_SOUND_MACHINE_SOUNDS
+from .const import DEFAULT_SOUND_MACHINE_SOUNDS
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -28,7 +28,7 @@ async def async_setup_entry(
     for cam_data in entry.runtime_data.cameras.values():
         sl_coordinator = cam_data.sound_light_coordinator
         if sl_coordinator is not None:
-            entities.append(NanitSoundSelect(sl_coordinator, entry))
+            entities.append(NanitSoundSelect(sl_coordinator))
 
     async_add_entities(entities)
 
@@ -42,15 +42,11 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
     def __init__(
         self,
         coordinator: NanitSoundLightCoordinator,
-        entry: NanitConfigEntry,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._entry = entry
-        self._attr_unique_id = (
-            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
-            "_sound_machine_sound"
-        )
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_sound"
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import EntityCategory, LIGHT_LUX, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -107,6 +107,7 @@ async def async_setup_entry(
         if sl_coordinator is not None:
             for description in SL_SENSORS:
                 entities.append(NanitSLSensor(sl_coordinator, description))
+            entities.append(NanitSLConnectionModeSensor(sl_coordinator))
 
     async_add_entities(entities)
 
@@ -156,3 +157,34 @@ class NanitSLSensor(NanitSoundLightEntity, SensorEntity):
         if self.coordinator.data is None:
             return None
         return self.entity_description.value_fn(self.coordinator.data)
+
+
+class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
+    """Diagnostic sensor showing S&L connection type: local, cloud, or unavailable."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "sl_connection_mode"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["local", "cloud", "unavailable"]
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sl_connection_mode"
+
+    @property
+    def available(self) -> bool:
+        """Always available so it can report the unavailable connection state."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the current connection mode."""
+        return self.coordinator.sound_light.connection_mode

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -87,7 +87,15 @@
       "humidity": { "name": "Humidity" },
       "light": { "name": "Light Level" },
       "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" }
+      "sl_humidity": { "name": "Humidity" },
+      "sl_connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud",
+          "unavailable": "Unavailable"
+        }
+      }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -87,7 +87,15 @@
       "humidity": { "name": "Humidity" },
       "light": { "name": "Light Level" },
       "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" }
+      "sl_humidity": { "name": "Humidity" },
+      "sl_connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud",
+          "unavailable": "Unavailable"
+        }
+      }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -39,6 +39,16 @@ class NanitRestClient:
         self._session: aiohttp.ClientSession = session
         self._base_url: str = base_url.rstrip("/")
 
+    @property
+    def base_url(self) -> str:
+        """Return the base URL for the Nanit API."""
+        return self._base_url
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        """Return the underlying aiohttp session."""
+        return self._session
+
     async def async_login(
         self,
         email: str,

--- a/tests/unit/test_sl_coordinator.py
+++ b/tests/unit/test_sl_coordinator.py
@@ -1,0 +1,211 @@
+"""Tests for coordinator.py — NanitSoundLightCoordinator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.nanit.aionanit_sl.models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+)
+from custom_components.nanit.coordinator import NanitSoundLightCoordinator
+from custom_components.nanit.const import DOMAIN
+
+from .conftest import MOCK_EMAIL, mock_entry_data_v2
+
+
+def _make_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _make_mock_sound_light(
+    speaker_uid: str = "L101TEST",
+    connected: bool = False,
+) -> MagicMock:
+    sl = MagicMock()
+    sl.speaker_uid = speaker_uid
+    sl.connected = connected
+    sl.state = SoundLightFullState()
+    sl.subscribe = MagicMock(return_value=lambda: None)
+    sl.async_start = AsyncMock()
+    sl.async_stop = AsyncMock()
+    sl.restore_state = MagicMock()
+    return sl
+
+
+class TestGracePeriod:
+    """Test the 30-second availability grace period."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_starts_grace_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light(connected=True)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        # Simulate initial setup
+        coord._sl_connected = True
+
+        # Simulate disconnect event
+        sl.connected = False
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(event)
+
+        # Should still be "connected" due to grace period
+        assert coord.connected is True
+        assert coord._availability_timer is not None
+
+    @pytest.mark.asyncio
+    async def test_reconnect_cancels_grace_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light(connected=True)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+        coord._sl_connected = True
+
+        # Simulate disconnect
+        sl.connected = False
+        disconnect_event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(disconnect_event)
+        assert coord._availability_timer is not None
+
+        # Simulate reconnect
+        sl.connected = True
+        reconnect_event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(reconnect_event)
+
+        # Timer should be cancelled, still connected
+        assert coord._availability_timer is None
+        assert coord.connected is True
+
+
+class TestDebouncedSave:
+    """Test debounced state persistence."""
+
+    @pytest.mark.asyncio
+    async def test_state_update_schedules_save(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        state = SoundLightFullState(power_on=True, brightness=0.5)
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.STATE_UPDATE,
+            state=state,
+        )
+        coord._on_sl_event(event)
+
+        # Save timer should be running
+        assert coord._save_timer is not None
+        assert coord._pending_save_state is state
+
+    @pytest.mark.asyncio
+    async def test_rapid_updates_only_schedule_one_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        state1 = SoundLightFullState(brightness=0.3)
+        state2 = SoundLightFullState(brightness=0.6)
+        state3 = SoundLightFullState(brightness=0.9)
+
+        for state in (state1, state2, state3):
+            coord._on_sl_event(SoundLightEvent(
+                kind=SoundLightEventKind.STATE_UPDATE,
+                state=state,
+            ))
+
+        # Only the latest state should be pending
+        assert coord._pending_save_state is state3
+        # Timer should be set only once (not reset on each update)
+        assert coord._save_timer is not None
+
+    @pytest.mark.asyncio
+    async def test_connection_change_does_not_schedule_save(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(event)
+
+        assert coord._save_timer is None
+        assert coord._pending_save_state is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_save_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        # Schedule a save
+        state = SoundLightFullState(power_on=True)
+        coord._on_sl_event(SoundLightEvent(
+            kind=SoundLightEventKind.STATE_UPDATE,
+            state=state,
+        ))
+        assert coord._save_timer is not None
+
+        # Shutdown should cancel timer and clear pending state
+        await coord.async_shutdown()
+        assert coord._save_timer is None
+        assert coord._pending_save_state is None
+
+
+class TestRestoreState:
+    """Test state restoration using public restore_state() method."""
+
+    @pytest.mark.asyncio
+    async def test_setup_calls_restore_state_when_no_initial_state(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        # power_on=None means no initial state received yet
+        sl.state = SoundLightFullState(power_on=None)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        restored = SoundLightFullState(power_on=True, brightness=0.7)
+        with patch.object(coord, "_async_restore_state", new_callable=AsyncMock, return_value=restored):
+            await coord.async_setup()
+
+        # Should call restore_state (public method) not _state directly
+        sl.restore_state.assert_called_once_with(restored)
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_restore_when_state_exists(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        sl.state = SoundLightFullState(power_on=True)  # already has state
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        with patch.object(coord, "_async_restore_state", new_callable=AsyncMock) as mock_restore:
+            await coord.async_setup()
+
+        # Should NOT attempt to restore
+        mock_restore.assert_not_called()
+        sl.restore_state.assert_not_called()

--- a/tests/unit/test_sl_protocol.py
+++ b/tests/unit/test_sl_protocol.py
@@ -1,0 +1,393 @@
+"""Tests for aionanit_sl/sl_protocol.py — S&L protobuf wire-format decode/encode."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from custom_components.nanit.aionanit_sl.sl_protocol import (
+    SLDecodedState,
+    _encode_fixed32_field,
+    _encode_length_delimited,
+    _encode_varint,
+    _encode_varint_field,
+    build_brightness_cmd,
+    build_color_cmd,
+    build_light_enabled_cmd,
+    build_power_cmd,
+    build_sound_on_cmd,
+    build_track_cmd,
+    build_volume_cmd,
+    classify_message,
+    decode_cloud_relay,
+    decode_fields,
+    decode_full_state,
+    decode_sensors,
+    fixed32_to_float,
+    float_to_fixed32,
+    is_cloud_relay_ack,
+    is_cloud_relay_error,
+    is_cloud_relay_forbidden,
+    FIXED32,
+    LENGTH_DELIMITED,
+    VARINT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build raw protobuf bytes for test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cloud_relay_status(status_code: int, body: bytes = b"") -> bytes:
+    """Build a cloud relay envelope: field 2 { field 2: status, [field 4: body] }."""
+    inner = _encode_varint_field(2, status_code)
+    if body:
+        inner += _encode_length_delimited(4, body)
+    return _encode_length_delimited(2, inner)
+
+
+def _make_cloud_relay_ack() -> bytes:
+    """Build a cloud relay ack: field 3 { field 1 { field 1: 1 } }."""
+    inner_inner = _encode_varint_field(1, 1)
+    inner = _encode_length_delimited(1, inner_inner)
+    return _encode_length_delimited(3, inner)
+
+
+def _make_state_fields(
+    brightness: float | None = None,
+    power_on: bool | None = None,
+    volume: float | None = None,
+    temperature_c: float | None = None,
+    humidity_pct: float | None = None,
+    light_enabled: bool | None = None,
+    sound_on: bool | None = None,
+    track_name: str | None = None,
+) -> bytes:
+    """Build raw state field bytes (the contents of field 1.6 or cloud field 2.4)."""
+    result = b""
+    if brightness is not None:
+        result += _encode_fixed32_field(1, float_to_fixed32(brightness))
+    if light_enabled is not None:
+        # INVERTED: True → 0, False → 1
+        sub = _encode_varint_field(1, 0 if light_enabled else 1)
+        result += _encode_length_delimited(2, sub)
+    if volume is not None:
+        result += _encode_fixed32_field(3, float_to_fixed32(volume))
+    if sound_on is not None or track_name is not None:
+        sub = b""
+        if sound_on is not None:
+            sub += _encode_varint_field(1, 0 if sound_on else 1)
+        if track_name is not None:
+            sub += _encode_length_delimited(2, track_name.encode("utf-8"))
+        result += _encode_length_delimited(4, sub)
+    if power_on is not None:
+        result += _encode_varint_field(5, 1 if power_on else 0)
+    if temperature_c is not None:
+        result += _encode_fixed32_field(7, float_to_fixed32(temperature_c))
+    if humidity_pct is not None:
+        result += _encode_fixed32_field(8, float_to_fixed32(humidity_pct))
+    return result
+
+
+def _make_local_state_message(state_bytes: bytes) -> bytes:
+    """Wrap state bytes in local envelope: field 1 { field 6 { state_bytes } }."""
+    field_6 = _encode_length_delimited(6, state_bytes)
+    return _encode_length_delimited(1, field_6)
+
+
+def _make_cloud_state_message(state_bytes: bytes) -> bytes:
+    """Wrap state bytes in cloud relay envelope: field 2 { 2: 200, 4: { state } }."""
+    return _make_cloud_relay_status(200, body=state_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Tests — Cloud relay message classifiers
+# ---------------------------------------------------------------------------
+
+
+class TestIsCloudRelayForbidden:
+    def test_returns_true_for_403(self) -> None:
+        msg = _make_cloud_relay_status(403)
+        assert is_cloud_relay_forbidden(msg) is True
+
+    def test_returns_false_for_200(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_forbidden(msg) is False
+
+    def test_returns_false_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert is_cloud_relay_forbidden(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_forbidden(b"") is False
+
+    def test_returns_false_for_garbage(self) -> None:
+        assert is_cloud_relay_forbidden(b"\xff\xff\xff") is False
+
+
+class TestIsCloudRelayError:
+    def test_returns_true_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert is_cloud_relay_error(msg) is True
+
+    def test_returns_true_for_500(self) -> None:
+        msg = _make_cloud_relay_status(500)
+        assert is_cloud_relay_error(msg) is True
+
+    def test_returns_false_for_200(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_error(msg) is False
+
+    def test_returns_false_for_403(self) -> None:
+        # 403 is handled separately by is_cloud_relay_forbidden
+        msg = _make_cloud_relay_status(403)
+        assert is_cloud_relay_error(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_error(b"") is False
+
+    def test_returns_false_for_non_field2_envelope(self) -> None:
+        # field 1 envelope instead of field 2
+        msg = _encode_length_delimited(1, _encode_varint_field(2, 400))
+        assert is_cloud_relay_error(msg) is False
+
+    def test_real_400_hex_from_device(self) -> None:
+        """The actual hex captured from the device rejecting a keepalive."""
+        raw = bytes.fromhex("121c1090031a174661696c656420746f2070617273652072657175657374")
+        assert is_cloud_relay_error(raw) is True
+
+
+class TestIsCloudRelayAck:
+    def test_returns_true_for_ack(self) -> None:
+        msg = _make_cloud_relay_ack()
+        assert is_cloud_relay_ack(msg) is True
+
+    def test_returns_false_for_status_message(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_ack(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_ack(b"") is False
+
+    def test_real_ack_hex(self) -> None:
+        """Known ack hex signature."""
+        raw = bytes.fromhex("1a040a020801")
+        assert is_cloud_relay_ack(raw) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — State decoding
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeFullState:
+    def test_decodes_brightness_and_power(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.75, power_on=True)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.power_on is True
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.75) < 0.01
+
+    def test_decodes_volume(self) -> None:
+        state_bytes = _make_state_fields(volume=0.6)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.volume is not None
+        assert abs(result.volume - 0.6) < 0.01
+
+    def test_decodes_temp_and_humidity(self) -> None:
+        state_bytes = _make_state_fields(temperature_c=22.5, humidity_pct=45.0)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.temperature_c is not None
+        assert abs(result.temperature_c - 22.5) < 0.1
+        assert result.humidity_pct is not None
+        assert abs(result.humidity_pct - 45.0) < 0.1
+
+    def test_decodes_inverted_light_enabled(self) -> None:
+        state_bytes = _make_state_fields(light_enabled=True)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.light_enabled is True
+
+    def test_decodes_inverted_light_disabled(self) -> None:
+        state_bytes = _make_state_fields(light_enabled=False)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.light_enabled is False
+
+    def test_decodes_sound_on_with_track(self) -> None:
+        state_bytes = _make_state_fields(sound_on=True, track_name="White Noise")
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.sound_on is True
+        assert result.current_track == "White Noise"
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_full_state(b"") is None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert decode_full_state(b"\xff\xff\xff") is None
+
+
+class TestDecodeCloudRelay:
+    def test_decodes_200_state(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.5, power_on=True)
+        msg = _make_cloud_state_message(state_bytes)
+        result = decode_cloud_relay(msg)
+        assert result is not None
+        assert result.power_on is True
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.5) < 0.01
+
+    def test_returns_none_for_403(self) -> None:
+        msg = _make_cloud_relay_status(403)
+        assert decode_cloud_relay(msg) is None
+
+    def test_returns_none_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert decode_cloud_relay(msg) is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_cloud_relay(b"") is None
+
+
+class TestDecodeSensors:
+    def test_decodes_temp_and_humidity(self) -> None:
+        # Build: field 1 { field 1: varint(1), field 10 { 2: temp, 3: hum } }
+        sensor_sub = (
+            _encode_fixed32_field(2, float_to_fixed32(23.5))
+            + _encode_fixed32_field(3, float_to_fixed32(55.0))
+        )
+        inner = _encode_varint_field(1, 1) + _encode_length_delimited(10, sensor_sub)
+        msg = _encode_length_delimited(1, inner)
+        result = decode_sensors(msg)
+        assert result is not None
+        assert result.temperature_c is not None
+        assert abs(result.temperature_c - 23.5) < 0.1
+        assert result.humidity_pct is not None
+        assert abs(result.humidity_pct - 55.0) < 0.1
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_sensors(b"") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — Message classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyMessage:
+    def test_state_message_type_0(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.5)
+        msg = _make_local_state_message(state_bytes)
+        assert classify_message(msg) == 0
+
+    def test_sensor_message_type_1(self) -> None:
+        sensor_sub = _encode_fixed32_field(2, float_to_fixed32(22.0))
+        inner = _encode_varint_field(1, 1) + _encode_length_delimited(10, sensor_sub)
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 1
+
+    def test_routine_message_type_2(self) -> None:
+        inner = _encode_varint_field(1, 2) + _encode_length_delimited(6, b"\x00")
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 2
+
+    def test_routine_message_type_3(self) -> None:
+        inner = _encode_varint_field(1, 3) + _encode_length_delimited(6, b"\x00")
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 3
+
+    def test_network_info_returns_negative_1(self) -> None:
+        """Large varint type indicators (e.g. timestamps) → network info → -1."""
+        inner = _encode_varint_field(1, 999999)
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == -1
+
+    def test_empty_returns_none(self) -> None:
+        assert classify_message(b"") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — Command encoding roundtrips
+# ---------------------------------------------------------------------------
+
+
+class TestCommandEncoding:
+    def test_power_on_roundtrip(self) -> None:
+        cmd = build_power_cmd(True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.power_on is True
+
+    def test_power_off_roundtrip(self) -> None:
+        cmd = build_power_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.power_on is False
+
+    def test_brightness_roundtrip(self) -> None:
+        cmd = build_brightness_cmd(0.8)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.8) < 0.01
+
+    def test_volume_roundtrip(self) -> None:
+        cmd = build_volume_cmd(0.42)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.volume is not None
+        assert abs(result.volume - 0.42) < 0.01
+
+    def test_light_enabled_roundtrip(self) -> None:
+        cmd = build_light_enabled_cmd(True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is True
+
+    def test_light_disabled_roundtrip(self) -> None:
+        cmd = build_light_enabled_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is False
+
+    def test_sound_on_roundtrip(self) -> None:
+        cmd = build_sound_on_cmd(True, current_track="Rain")
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.sound_on is True
+        assert result.current_track == "Rain"
+
+    def test_sound_off_roundtrip(self) -> None:
+        cmd = build_sound_on_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.sound_on is False
+
+    def test_track_roundtrip(self) -> None:
+        cmd = build_track_cmd("Ocean Waves", sound_on=True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.current_track == "Ocean Waves"
+        assert result.sound_on is True
+
+    def test_color_roundtrip(self) -> None:
+        cmd = build_color_cmd(0.3, 0.7, light_enabled=True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is True
+        assert result.color_r is not None
+        assert abs(result.color_r - 0.3) < 0.01
+        assert result.color_g is not None
+        assert abs(result.color_g - 0.7) < 0.01

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -1,0 +1,206 @@
+"""Tests for aionanit_sl/sound_light.py — NanitSoundLight WebSocket client."""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.nanit.aionanit_sl.models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+)
+from custom_components.nanit.aionanit_sl.sound_light import NanitSoundLight
+
+
+def _make_sound_light(
+    device_ip: str | None = "192.168.1.50",
+    speaker_uid: str = "L101TEST",
+) -> NanitSoundLight:
+    """Create a NanitSoundLight instance with mocked dependencies."""
+    token_manager = MagicMock()
+    token_manager.async_get_access_token = AsyncMock(return_value="mock_access_token")
+
+    rest_client = MagicMock()
+    rest_client.base_url = "https://api.nanit.com"
+
+    session = MagicMock()
+
+    return NanitSoundLight(
+        speaker_uid=speaker_uid,
+        token_manager=token_manager,
+        rest_client=rest_client,
+        session=session,
+        device_ip=device_ip,
+    )
+
+
+class TestProperties:
+    def test_speaker_uid(self) -> None:
+        sl = _make_sound_light(speaker_uid="L101ABC")
+        assert sl.speaker_uid == "L101ABC"
+
+    def test_initial_state(self) -> None:
+        sl = _make_sound_light()
+        assert sl.state == SoundLightFullState()
+
+    def test_initial_connected_false(self) -> None:
+        sl = _make_sound_light()
+        assert sl.connected is False
+
+    def test_connection_mode_unavailable_when_disconnected(self) -> None:
+        sl = _make_sound_light()
+        assert sl.connection_mode == "unavailable"
+
+    def test_connection_mode_local_when_connected_with_ip(self) -> None:
+        sl = _make_sound_light(device_ip="192.168.1.50")
+        sl._connected = True
+        sl._use_cloud_relay = False
+        assert sl.connection_mode == "local"
+
+    def test_connection_mode_cloud_when_connected_without_ip(self) -> None:
+        sl = _make_sound_light(device_ip=None)
+        sl._connected = True
+        sl._use_cloud_relay = True
+        assert sl.connection_mode == "cloud"
+
+
+class TestRestoreState:
+    def test_restore_state_updates_internal_state(self) -> None:
+        sl = _make_sound_light()
+        new_state = SoundLightFullState(power_on=True, brightness=0.5)
+        sl.restore_state(new_state)
+        assert sl.state.power_on is True
+        assert sl.state.brightness == 0.5
+
+    def test_restore_state_replaces_completely(self) -> None:
+        sl = _make_sound_light()
+        sl.restore_state(SoundLightFullState(volume=0.8))
+        sl.restore_state(SoundLightFullState(brightness=0.3))
+        # Second restore should replace, not merge
+        assert sl.state.volume is None
+        assert sl.state.brightness == 0.3
+
+
+class TestSubscription:
+    def test_subscribe_and_fire_event(self) -> None:
+        sl = _make_sound_light()
+        events: list[SoundLightEvent] = []
+        sl.subscribe(events.append)
+        sl._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+        assert len(events) == 1
+        assert events[0].kind == SoundLightEventKind.CONNECTION_CHANGE
+
+    def test_unsubscribe(self) -> None:
+        sl = _make_sound_light()
+        events: list[SoundLightEvent] = []
+        unsub = sl.subscribe(events.append)
+        unsub()
+        sl._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+        assert len(events) == 0
+
+    def test_subscriber_exception_does_not_propagate(self) -> None:
+        sl = _make_sound_light()
+
+        def bad_callback(event: SoundLightEvent) -> None:
+            raise RuntimeError("boom")
+
+        sl.subscribe(bad_callback)
+        # Should not raise
+        sl._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+
+class TestDualSslContext:
+    """Verify that local and cloud connections use different TLS settings."""
+
+    def test_local_ssl_ctx_uses_cert_none(self) -> None:
+        sl = _make_sound_light(device_ip="192.168.1.50")
+        # Trigger SSL context creation
+        sl._local_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        sl._local_ssl_ctx.check_hostname = False
+        sl._local_ssl_ctx.verify_mode = ssl.CERT_NONE
+        assert sl._local_ssl_ctx.verify_mode == ssl.CERT_NONE
+
+    def test_no_global_ssl_ctx_attribute(self) -> None:
+        """Ensure the old _ssl_ctx attribute no longer exists."""
+        sl = _make_sound_light()
+        assert not hasattr(sl, "_ssl_ctx")
+
+    def test_local_ssl_ctx_initialized_none(self) -> None:
+        sl = _make_sound_light()
+        assert sl._local_ssl_ctx is None
+
+
+class TestReconnectTaskTracking:
+    """Verify reconnect tasks are properly tracked for cleanup."""
+
+    def test_reconnect_task_initialized_none(self) -> None:
+        sl = _make_sound_light()
+        assert sl._reconnect_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_stop_cancels_reconnect_task(self) -> None:
+        sl = _make_sound_light()
+        # Create a dummy task
+        async def dummy() -> None:
+            await asyncio.sleep(100)
+
+        sl._reconnect_task = asyncio.get_running_loop().create_task(dummy())
+        assert not sl._reconnect_task.done()
+
+        await sl.async_stop()
+        assert sl._reconnect_task is None
+
+    @pytest.mark.asyncio
+    async def test_close_ws_cancels_reconnect_task(self) -> None:
+        sl = _make_sound_light()
+
+        async def dummy() -> None:
+            await asyncio.sleep(100)
+
+        sl._reconnect_task = asyncio.get_running_loop().create_task(dummy())
+        await sl._async_close_ws()
+        assert sl._reconnect_task is None
+
+
+class TestCloudRelayPrefersDefaultTls:
+    """Verify that cloud relay connections don't pass the CERT_NONE ssl context."""
+
+    @pytest.mark.asyncio
+    async def test_cloud_relay_no_ssl_param(self) -> None:
+        """When connecting to cloud relay, ws_connect should NOT receive ssl=_local_ssl_ctx."""
+        sl = _make_sound_light(device_ip=None)  # cloud relay only
+        sl._stopped = False
+
+        mock_ws = MagicMock()
+        mock_ws.closed = False
+        mock_ws.__aiter__ = MagicMock(return_value=iter([]))
+
+        sl._session.ws_connect = AsyncMock(return_value=mock_ws)
+
+        try:
+            await sl._async_connect()
+        except Exception:
+            pass  # May fail on recv_task setup, that's fine
+
+        # Check the ws_connect call — ssl should NOT be the CERT_NONE context
+        if sl._session.ws_connect.call_count > 0:
+            call_kwargs = sl._session.ws_connect.call_args
+            # Cloud relay call should not have ssl=<SSLContext> with CERT_NONE
+            ssl_arg = call_kwargs.kwargs.get("ssl") if call_kwargs.kwargs else None
+            if ssl_arg is not None:
+                assert ssl_arg.verify_mode != ssl.CERT_NONE, \
+                    "Cloud relay must not use CERT_NONE"
+
+
+class TestUseCloudRelayFlag:
+    def test_no_ip_sets_cloud_relay_true(self) -> None:
+        sl = _make_sound_light(device_ip=None)
+        assert sl._use_cloud_relay is True
+
+    def test_with_ip_sets_cloud_relay_false(self) -> None:
+        sl = _make_sound_light(device_ip="10.0.0.1")
+        assert sl._use_cloud_relay is False


### PR DESCRIPTION
# PR #11 — Sound & Light Machine: Testing & Bug Fixes

This comment tracks all changes made to the `ha-nanit-rebase-pr-11` branch during testing and debugging of the Nanit Sound & Light Machine integration.

---

## Changes Summary

### aionanit S&L Protocol (`aionanit_sl/sl_protocol.py`)

- **Device token fetch rewritten** — Changed from `POST` to `GET /speakers/{uid}/udtokens` with correct NanitLite headers (`token` prefix instead of `Bearer`, NanitLite User-Agent). Response parsing updated to extract from `user_device_token.token` path. (Fix: original returned HTTP 404)
- **Cloud relay ack handler** — Added `is_cloud_relay_ack()` to detect and silently ignore `field 3 { field 1 { field 1: 1 } }` acknowledgment messages that followed every command via cloud relay.
- **Network info classifier** — `classify_message()` now returns `-1` for network metadata messages (WiFi SSID, MAC addresses) with type indicators > 3, preventing "unknown message type" log spam.
- **Removed `build_state_request()`** — The probe message never worked; the device only replied with an ack and no state data.
- **Removed `build_sl_keepalive()`** — The custom keepalive caused the device to return 400 "Failed to parse request" errors. aiohttp's `heartbeat=60` handles connection keepalive at the transport layer.
- **Added `is_cloud_relay_error()`** — Detects non-200/non-403 error responses in field 2 envelope and silently ignores them.

### S&L WebSocket Client (`aionanit_sl/sound_light.py`)

- **Removed broken keepalive loop** — Deleted `_keepalive_loop()`, the keepalive task creation, and `_KEEPALIVE_INTERVAL`. The device was rejecting the empty protobuf keepalive with HTTP 400.
- **Removed dead REST state fetch** — `_async_fetch_rest_state()` was deleted; testing confirmed the Nanit REST API returns only metadata, not operational state.
- **Removed dead state request probe** — The poll loop was simplified to just reconnect on the 5-minute interval.
- **Dual connection strategy** — Local WebSocket (`wss://{ip}:442/`) preferred when IP is configured; falls back to cloud relay (`wss://remote.nanit.com/speakers/{uid}/user_connect/`) automatically. Local retried on each reconnect cycle.
- **Resilient startup** — `async_start()` catches initial connection failures and starts background reconnect instead of propagating the exception (which previously disabled S&L permanently).
- **Cloud relay error logging** — Promoted from `debug` to `warning` level.
- **Connection mode property** — New `connection_mode` property exposes "Local", "Cloud", or "Unavailable" from existing internal flags.

### Coordinator (`coordinator.py`)

- **State persistence** — `NanitSoundLightCoordinator` saves state to HA `Store` on every update and shutdown; restores on startup. Fixes cloud relay showing "unknown" entities after HA restart (cloud relay doesn't send initial state dump).
- **30-second grace period** — Matches the camera's `NanitPushCoordinator` pattern. Brief disconnections during hourly token refresh (~3 seconds) no longer flash entities as "Unavailable".

### Integration Setup (`__init__.py`, `hub.py`)

- **Stale device removal fix** — Added `{camera_uid}_sound_light` to valid device identifiers so S&L devices aren't removed on reload.
- **Speaker UID auto-discovery** — Three-tier fallback: persisted map -> `Baby.speaker_uid` attribute -> raw `/babies` API at `baby.speaker.speaker.uid`. Persisted to `entry.data` after discovery.
- **Optional speaker IP** — `hub.py` passes `None` for speaker IP when not configured, enabling cloud-relay-only operation.
- **Session passthrough** — `NanitSoundLight` receives the aiohttp session for inline device token fetching.

### Config Flow (`config_flow.py`)

- **Speaker IP field** — Options flow camera IP step now includes `CONF_SPEAKER_IP`, stored in `CONF_SPEAKER_IPS` dict keyed by camera UID.
- **IP clearing fix** — Changed from `vol.Optional(key, default=current_ip)` to `vol.Optional(key, description={"suggested_value": current_ip})`. The `default` parameter caused voluptuous to silently restore the old IP when the user cleared the field, making it impossible to remove an IP address.

### Entities

- **Connection mode sensor** — New `SensorDeviceClass.ENUM` diagnostic sensor showing "Local", "Cloud", or "Unavailable".
- **S&L entity availability** — Entities remain available when WebSocket disconnects, displaying last-known values. Connection state reported separately by connectivity binary sensor and connection mode sensor.

---

## Files Modified

| File | Changes |
|------|---------|
| `aionanit_sl/sound_light.py` | Removed keepalive, REST fetch, state probe; added dual connection, resilient startup, connection mode property |
| `aionanit_sl/sl_protocol.py` | Removed `build_sl_keepalive()`, `build_state_request()`; added `is_cloud_relay_ack()`, `is_cloud_relay_error()`, network info classifier |
| `coordinator.py` | Added Store persistence, 30-second grace period with availability timer |
| `__init__.py` | Fixed stale device removal for S&L devices |
| `hub.py` | Speaker UID auto-discovery, optional speaker IP, session passthrough |
| `config_flow.py` | Added speaker IP field, fixed IP clearing with `suggested_value` |
| `sensor.py` | Added connection mode diagnostic sensor |
| `entity.py` | S&L availability doesn't require active connection |
| `strings.json` / `translations/en.json` | Added `sl_connection_mode` translation |

---

## Entity Summary

| Entity | Type | Controllable | Notes |
|--------|------|:------------:|-------|
| Power | Switch | Yes | Turns entire device on/off |
| Sound | Switch | Yes | Toggles sound playback |
| Sound Track | Select | Yes | Dropdown of available tracks |
| Volume | Number (0-100) | Yes | Maps to 0.0-1.0 float |
| Light | Switch | Yes | Toggles night light |
| Brightness | Number (0-100) | Yes | Maps to 0.0-1.0 float |
| Light Color | Color picker | Yes | 2-parameter model (experimental) |
| Temperature | Sensor | No | Celsius |
| Humidity | Sensor | No | Percentage |
| S&L Connectivity | Binary Sensor | No | WebSocket connection state |
| Connection Mode | Sensor (Enum) | No | Diagnostic: Local / Cloud / Unavailable |

---

## Known Limitations

**Cloud relay does not detect device power-off** — The cloud relay WebSocket connects to `remote.nanit.com`, not the physical device. If the S&L is powered off, the WebSocket stays open and connectivity shows "connected / cloud". The NanitLite app detects this through a separate mechanism not yet reverse-engineered. Local connections are not affected — powering off the device drops TCP immediately.

---

## Testing Notes

- Local WebSocket sends full state dump on connect; cloud relay does not (relies on Store persistence)
- Hourly token refresh causes brief (~3s) disconnections — grace period prevents entity availability flicker
- Cloud relay wraps state in `field 2 { status: 200, body: { ...state... } }` envelope
- Device uses inverted booleans: wire `0` = ON, wire `1` = OFF for light and sound toggles
- Cloud relay endpoint confirmed as `remote.nanit.com` (not `api.nanit.com` which is HTTP API only)
