### PR TITLE
fix: tighten aionanit pin to >=1.3.2

### DIFF
--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -8,6 +8,6 @@
   "config_flow": true,
   "iot_class": "cloud_push",
   "integration_type": "hub",
-  "requirements": ["aionanit>=1.3.0"],
+  "requirements": ["aionanit>=1.3.2"],
   "loggers": ["custom_components.nanit", "aionanit"]
 }


### PR DESCRIPTION
## Summary
- Tightens `requirements` pin in `manifest.json` from `aionanit>=1.3.0` to `aionanit>=1.3.2`
- Prevents HA from using cached aionanit 1.3.0/1.3.1 which had protobuf gencode 6.33.4, causing `VersionError` on HA instances with protobuf runtime <6.33.4
- aionanit 1.3.2 has gencode 6.31.1 which is compatible with all protobuf 6.31.1+ runtimes

## Root cause
v1.3.2 manifest had `aionanit>=1.3.0`, so HA's pip would accept any cached version ≥1.3.0 — including 1.3.0/1.3.1 with the broken gencode.