### PR TITLE
fix: correct jq field name in promote recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -123,7 +123,7 @@ release-beta bump:
 promote:
     #!/usr/bin/env bash
     set -euo pipefail
-    beta_tag=$(gh release list --limit 20 --json tagName,isPreRelease,isDraft --jq '[.[] | select(.isPreRelease and (.isDraft | not))] | first | .tagName')
+    beta_tag=$(gh release list --limit 20 --json tagName,isPrerelease,isDraft --jq '[.[] | select(.isPrerelease and (.isDraft | not))] | first | .tagName')
     if [ -z "${beta_tag}" ] || [ "${beta_tag}" = "null" ]; then
         echo "Error: No pre-release found to promote."
         exit 1


### PR DESCRIPTION
## Summary

- Fix `just promote` recipe: `gh release list` returns `isPrerelease` (lowercase r), not `isPreRelease` — the case mismatch caused the jq filter to match nothing, making promote always fail with "No pre-release found to promote."

## Changes

Single character fix in `justfile` line 126: `.isPreRelease` → `.isPrerelease`

## Testing

Verified `gh release list --json isPrerelease` returns the correct field. After this fix, `just promote` will correctly find v1.3.3-beta.2 and promote it to stable.