### PR TITLE
fix: pin aionanit>=1.3.0 to ensure brightness field exists

### DIFF
--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -107,7 +107,7 @@ class NanitNightLight(NanitEntity, RestoreEntity, LightEntity):
         if nl is not None:
             self._attr_is_on = nl == NightLightState.ON
 
-        device_brightness = state.settings.night_light_brightness
+        device_brightness: int | None = getattr(state.settings, "night_light_brightness", None)
         if device_brightness is not None and device_brightness > 0:
             self._attr_brightness = value_to_brightness(_BRIGHTNESS_SCALE, device_brightness)
 
@@ -125,7 +125,9 @@ class NanitNightLight(NanitEntity, RestoreEntity, LightEntity):
                 if state.control.night_light is not None
                 else None
             )
-            new_device_brightness = state.settings.night_light_brightness
+            new_device_brightness: int | None = getattr(
+                state.settings, "night_light_brightness", None
+            )
 
             if self._command_is_on is not None or self._command_brightness is not None:
                 elapsed = time.monotonic() - self._command_ts

--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -8,6 +8,6 @@
   "config_flow": true,
   "iot_class": "cloud_push",
   "integration_type": "hub",
-  "requirements": ["aionanit>=1.0.13"],
+  "requirements": ["aionanit>=1.3.0"],
   "loggers": ["custom_components.nanit", "aionanit"]
 }


### PR DESCRIPTION
## Summary
- Bumps `manifest.json` requirement from `aionanit>=1.0.13` to `aionanit>=1.3.0` so HA installs the version containing the `night_light_brightness` field
- Adds defensive `getattr` fallback in `light.py` for `night_light_brightness` so the entity doesn't crash even if an older aionanit is cached

Fixes startup error: `'SettingsState' object has no attribute 'night_light_brightness'`