### PR TITLE
chore: automated beta release pipeline with opt-in PR labels

### DIFF
--- a/.github/workflows/auto-beta.yaml
+++ b/.github/workflows/auto-beta.yaml
@@ -1,0 +1,157 @@
+name: Auto Beta Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+concurrency:
+  group: auto-beta
+  cancel-in-progress: false
+
+jobs:
+  beta-release:
+    name: Create Beta Release
+    if: >-
+      github.event.pull_request.merged == true && (
+        contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+        contains(github.event.pull_request.labels.*.name, 'release:major')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/aionanit/
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine bump type from PR labels
+        id: bump
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q '"release:major"'; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -q '"release:minor"'; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute next beta version
+        id: version
+        run: |
+          latest_stable=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+            | { grep -v '-' || true; } \
+            | sort -V \
+            | tail -1)
+          latest_stable="${latest_stable:-v0.0.0}"
+          latest_stable="${latest_stable#v}"
+          IFS='.' read -r major minor patch <<< "${latest_stable}"
+
+          case "${{ steps.bump.outputs.type }}" in
+            patch) patch=$((patch + 1)) ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+          esac
+          new="${major}.${minor}.${patch}"
+
+          # If a higher version beta already exists, use that version instead
+          highest_beta_version=""
+          for t in $(git tag -l 'v*-beta.*'); do
+            base="${t#v}"
+            base="${base%-beta.*}"
+            if [ -n "$highest_beta_version" ]; then
+              higher=$(printf '%s\n%s\n' "$base" "$highest_beta_version" | sort -V | tail -1)
+              highest_beta_version="$higher"
+            else
+              highest_beta_version="$base"
+            fi
+          done
+
+          if [ -n "$highest_beta_version" ]; then
+            final=$(printf '%s\n%s\n' "$new" "$highest_beta_version" | sort -V | tail -1)
+            new="$final"
+            IFS='.' read -r major minor patch <<< "$new"
+          fi
+
+          beta_num=1
+          for t in $(git tag -l "v${new}-beta.*"); do
+            n="${t##*-beta.}"
+            if [ "$n" -ge "$beta_num" ]; then
+              beta_num=$((n + 1))
+            fi
+          done
+
+          semver="${new}-beta.${beta_num}"
+          pep440="${major}.${minor}.${patch}b${beta_num}"
+          tag="v${semver}"
+
+          echo "semver=${semver}" >> "$GITHUB_OUTPUT"
+          echo "pep440=${pep440}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Computed: ${tag} (PEP 440: ${pep440})"
+
+      - name: Update version files
+        env:
+          SEMVER: ${{ steps.version.outputs.semver }}
+          PEP440: ${{ steps.version.outputs.pep440 }}
+        run: |
+          jq --arg v "$SEMVER" --arg r "aionanit>=$PEP440" \
+            '.version = $v | .requirements = [$r]' \
+            custom_components/nanit/manifest.json > /tmp/manifest.json
+          mv /tmp/manifest.json custom_components/nanit/manifest.json
+
+          sed -i "s/^version = \".*\"/version = \"$PEP440\"/" packages/aionanit/pyproject.toml
+
+      - name: Validate modified files
+        run: |
+          python3 -c "import json; json.load(open('custom_components/nanit/manifest.json'))"
+          python3 -c "
+          import tomllib
+          tomllib.load(open('packages/aionanit/pyproject.toml', 'rb'))
+          "
+          echo "Version files are valid."
+
+      - name: Commit, tag, and push
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SEMVER: ${{ steps.version.outputs.semver }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
+          git commit -m "chore: bump version to ${SEMVER} [skip ci]"
+          git tag "${TAG}"
+          git push && git push --tags
+
+      - name: Create GitHub pre-release
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --generate-notes \
+            --prerelease \
+            --latest=false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Build aionanit package
+        run: |
+          pip install build
+          python -m build packages/aionanit
+
+      - name: Publish beta to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: packages/aionanit/dist/
+          skip-existing: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Release tag to (re)publish, e.g. v1.4.0-beta.1"
+        description: "Stable release tag to (re)publish, e.g. v1.4.0"
         required: true
         type: string
 
@@ -25,7 +25,6 @@ jobs:
       contents: read
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
-      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       is_stable: ${{ steps.meta.outputs.is_stable }}
     steps:
       - name: Resolve release metadata
@@ -36,45 +35,11 @@ jobs:
           tag="${{ env.TAG }}"
           is_pre=$(gh release view "${tag}" --json isPrerelease -q .isPrerelease)
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "is_prerelease=${is_pre}" >> "$GITHUB_OUTPUT"
           if [ "${is_pre}" = "false" ] && [[ "${tag}" == v* ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_stable=false" >> "$GITHUB_OUTPUT"
           fi
-
-  publish-beta:
-    name: Publish Beta to PyPI
-    needs: resolve
-    if: needs.resolve.outputs.is_prerelease == 'true'
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/aionanit/
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.resolve.outputs.tag }}
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-
-      - name: Install build
-        run: pip install build
-
-      - name: Build package
-        working-directory: packages/aionanit
-        run: python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: packages/aionanit/dist/
-          skip-existing: true
 
   ci-gate:
     name: CI Gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,18 +72,16 @@ docs/                      ← Security checklist, connection reliability, testi
 ```bash
 just setup            # Install deps, tooling, pre-commit hooks
 just check            # Run ALL checks (lint + format + typecheck + tests) — use before any PR
-just lint             # Ruff lint
-just format           # Ruff format
-just typecheck        # mypy strict
-just test             # Integration tests (custom_components)
-just test-lib         # aionanit library tests
-just test-all         # Both test suites
+just fix              # Auto-fix lint issues and reformat
+just test             # Integration tests with coverage (custom_components)
+just test lib         # aionanit library tests
+just test all         # Both test suites
 just dev              # Start dev HA instance → http://localhost:8123
-just dev-restart      # Restart after code changes
-just release-beta     # Create a pre-release (beta → test via HACS → promote)
-just release-hotfix   # Emergency patch pre-release
+just dev restart      # Restart after code changes
+just dev stop         # Stop dev HA instance
 just release-retry    # Re-trigger release workflow after fixing CI (uses same tag)
-just promote          # ⚠️  HUMAN ONLY — promote beta to stable release
+just promote          # ⚠️  HUMAN ONLY — promote a beta to stable (interactive version picker)
+just promote 1.4.0    # ⚠️  HUMAN ONLY — promote a specific version directly
 ```
 
 ---
@@ -117,33 +115,45 @@ Rules:
 ### PR process
 
 1. Branch from `main` → make changes → `just check` passes locally.
-2. Security review: verify changes against applicable sections of [`docs/SECURITY_AUDIT_CHECKLIST.md`](docs/SECURITY_AUDIT_CHECKLIST.md).
-3. Open PR against `main`. CI must pass (lint, typecheck, tests).
-4. Merge only after security review passes. Block on any Critical or High finding.
+2. If the PR should trigger a release: add a label — `release:patch`, `release:minor`, or `release:major`. PRs without a release label (e.g., CI, docs, chore changes) will not create a beta release.
+3. Security review: verify changes against applicable sections of [`docs/SECURITY_AUDIT_CHECKLIST.md`](docs/SECURITY_AUDIT_CHECKLIST.md).
+4. Open PR against `main`. CI must pass (lint, typecheck, tests).
+5. Merge only after security review passes. Block on any Critical or High finding.
+6. On merge, if a `release:*` label is present, `auto-beta.yaml` automatically creates a beta pre-release and publishes to PyPI.
 
 ### Releases
 
-Two-step release flow: **beta → test → promote**.
+Automated two-step release flow: **PR merge → auto-beta → test → promote**.
 
 ```
+PR opened against main
+  │
+  Add label: release:patch / release:minor / release:major
+  (no label = no release, for CI/docs/chore PRs)
+  │
 PR merged to main
   │
-  just release-beta patch/minor/major
+  auto-beta.yaml (only if release label present)
   │
-  ├─ Bumps version to X.Y.Z-beta.N
-  ├─ Creates GitHub pre-release
-  └─ GitHub Actions publishes aionanit beta to PyPI
+  ├─ Reads PR label to determine bump type
+  ├─ Computes version + beta number from existing tags
+  ├─ Updates manifest.json + pyproject.toml on main
+  ├─ Tags vX.Y.Z-beta.N, creates GitHub pre-release
+  └─ Publishes aionanit beta to PyPI
   │
   You test on your HA via HACS beta channel
   │
-  just promote
+  just promote [version]
   │
+  ├─ Lists available betas (or targets specific version)
   ├─ Creates stable GitHub release (v X.Y.Z)
   ├─ Retains beta release + tag for historical record
   └─ GitHub Actions: CI gate → publish aionanit stable to PyPI → attach nanit.zip
 ```
 
-**Version lives in two files** (kept in sync by the justfile recipes):
+**Multiple concurrent betas** are supported. Different features can have independent beta tracks (e.g., `v1.4.0-beta.2` and `v1.5.0-beta.1` can coexist). Use `just promote <version>` to promote a specific version.
+
+**Version lives in two files** (kept in sync by auto-beta workflow and promote recipe):
 - `custom_components/nanit/manifest.json` → `"version"` (semver) + `"requirements"` (PEP 440)
 - `packages/aionanit/pyproject.toml` → `version` (PEP 440)
 
@@ -153,18 +163,18 @@ PR merged to main
 | Stable          | `1.4.0`               | `1.4.0`                  | `["aionanit>=1.4.0"]`       |
 
 ```bash
-just release-beta patch   # 1.3.1 → 1.4.0-beta.1 (pre-release)
-just release-beta minor   # 1.3.1 → 1.4.0-beta.1
-just release-beta major   # 1.3.1 → 2.0.0-beta.1
-just promote              # 1.4.0-beta.1 → 1.4.0 (stable release)
-just release-hotfix       # Emergency: 1.4.0 → 1.4.1-beta.1
+# Beta releases are opt-in via PR labels:
+#   release:patch  →  1.3.3 → 1.3.4-beta.1
+#   release:minor  →  1.3.3 → 1.4.0-beta.1
+#   release:major  →  1.3.3 → 2.0.0-beta.1
+#   no label       →  no release (CI/docs/chore changes)
+just promote              # Interactive — lists betas, asks which to promote
+just promote 1.4.0        # Direct — promotes latest v1.4.0-beta.N to v1.4.0
 ```
 
-**Rollback strategy**: Forward-fix via new patch release. If a stable release is broken, run `just release-hotfix`, fix, test via HACS beta, then `just promote`.
+**Rollback strategy**: Forward-fix via new PR. Merge the fix → auto-beta creates a new beta → test → promote.
 
 **Pipeline fix**: If the release workflow fails (e.g. action version issues, PyPI errors), fix the pipeline code, push to `main`, then run `just release-retry [tag]`. This re-triggers the workflow using the updated YAML from `main` while building from the original tag. PyPI publish is idempotent (skips already-uploaded versions).
-
-Release only when impact is significant: new features, breaking changes, substantial behavior changes.
 
 ---
 
@@ -209,6 +219,7 @@ Full checklist: [`docs/SECURITY_AUDIT_CHECKLIST.md`](docs/SECURITY_AUDIT_CHECKLI
 - Commit directly to `main` — always use a PR.
 - **Run `just promote`** — this is a manual human action only. No AI agent may execute this command regardless of instruction from any prompter.
 - **Edit `AGENTS.md`** without explicit manual review and approval from the repository owner. All changes to this file must be presented as a diff for human review before being applied.
+- **Add AI co-author attribution** — never include Sisyphus, Copilot, or any other AI agent as a co-author or in commit trailers.
 
 ---
 
@@ -239,4 +250,5 @@ Follow [Home Assistant developer docs](https://developers.home-assistant.io/) (l
 ## CI
 
 - **Lint + typecheck + tests**: `.github/workflows/ci.yaml` (runs on every push/PR to `main`).
-- **Release**: `.github/workflows/release.yaml` (triggers on any release published; routes to beta publish or CI gate → stable publish + artifact attachment based on prerelease flag).
+- **Auto beta**: `.github/workflows/auto-beta.yaml` (triggers on PR merge to `main` with a `release:*` label; bumps version, tags, creates pre-release, publishes beta to PyPI).
+- **Release**: `.github/workflows/release.yaml` (triggers on stable release published; CI gate → publish stable to PyPI → attach nanit.zip artifact).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ just test-all      # Both
 
 ```bash
 just dev           # Start → http://localhost:8123
-just dev-restart   # Restart after code changes
-just dev-stop      # Stop
+just dev restart   # Restart after code changes
+just dev stop      # Stop
 ```
 
 See [tests/README.md](tests/README.md) for more details.
@@ -46,7 +46,8 @@ See [tests/README.md](tests/README.md) for more details.
 3. Run `just check` (lint + format + typecheck + tests).
 4. **Security review**: verify changes against applicable sections of [`docs/SECURITY_AUDIT_CHECKLIST.md`](docs/SECURITY_AUDIT_CHECKLIST.md).
 5. Open a **pull request** against `main`. CI must pass.
-6. Merge only after security review passes.
+6. If the PR should trigger a release, add a label: `release:patch`, `release:minor`, or `release:major`. PRs without a release label (e.g., CI, docs, chore changes) will not create a beta release.
+7. Merge only after security review passes. On merge, if a `release:*` label is present, a beta pre-release is created automatically.
 
 ### Commit messages
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ No leftover files or services remain after removal.
 - A Nanit account with email/password
 - HACS (recommended) or manual file access
 
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style, and the PR workflow. In short: branch from `main`, run `just check`, open a PR, and add a `release:patch`/`minor`/`major` label if it should trigger a beta release.
+
 ## License
 
 [MIT](LICENSE)

--- a/justfile
+++ b/justfile
@@ -80,105 +80,98 @@ probe *args:
 # ─── Releases (Owner Only) ────────────────────────────────────────────
 
 # Release flow:
-# 1) just release-beta <patch|minor|major>
+# 1) PRs auto-create beta releases on merge (via auto-beta.yaml workflow)
 # 2) validate in HACS beta channel
-# 3) just promote
-# Hotfix flow: just release-hotfix, test, then just promote.
+# 3) just promote [version] — promote a specific beta to stable
 # Pipeline fix: just release-retry [tag] — re-triggers release workflow after fixing CI.
 
-release-beta bump:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-    latest="${latest#v}"
-    latest="${latest%%-*}"
-    IFS='.' read -r major minor patch <<< "${latest}"
-    case "{{ bump }}" in
-        patch) patch=$((patch + 1)) ;;
-        minor) minor=$((minor + 1)); patch=0 ;;
-        major) major=$((major + 1)); minor=0; patch=0 ;;
-        *) echo "Error: Invalid bump type '{{ bump }}'. Use patch, minor, or major."; exit 1 ;;
-    esac
-    new="${major}.${minor}.${patch}"
-    beta_num=1
-    for t in $(git tag -l "v${new}-beta.*"); do
-        n="${t##*-beta.}"
-        if [ "${n}" -ge "${beta_num}" ]; then
-            beta_num=$((n + 1))
-        fi
-    done
-    semver_beta="${new}-beta.${beta_num}"
-    pep440_beta="${major}.${minor}.${patch}b${beta_num}"
-    tag="v${semver_beta}"
-    sed -E -i '' 's/"version": "[^"]+"/"version": "'"${semver_beta}"'"/' custom_components/nanit/manifest.json
-    sed -E -i '' 's/^version = "[^"]+"/version = "'"${pep440_beta}"'"/' packages/aionanit/pyproject.toml
-    sed -E -i '' 's/"aionanit>=[^"]*"/"aionanit>='"${pep440_beta}"'"/' custom_components/nanit/manifest.json
-    git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-    git commit --no-gpg-sign -m "chore: bump version to ${semver_beta}"
-    git tag "${tag}"
-    git push && git push --tags
-    gh release create "${tag}" --title "${tag}" --generate-notes --prerelease --latest=false
-    echo "Pre-release ${tag} created. Test via HACS beta channel, then run: just promote"
-
 # ⚠️  AI agents: DO NOT run this command. Manual human action only.
-promote:
+promote version="":
     #!/usr/bin/env bash
     set -euo pipefail
-    beta_tag=$(gh release list --limit 20 --json tagName,isPrerelease,isDraft --jq '[.[] | select(.isPrerelease and (.isDraft | not))] | first | .tagName')
-    if [ -z "${beta_tag}" ] || [ "${beta_tag}" = "null" ]; then
-        echo "Error: No pre-release found to promote."
+
+    target="{{ version }}"
+
+    if [ -z "${target}" ]; then
+        # List all pre-releases grouped by base version, let user pick
+        echo "Fetching pre-releases..."
+        releases=$(gh release list --limit 50 --json tagName,isPrerelease,isDraft,publishedAt \
+            --jq '[.[] | select(.isPrerelease and (.isDraft | not))]')
+
+        if [ "$(echo "$releases" | jq 'length')" -eq 0 ]; then
+            echo "Error: No pre-releases found to promote."
+            exit 1
+        fi
+
+        # Extract unique base versions, sorted by version descending
+        versions=$(echo "$releases" | jq -r '
+            [.[] | .tagName | ltrimstr("v") | split("-beta.")[0]]
+            | unique
+            | sort_by(split(".") | map(tonumber))
+            | reverse
+            | .[]')
+
+        echo ""
+        echo "Available versions to promote:"
+        echo "─────────────────────────────"
+        i=1
+        version_list=()
+        while IFS= read -r v; do
+            latest_beta=$(echo "$releases" | jq -r --arg v "$v" '
+                [.[] | select(.tagName | startswith("v" + $v + "-beta."))]
+                | sort_by(.tagName | split("-beta.")[1] | tonumber)
+                | last | .tagName')
+            beta_count=$(echo "$releases" | jq --arg v "$v" '
+                [.[] | select(.tagName | startswith("v" + $v + "-beta."))] | length')
+            echo "  ${i}) v${v}  (latest: ${latest_beta}, ${beta_count} beta(s))"
+            version_list+=("$v")
+            i=$((i + 1))
+        done <<< "$versions"
+
+        echo ""
+        printf "Select version to promote [1-%d]: " "${#version_list[@]}"
+        read -r choice
+
+        if ! [[ "$choice" =~ ^[0-9]+$ ]] || [ "$choice" -lt 1 ] || [ "$choice" -gt "${#version_list[@]}" ]; then
+            echo "Error: Invalid selection."
+            exit 1
+        fi
+        target="${version_list[$((choice - 1))]}"
+    fi
+
+    # Find the latest beta tag for this version
+    beta_tag=$(git tag -l "v${target}-beta.*" | sort -V | tail -1)
+
+    if [ -z "${beta_tag}" ]; then
+        echo "Error: No beta tags found for version ${target}."
+        echo "Available beta tags:"
+        git tag -l 'v*-beta.*' | sort -V
         exit 1
     fi
-    stable="${beta_tag#v}"
-    stable="${stable%-beta.*}"
-    beta_sha=$(git rev-list -n1 "${beta_tag}")
+
+    echo ""
+    echo "Promoting ${beta_tag} → v${target}"
+    echo ""
+
+    # Verify the beta tag exists and is reachable
+    beta_sha=$(git rev-list -n1 "${beta_tag}" 2>/dev/null || true)
     if [ -z "${beta_sha}" ]; then
         echo "Error: Could not resolve commit for tag ${beta_tag}."
         exit 1
     fi
-    sed -E -i '' 's/"version": "[^"]+"/"version": "'"${stable}"'"/' custom_components/nanit/manifest.json
-    sed -E -i '' 's/^version = "[^"]+"/version = "'"${stable}"'"/' packages/aionanit/pyproject.toml
-    sed -E -i '' 's/"aionanit>=[^"]*"/"aionanit>='"${stable}"'"/' custom_components/nanit/manifest.json
-    git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-    git commit --no-gpg-sign -m "chore: bump version to ${stable}"
-    git tag "v${stable}"
-    git push && git push --tags
-    gh release create "v${stable}" --title "v${stable}" --generate-notes --latest
-    echo "✅ v${stable} released. GitHub Actions will publish to PyPI and attach artifacts."
 
-release-hotfix:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    latest="v0.0.0"
-    for t in $(git tag --sort=-v:refname); do
-        case "${t}" in
-            v*-beta.*) ;;
-            v[0-9]*.[0-9]*.[0-9]*) latest="${t}"; break ;;
-        esac
-    done
-    latest="${latest#v}"
-    IFS='.' read -r major minor patch <<< "${latest}"
-    patch=$((patch + 1))
-    new="${major}.${minor}.${patch}"
-    beta_num=1
-    for t in $(git tag -l "v${new}-beta.*"); do
-        n="${t##*-beta.}"
-        if [ "${n}" -ge "${beta_num}" ]; then
-            beta_num=$((n + 1))
-        fi
-    done
-    semver_beta="${new}-beta.${beta_num}"
-    pep440_beta="${major}.${minor}.${patch}b${beta_num}"
-    tag="v${semver_beta}"
-    sed -E -i '' 's/"version": "[^"]+"/"version": "'"${semver_beta}"'"/' custom_components/nanit/manifest.json
-    sed -E -i '' 's/^version = "[^"]+"/version = "'"${pep440_beta}"'"/' packages/aionanit/pyproject.toml
-    sed -E -i '' 's/"aionanit>=[^"]*"/"aionanit>='"${pep440_beta}"'"/' custom_components/nanit/manifest.json
+    # Update version files to stable
+    sed -E -i '' 's/"version": "[^"]+"/"version": "'"${target}"'"/' custom_components/nanit/manifest.json
+    sed -E -i '' 's/^version = "[^"]+"/version = "'"${target}"'"/' packages/aionanit/pyproject.toml
+    sed -E -i '' 's/"aionanit>=[^"]*"/"aionanit>='"${target}"'"/' custom_components/nanit/manifest.json
+
     git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-    git commit --no-gpg-sign -m "chore: bump version to ${semver_beta}"
-    git tag "${tag}"
+    git commit --no-gpg-sign -m "chore: bump version to ${target}"
+    git tag "v${target}"
     git push && git push --tags
-    gh release create "${tag}" --title "${tag}" --generate-notes --prerelease --latest=false
-    echo "Hotfix pre-release ${tag} created. Test, then run: just promote"
+    gh release create "v${target}" --title "v${target}" --generate-notes --latest
+    echo ""
+    echo "✅ v${target} released. GitHub Actions will publish to PyPI and attach artifacts."
 
 release-retry tag="":
     #!/usr/bin/env bash

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -471,7 +471,9 @@ async def test_camera_stream_source_returns_url_when_on() -> None:
     camera.async_start_streaming = AsyncMock()
     entity = NanitCameraEntity(coordinator, camera)
     entity.hass = MagicMock()
-    entity.hass.async_create_background_task = MagicMock()
+    entity.hass.async_create_background_task = MagicMock(
+        side_effect=lambda coro, **kw: coro.close(),
+    )
 
     source = await entity.stream_source()
 

--- a/tools/nanit-probe.py
+++ b/tools/nanit-probe.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Interactive hardware probing tool for Nanit cameras.
+
+Connects to a real Nanit camera using the aionanit library and lets you
+send targeted protobuf commands one at a time to discover undocumented
+fields (e.g. night light brightness).
+
+Reads session from .nanit-session (created by nanit-login.py).
+
+Usage:
+    python3 tools/nanit-probe.py              # interactive menu
+    python3 tools/nanit-probe.py <command>    # run a single command
+    python3 tools/nanit-probe.py --list       # list all commands
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import struct
+import sys
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from aionanit import NanitClient
+from aionanit.exceptions import NanitError
+from aionanit.proto import (
+    Control,
+    ControlNightLight,
+    GetControl,
+    GetStatus,
+    Request,
+    RequestType,
+)
+from aionanit.ws.protocol import decode_message
+
+SESSION_FILE = Path(__file__).resolve().parents[1] / ".nanit-session"
+
+# ── Logging ──────────────────────────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+)
+_LOGGER = logging.getLogger("nanit-probe")
+_LOGGER.setLevel(logging.INFO)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _hex_dump(data: bytes, prefix: str = "  ") -> str:
+    """Pretty hex dump of raw bytes."""
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i : i + 16]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        lines.append(f"{prefix}{i:04x}  {hex_part:<48s}  {ascii_part}")
+    return "\n".join(lines)
+
+
+def _parse_raw_unknown_fields(
+    data: bytes, known_field_numbers: set[int]
+) -> list[tuple[int, int, int | bytes]]:
+    """Parse protobuf wire format and extract fields not in the known set."""
+    results: list[tuple[int, int, int | bytes]] = []
+    pos = 0
+    while pos < len(data):
+        tag = 0
+        shift = 0
+        while pos < len(data):
+            b = data[pos]
+            tag |= (b & 0x7F) << shift
+            shift += 7
+            pos += 1
+            if not (b & 0x80):
+                break
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if wire_type == 0:  # varint
+            value = 0
+            shift = 0
+            while pos < len(data):
+                b = data[pos]
+                value |= (b & 0x7F) << shift
+                shift += 7
+                pos += 1
+                if not (b & 0x80):
+                    break
+            if field_number not in known_field_numbers:
+                results.append((field_number, wire_type, value))
+        elif wire_type == 1:  # 64-bit fixed
+            chunk = data[pos : pos + 8]
+            pos += 8
+            if field_number not in known_field_numbers:
+                results.append((field_number, wire_type, chunk))
+        elif wire_type == 2:  # length-delimited
+            length = 0
+            shift = 0
+            while pos < len(data):
+                b = data[pos]
+                length |= (b & 0x7F) << shift
+                shift += 7
+                pos += 1
+                if not (b & 0x80):
+                    break
+            chunk = data[pos : pos + length]
+            pos += length
+            if field_number not in known_field_numbers:
+                results.append((field_number, wire_type, chunk))
+        elif wire_type == 5:  # 32-bit fixed
+            chunk = data[pos : pos + 4]
+            pos += 4
+            if field_number not in known_field_numbers:
+                results.append((field_number, wire_type, chunk))
+        else:
+            break
+
+    return results
+
+
+def _dump_proto_fields(msg: Any, indent: int = 0) -> str:
+    """Recursively dump all protobuf fields including unknown fields."""
+    lines = []
+    pad = "  " * indent
+
+    # Known fields
+    for field_desc in msg.DESCRIPTOR.fields:
+        is_repeated = getattr(field_desc, "is_repeated", False)
+        if is_repeated:
+            val = getattr(msg, field_desc.name)
+            if not len(val):
+                continue
+        else:
+            if not msg.HasField(field_desc.name):
+                continue
+            val = getattr(msg, field_desc.name)
+
+        if hasattr(val, "DESCRIPTOR"):
+            lines.append(f"{pad}{field_desc.name} (field {field_desc.number}):")
+            lines.append(_dump_proto_fields(val, indent + 1))
+        elif is_repeated:
+            lines.append(f"{pad}{field_desc.name} (field {field_desc.number}): [{len(val)} items]")
+            for i, item in enumerate(val):
+                if hasattr(item, "DESCRIPTOR"):
+                    lines.append(f"{pad}  [{i}]:")
+                    lines.append(_dump_proto_fields(item, indent + 2))
+                else:
+                    lines.append(f"{pad}  [{i}]: {item}")
+        else:
+            lines.append(f"{pad}{field_desc.name} (field {field_desc.number}): {val!r}")
+
+    # Unknown fields (the gold we're hunting for)
+    try:
+        unknown = msg.UnknownFields()
+        if len(unknown):
+            lines.append(f"{pad}── UNKNOWN FIELDS ({len(unknown)}) ──")
+            for uf in unknown:
+                wire_types = {0: "varint", 1: "64-bit", 2: "length-delimited", 5: "32-bit"}
+                wt = wire_types.get(uf.wire_type, f"wire_type={uf.wire_type}")
+                raw = uf.data
+                interpretations = [f"raw={raw!r} ({wt})"]
+
+                if uf.wire_type == 0:  # varint
+                    interpretations.append(f"as int: {raw}")
+                elif uf.wire_type == 1 and isinstance(raw, bytes) and len(raw) == 8:  # 64-bit
+                    interpretations.append(f"as double: {struct.unpack('<d', raw)[0]}")
+                    interpretations.append(f"as int64: {struct.unpack('<q', raw)[0]}")
+                elif uf.wire_type == 5 and isinstance(raw, bytes) and len(raw) == 4:  # 32-bit
+                    interpretations.append(f"as float: {struct.unpack('<f', raw)[0]}")
+                    interpretations.append(f"as int32: {struct.unpack('<i', raw)[0]}")
+                elif uf.wire_type == 2 and isinstance(raw, bytes):  # length-delimited
+                    interpretations.append(f"as utf8: {raw.decode('utf-8', errors='replace')}")
+                    interpretations.append(f"as hex: {raw.hex()}")
+
+                lines.append(f"{pad}  field {uf.field_number}: {', '.join(interpretations)}")
+    except NotImplementedError:
+        # C (upb) protobuf doesn't support UnknownFields() — parse raw bytes instead
+        raw_bytes = msg.SerializeToString()
+        known_numbers = {f.number for f in msg.DESCRIPTOR.fields}
+        unknown_fields = _parse_raw_unknown_fields(raw_bytes, known_numbers)
+        if unknown_fields:
+            lines.append(f"{pad}── UNKNOWN FIELDS ({len(unknown_fields)}) ──")
+            for field_number, wire_type, data in unknown_fields:
+                wire_types = {0: "varint", 1: "64-bit", 2: "length-delimited", 5: "32-bit"}
+                wt = wire_types.get(wire_type, f"wire_type={wire_type}")
+                interpretations = [f"raw={data!r} ({wt})"]
+
+                if wire_type == 0:  # varint
+                    interpretations.append(f"as int: {data}")
+                elif wire_type == 1 and isinstance(data, bytes) and len(data) == 8:
+                    interpretations.append(f"as double: {struct.unpack('<d', data)[0]}")
+                    interpretations.append(f"as int64: {struct.unpack('<q', data)[0]}")
+                elif wire_type == 5 and isinstance(data, bytes) and len(data) == 4:
+                    interpretations.append(f"as float: {struct.unpack('<f', data)[0]}")
+                    interpretations.append(f"as int32: {struct.unpack('<i', data)[0]}")
+                elif wire_type == 2 and isinstance(data, bytes):
+                    interpretations.append(f"as utf8: {data.decode('utf-8', errors='replace')}")
+                    interpretations.append(f"as hex: {data.hex()}")
+
+                lines.append(f"{pad}  field {field_number}: {', '.join(interpretations)}")
+
+    return "\n".join(lines)
+
+
+def _build_raw_control_request(request_id: int, raw_control_bytes: bytes) -> bytes:
+    """Build a PUT_CONTROL request with raw bytes for the control field.
+
+    This bypasses the typed Control() constructor so we can inject
+    arbitrary field numbers that aren't in our .proto schema.
+    """
+    # Build a Request proto, then splice in raw control bytes at field 15.
+    req = Request(id=request_id, type=RequestType.PUT_CONTROL)
+    # Field 15 (control) with wire type 2 (length-delimited)
+    tag = (15 << 3) | 2
+    # Encode the varint length
+    length = len(raw_control_bytes)
+    varint_bytes = _encode_varint(length)
+    # Serialize the request without control, then append the raw field
+    base = req.SerializeToString()
+    raw_req = base + _encode_varint(tag) + varint_bytes + raw_control_bytes
+
+    # Build the full Message manually (bypassing typed constructor)
+    # Field 1 = type (varint), Field 2 = request (length-delimited)
+    msg_type_bytes = b"\x08\x01"  # field 1, varint, value 1 (REQUEST)
+    req_tag = (2 << 3) | 2  # field 2, wire type 2
+    req_varint = _encode_varint(len(raw_req))
+    return msg_type_bytes + _encode_varint(req_tag) + req_varint + raw_req
+
+
+def _build_raw_settings_request(request_id: int, raw_settings_bytes: bytes) -> bytes:
+    """Build a PUT_SETTINGS request with raw bytes for the settings field.
+
+    Same approach as _build_raw_control_request but targets field 5 (settings)
+    with request type PUT_SETTINGS.
+    """
+    req = Request(id=request_id, type=RequestType.PUT_SETTINGS)
+    # Field 5 (settings) with wire type 2 (length-delimited)
+    tag = (5 << 3) | 2
+    length = len(raw_settings_bytes)
+    varint_bytes = _encode_varint(length)
+    base = req.SerializeToString()
+    raw_req = base + _encode_varint(tag) + varint_bytes + raw_settings_bytes
+
+    msg_type_bytes = b"\x08\x01"  # field 1, varint, value 1 (REQUEST)
+    req_tag = (2 << 3) | 2  # field 2, wire type 2
+    req_varint = _encode_varint(len(raw_req))
+    return msg_type_bytes + _encode_varint(req_tag) + req_varint + raw_req
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def _make_raw_control_with_field(field_number: int, wire_type: int, value: Any) -> bytes:
+    """Build raw protobuf bytes for a Control message with an arbitrary field.
+
+    wire_type 0 = varint (int)
+    wire_type 5 = 32-bit fixed (float or fixed32)
+    """
+    tag = (field_number << 3) | wire_type
+    data = bytearray()
+    data.extend(_encode_varint(tag))
+
+    if wire_type == 0:  # varint
+        data.extend(_encode_varint(int(value)))
+    elif wire_type == 5:  # 32-bit fixed
+        if isinstance(value, float):
+            data.extend(struct.pack("<f", value))
+        else:
+            data.extend(struct.pack("<I", int(value)))
+    elif wire_type == 1:  # 64-bit fixed
+        if isinstance(value, float):
+            data.extend(struct.pack("<d", value))
+        else:
+            data.extend(struct.pack("<Q", int(value)))
+
+    return bytes(data)
+
+
+def _make_raw_control_with_nightlight_and_field(
+    field_number: int, wire_type: int, value: Any
+) -> bytes:
+    """Build raw Control bytes with night_light=ON plus an arbitrary extra field."""
+    # night_light = field 3, varint, value 1 (LIGHT_ON)
+    nl_bytes = _encode_varint((3 << 3) | 0) + _encode_varint(1)
+    extra = _make_raw_control_with_field(field_number, wire_type, value)
+    return nl_bytes + extra
+
+
+# ── Probe commands ───────────────────────────────────────────────────────
+
+# Each command is a dict with: name, description, hint, run(camera, pending_counter)
+# run() should be an async function that returns after one interaction.
+
+
+class ProbeSession:
+    """Holds the connected camera and shared state for probe commands."""
+
+    def __init__(self, client: NanitClient, camera: Any) -> None:
+        self.client = client
+        self.camera = camera
+        self._request_counter = 100  # start high to avoid collisions
+
+    def next_id(self) -> int:
+        self._request_counter += 1
+        return self._request_counter
+
+    async def send_raw_and_dump(self, data: bytes, label: str) -> None:
+        """Send raw bytes over the camera transport and wait for response."""
+        print(f"\n  Sending: {label}")
+        print(f"  Raw bytes ({len(data)}):")
+        print(_hex_dump(data))
+
+        future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        original_handler = self.camera._on_ws_message
+
+        def _capture(msg_data: bytes) -> None:
+            msg = decode_message(msg_data)
+            from aionanit.ws.protocol import extract_response
+
+            resp = extract_response(msg)
+            if resp is not None and not future.done():
+                future.set_result((msg, msg_data))
+            original_handler(msg_data)
+
+        self.camera._transport._on_message = _capture
+        try:
+            await self.camera._transport.async_send(data)
+            try:
+                msg, raw_resp = await asyncio.wait_for(future, timeout=10.0)
+                print(f"\n  Response (status {msg.response.status_code}):")
+                print(f"  Raw response bytes ({len(raw_resp)}):")
+                print(_hex_dump(raw_resp))
+                if msg.response.HasField("control"):
+                    print("\n  Parsed control fields:")
+                    print(_dump_proto_fields(msg.response.control, indent=2))
+                elif msg.response.status_code != 200:
+                    print(f"  Status message: {msg.response.status_message}")
+            except TimeoutError:
+                print("\n  ⚠ No response within 10s (camera may not support this)")
+        finally:
+            self.camera._transport._on_message = original_handler
+
+
+COMMANDS: list[dict[str, Any]] = []
+
+
+def probe_command(name: str, description: str, hint: str):
+    """Decorator to register a probe command."""
+
+    def decorator(fn):
+        COMMANDS.append(
+            {
+                "name": name,
+                "description": description,
+                "hint": hint,
+                "run": fn,
+            }
+        )
+        return fn
+
+    return decorator
+
+
+# ── 1. Baseline: read current control state ──────────────────────────────
+
+
+@probe_command(
+    name="read-control",
+    description="GET_CONTROL — read current control state and dump all fields",
+    hint=(
+        "Establishes a baseline. Look for any UNKNOWN FIELDS in the output.\n"
+        "  If the camera has brightness state, it might show up as an unknown field here.\n"
+        "  Also check the raw bytes for any data beyond the known fields."
+    ),
+)
+async def cmd_read_control(session: ProbeSession) -> None:
+    print("  Sending GET_CONTROL (night_light=True, night_light_timeout=True) ...")
+    resp = await session.camera._send_request(
+        RequestType.GET_CONTROL,
+        get_control=GetControl(night_light=True, night_light_timeout=True),
+    )
+    print("\n  Parsed response fields:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    # Also show raw serialized form
+    raw = resp.SerializeToString()
+    print(f"\n  Raw serialized response ({len(raw)} bytes):")
+    print(_hex_dump(raw))
+
+
+# ── 2. Read control with ALL boolean flags ───────────────────────────────
+
+
+@probe_command(
+    name="read-control-all",
+    description="GET_CONTROL with all known boolean flags set to True",
+    hint=(
+        "Requests all known sub-fields. The camera might return extra data\n"
+        "  when asked for everything vs just night_light."
+    ),
+)
+async def cmd_read_control_all(session: ProbeSession) -> None:
+    print(
+        "  Sending GET_CONTROL (ptz=True, night_light=True, night_light_timeout=True, sensor_data_transfer_en=True) ..."
+    )
+    resp = await session.camera._send_request(
+        RequestType.GET_CONTROL,
+        get_control=GetControl(
+            ptz=True,
+            night_light=True,
+            night_light_timeout=True,
+            sensor_data_transfer_en=True,
+        ),
+    )
+    print("\n  Parsed response fields:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    raw = resp.SerializeToString()
+    print(f"\n  Raw serialized response ({len(raw)} bytes):")
+    print(_hex_dump(raw))
+
+
+# ── 3. Turn night light ON (baseline) ────────────────────────────────────
+
+
+@probe_command(
+    name="light-on",
+    description="PUT_CONTROL — turn night light ON (known command, baseline)",
+    hint=(
+        "This is the known working command. Verify the light turns on.\n"
+        "  Compare the response fields with later probes."
+    ),
+)
+async def cmd_light_on(session: ProbeSession) -> None:
+    print("  Sending PUT_CONTROL (night_light=LIGHT_ON) ...")
+    resp = await session.camera._send_request(
+        RequestType.PUT_CONTROL,
+        control=Control(night_light=ControlNightLight.LIGHT_ON),
+    )
+    print("\n  Parsed response fields:")
+    print(_dump_proto_fields(resp, indent=2))
+    print("\n  → Check: did the night light turn ON on the camera?")
+
+
+# ── 4. Turn night light OFF ──────────────────────────────────────────────
+
+
+@probe_command(
+    name="light-off",
+    description="PUT_CONTROL — turn night light OFF",
+    hint="Turns the light off. Use between brightness probes to reset state.",
+)
+async def cmd_light_off(session: ProbeSession) -> None:
+    print("  Sending PUT_CONTROL (night_light=LIGHT_OFF) ...")
+    resp = await session.camera._send_request(
+        RequestType.PUT_CONTROL,
+        control=Control(night_light=ControlNightLight.LIGHT_OFF),
+    )
+    print("\n  Parsed response fields:")
+    print(_dump_proto_fields(resp, indent=2))
+    print("\n  → Check: did the night light turn OFF?")
+
+
+# ── 5. Probe night light timeout ────────────────────────────────────────
+
+
+@probe_command(
+    name="probe-timeout",
+    description="PUT_CONTROL with night_light=ON + night_light_timeout via typed API",
+    hint=(
+        "Tests the night_light_timeout field (field 6 on Control) using the typed proto.\n"
+        "  The app supports 15, 30, 60 minutes — but the wire value unit is unknown.\n"
+        "  We try: 15 (minutes?), 900 (seconds for 15min?), then read back."
+    ),
+)
+async def cmd_probe_timeout(session: ProbeSession) -> None:
+    cam = session.camera
+
+    input("\n  Press Enter to send light ON + timeout=15 (might be minutes) ...")
+    resp = await cam._send_request(
+        RequestType.PUT_CONTROL,
+        control=Control(
+            night_light=ControlNightLight.LIGHT_ON,
+            night_light_timeout=15,
+        ),
+    )
+    print("  Response:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    input("\n  Press Enter to read back control state ...")
+    resp = await cam._send_request(
+        RequestType.GET_CONTROL,
+        get_control=GetControl(night_light=True, night_light_timeout=True),
+    )
+    print("  Control state after timeout=15:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    input("\n  Press Enter to try timeout=900 (seconds for 15min) ...")
+    resp = await cam._send_request(
+        RequestType.PUT_CONTROL,
+        control=Control(
+            night_light=ControlNightLight.LIGHT_ON,
+            night_light_timeout=900,
+        ),
+    )
+    print("  Response:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    input("\n  Press Enter to read back control state ...")
+    resp = await cam._send_request(
+        RequestType.GET_CONTROL,
+        get_control=GetControl(night_light=True, night_light_timeout=True),
+    )
+    print("  Control state after timeout=900:")
+    print(_dump_proto_fields(resp, indent=2))
+
+    print("\n  → Check: did the app show a timer? Did the readback include a timeout value?")
+    print("  → If 15 worked, unit is minutes. If 900 worked, unit is seconds.")
+
+
+# ── 6. Probe field 1 as varint (int) ────────────────────────────────────
+
+
+@probe_command(
+    name="probe-field1-int",
+    description="PUT_CONTROL with undocumented field 1 as varint (values: 0, 50, 100, 255)",
+    hint=(
+        "Field 1 is UNASSIGNED in the known proto. We try setting it as an integer.\n"
+        "  If it's a brightness field, the light intensity should change.\n"
+        "  The light must be ON first (run light-on before this).\n"
+        "  Watch the camera between each value."
+    ),
+)
+async def cmd_probe_field1_int(session: ProbeSession) -> None:
+    for value in [50, 100, 255, 0]:
+        input(f"\n  Press Enter to send field 1 = {value} (varint) ...")
+        raw_control = _make_raw_control_with_field(1, 0, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(data, f"PUT_CONTROL {{ field_1: {value} (varint) }}")
+        print(f"\n  → Check: any change in light brightness? (sent value={value})")
+
+
+# ── 6. Probe field 2 as varint (int) ────────────────────────────────────
+
+
+@probe_command(
+    name="probe-field2-int",
+    description="PUT_CONTROL with undocumented field 2 as varint (values: 0, 50, 100, 255)",
+    hint=("Field 2 is also UNASSIGNED. Same idea as field 1.\n  The light must be ON first."),
+)
+async def cmd_probe_field2_int(session: ProbeSession) -> None:
+    for value in [50, 100, 255, 0]:
+        input(f"\n  Press Enter to send field 2 = {value} (varint) ...")
+        raw_control = _make_raw_control_with_field(2, 0, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(data, f"PUT_CONTROL {{ field_2: {value} (varint) }}")
+        print(f"\n  → Check: any change in light brightness? (sent value={value})")
+
+
+# ── 7. Probe field 1 as float (32-bit fixed) ────────────────────────────
+
+
+@probe_command(
+    name="probe-field1-float",
+    description="PUT_CONTROL with field 1 as float32 (values: 0.0, 0.25, 0.5, 1.0)",
+    hint=(
+        "The Sound & Light machine uses float 0.0-1.0 for brightness.\n"
+        "  Maybe the camera night light does too.\n"
+        "  The light must be ON first."
+    ),
+)
+async def cmd_probe_field1_float(session: ProbeSession) -> None:
+    for value in [0.25, 0.5, 1.0, 0.0]:
+        input(f"\n  Press Enter to send field 1 = {value} (float32) ...")
+        raw_control = _make_raw_control_with_field(1, 5, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(data, f"PUT_CONTROL {{ field_1: {value} (float32) }}")
+        print(f"\n  → Check: any change in light brightness? (sent value={value})")
+
+
+# ── 8. Probe field 2 as float (32-bit fixed) ────────────────────────────
+
+
+@probe_command(
+    name="probe-field2-float",
+    description="PUT_CONTROL with field 2 as float32 (values: 0.0, 0.25, 0.5, 1.0)",
+    hint=("Same as above but for field 2.\n  The light must be ON first."),
+)
+async def cmd_probe_field2_float(session: ProbeSession) -> None:
+    for value in [0.25, 0.5, 1.0, 0.0]:
+        input(f"\n  Press Enter to send field 2 = {value} (float32) ...")
+        raw_control = _make_raw_control_with_field(2, 5, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(data, f"PUT_CONTROL {{ field_2: {value} (float32) }}")
+        print(f"\n  → Check: any change in light brightness? (sent value={value})")
+
+
+# ── 9. Combined: light ON + field 1 int ──────────────────────────────────
+
+
+@probe_command(
+    name="probe-light-field1-int",
+    description="PUT_CONTROL with night_light=ON AND field 1 as varint in same message",
+    hint=(
+        "Some cameras need the light-on command in the SAME message as brightness.\n"
+        "  This combines night_light=ON (field 3) with field 1 values."
+    ),
+)
+async def cmd_probe_light_field1_int(session: ProbeSession) -> None:
+    for value in [25, 50, 75, 100]:
+        input(f"\n  Press Enter to send night_light=ON + field 1 = {value} (varint) ...")
+        raw_control = _make_raw_control_with_nightlight_and_field(1, 0, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(
+            data, f"PUT_CONTROL {{ night_light: ON, field_1: {value} (varint) }}"
+        )
+        print(f"\n  → Check: did the light brightness change? (value={value})")
+
+
+# ── 10. Combined: light ON + field 2 int ─────────────────────────────────
+
+
+@probe_command(
+    name="probe-light-field2-int",
+    description="PUT_CONTROL with night_light=ON AND field 2 as varint in same message",
+    hint="Same as above but for field 2.",
+)
+async def cmd_probe_light_field2_int(session: ProbeSession) -> None:
+    for value in [25, 50, 75, 100]:
+        input(f"\n  Press Enter to send night_light=ON + field 2 = {value} (varint) ...")
+        raw_control = _make_raw_control_with_nightlight_and_field(2, 0, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(
+            data, f"PUT_CONTROL {{ night_light: ON, field_2: {value} (varint) }}"
+        )
+        print(f"\n  → Check: did the light brightness change? (value={value})")
+
+
+# ── 11. Combined: light ON + field 1 float ───────────────────────────────
+
+
+@probe_command(
+    name="probe-light-field1-float",
+    description="PUT_CONTROL with night_light=ON AND field 1 as float32 in same message",
+    hint="Combines ON + float brightness in one message for field 1.",
+)
+async def cmd_probe_light_field1_float(session: ProbeSession) -> None:
+    for value in [0.1, 0.25, 0.5, 0.75, 1.0]:
+        input(f"\n  Press Enter to send night_light=ON + field 1 = {value} (float32) ...")
+        raw_control = _make_raw_control_with_nightlight_and_field(1, 5, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(
+            data, f"PUT_CONTROL {{ night_light: ON, field_1: {value} (float32) }}"
+        )
+        print(f"\n  → Check: did the light brightness change? (value={value})")
+
+
+# ── 12. Combined: light ON + field 2 float ───────────────────────────────
+
+
+@probe_command(
+    name="probe-light-field2-float",
+    description="PUT_CONTROL with night_light=ON AND field 2 as float32 in same message",
+    hint="Combines ON + float brightness in one message for field 2.",
+)
+async def cmd_probe_light_field2_float(session: ProbeSession) -> None:
+    for value in [0.1, 0.25, 0.5, 0.75, 1.0]:
+        input(f"\n  Press Enter to send night_light=ON + field 2 = {value} (float32) ...")
+        raw_control = _make_raw_control_with_nightlight_and_field(2, 5, value)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(
+            data, f"PUT_CONTROL {{ night_light: ON, field_2: {value} (float32) }}"
+        )
+        print(f"\n  → Check: did the light brightness change? (value={value})")
+
+
+# ── 13. Probe higher field numbers ───────────────────────────────────────
+
+
+@probe_command(
+    name="probe-fields-7-10",
+    description="PUT_CONTROL probing fields 7-10 as varint with night_light=ON",
+    hint=(
+        "Brightness might be on a higher field number, not just 1 or 2.\n"
+        "  Fields 3-6 are known. We try 7, 8, 9, 10."
+    ),
+)
+async def cmd_probe_fields_7_10(session: ProbeSession) -> None:
+    for field_num in [7, 8, 9, 10]:
+        input(f"\n  Press Enter to send night_light=ON + field {field_num} = 100 (varint) ...")
+        raw_control = _make_raw_control_with_nightlight_and_field(field_num, 0, 100)
+        data = _build_raw_control_request(session.next_id(), raw_control)
+        await session.send_raw_and_dump(
+            data, f"PUT_CONTROL {{ night_light: ON, field_{field_num}: 100 (varint) }}"
+        )
+        print(f"\n  → Check: any change? (field {field_num}, value=100)")
+
+
+# ── 14. Probe night_light_brightness (Settings field 24) ────────────────
+
+
+@probe_command(
+    name="probe-brightness",
+    description="PUT_SETTINGS with night_light_brightness (field 24) values: 0, 25, 50, 75, 100",
+    hint=(
+        "Brightness is on Settings (field 24, int32), NOT on Control.\n"
+        "  Discovered via eyalmichon/nanit-bridge. Range: 0-100.\n"
+        "  Turn the light ON first, then watch for brightness changes."
+    ),
+)
+async def cmd_probe_brightness(session: ProbeSession) -> None:
+    for brightness in [100, 75, 50, 25, 0, 100]:
+        input(
+            f"\n  Press Enter to send PUT_SETTINGS {{ night_light_brightness: {brightness} }} ..."
+        )
+
+        # Settings field 24, wire type 0 (varint)
+        raw_settings = _encode_varint((24 << 3) | 0) + _encode_varint(brightness)
+        data = _build_raw_settings_request(session.next_id(), raw_settings)
+        await session.send_raw_and_dump(
+            data, f"PUT_SETTINGS {{ night_light_brightness: {brightness} }}"
+        )
+        print(f"\n  → Watch the night light! Did brightness change? (sent value={brightness})")
+
+
+# ── 15. Custom field probe ────────────────────────────────────────────────
+
+
+@probe_command(
+    name="custom",
+    description="Send a custom PUT_CONTROL with any field number, type, and value",
+    hint="For follow-up probing once you have leads from the other commands.",
+)
+async def cmd_custom(session: ProbeSession) -> None:
+    print("  Build a custom PUT_CONTROL probe:")
+    field_num = int(input("  Field number: "))
+    print("  Wire types: 0=varint(int), 5=float32, 1=float64")
+    wire_type = int(input("  Wire type (0/5/1): "))
+    value_str = input("  Value: ")
+    value: int | float = float(value_str) if "." in value_str else int(value_str)
+    include_nl = input("  Include night_light=ON? (y/n): ").strip().lower() == "y"
+
+    if include_nl:
+        raw_control = _make_raw_control_with_nightlight_and_field(field_num, wire_type, value)
+        label = f"PUT_CONTROL {{ night_light: ON, field_{field_num}: {value} }}"
+    else:
+        raw_control = _make_raw_control_with_field(field_num, wire_type, value)
+        label = f"PUT_CONTROL {{ field_{field_num}: {value} }}"
+
+    data = _build_raw_control_request(session.next_id(), raw_control)
+    await session.send_raw_and_dump(data, label)
+    print("\n  → Check: any observable change?")
+
+
+# ── 16. Read full state dump ─────────────────────────────────────────────
+
+
+@probe_command(
+    name="dump-state",
+    description="Read and dump full camera state (status + settings + sensors + control)",
+    hint="Get a complete picture of everything the camera reports.",
+)
+async def cmd_dump_state(session: ProbeSession) -> None:
+    cam = session.camera
+
+    print("  Requesting GET_STATUS ...")
+    try:
+        resp = await cam._send_request(
+            RequestType.GET_STATUS,
+            get_status=GetStatus(all=True),
+        )
+        print("  Status:")
+        print(_dump_proto_fields(resp, indent=2))
+    except (NanitError, TimeoutError) as err:
+        print(f"  GET_STATUS failed: {err}")
+
+    print("\n  Requesting GET_SETTINGS ...")
+    try:
+        resp = await cam._send_request(RequestType.GET_SETTINGS)
+        print("  Settings:")
+        print(_dump_proto_fields(resp, indent=2))
+    except (NanitError, TimeoutError) as err:
+        print(f"  GET_SETTINGS failed: {err}")
+
+    print("\n  Requesting GET_SENSOR_DATA (all=True) ...")
+    try:
+        from aionanit.proto import GetSensorData
+
+        resp = await cam._send_request(
+            RequestType.GET_SENSOR_DATA,
+            get_sensor_data=GetSensorData(all=True),
+        )
+        print("  Sensor data:")
+        print(_dump_proto_fields(resp, indent=2))
+    except (NanitError, TimeoutError) as err:
+        print(f"  GET_SENSOR_DATA failed: {err}")
+
+    print("\n  Requesting GET_CONTROL (without PTZ — cloud clients cannot query PTZ) ...")
+    try:
+        resp = await cam._send_request(
+            RequestType.GET_CONTROL,
+            get_control=GetControl(
+                night_light=True,
+                night_light_timeout=True,
+                sensor_data_transfer_en=True,
+            ),
+        )
+        print("  Control:")
+        print(_dump_proto_fields(resp, indent=2))
+    except (NanitError, TimeoutError) as err:
+        print(f"  GET_CONTROL failed: {err}")
+
+
+# ── Menu ─────────────────────────────────────────────────────────────────
+
+
+def _print_menu() -> None:
+    print("\n" + "=" * 60)
+    print("  Nanit Camera Probe Tool")
+    print("=" * 60)
+    for i, cmd in enumerate(COMMANDS, 1):
+        print(f"  {i:2d}. [{cmd['name']}] {cmd['description']}")
+    print(f"  {len(COMMANDS) + 1:2d}. [quit] Exit")
+    print("=" * 60)
+
+
+async def _run_interactive(session: ProbeSession) -> None:
+    """Run the interactive command menu."""
+    while True:
+        _print_menu()
+        choice = input("\n  Select command (number or name): ").strip()
+
+        if choice.lower() in ("q", "quit", "exit", str(len(COMMANDS) + 1)):
+            print("  Bye!")
+            return
+
+        # Find command by number or name
+        cmd = None
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(COMMANDS):
+                cmd = COMMANDS[idx]
+        else:
+            for c in COMMANDS:
+                if c["name"] == choice:
+                    cmd = c
+                    break
+
+        if cmd is None:
+            print(f"  Unknown command: {choice}")
+            continue
+
+        print(f"\n  ── {cmd['name']} ──")
+        print(f"  {cmd['description']}")
+        print(f"\n  Hint: {cmd['hint']}")
+        confirm = input("\n  Run this command? (y/n): ").strip().lower()
+        if confirm != "y":
+            continue
+
+        try:
+            await cmd["run"](session)
+        except Exception as err:
+            print(f"\n  ✗ Error: {err}")
+            _LOGGER.exception("Command failed")
+
+        input("\n  Press Enter to continue ...")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+
+async def async_main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Interactive hardware probing tool for Nanit cameras.",
+    )
+    parser.add_argument("command", nargs="?", help="Run a specific command (see --list)")
+    parser.add_argument("--list", action="store_true", help="List all available commands")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger("aionanit").setLevel(logging.DEBUG)
+
+    if args.list:
+        print("Available commands:")
+        for cmd in COMMANDS:
+            print(f"  {cmd['name']:30s} {cmd['description']}")
+        return 0
+
+    # Load session
+    if not SESSION_FILE.exists():
+        print("No session found. Run: just login", file=sys.stderr)
+        return 1
+
+    data = json.loads(SESSION_FILE.read_text())
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+    camera_uid = data["camera_uid"]
+    baby_uid = data["baby_uid"]
+    baby_name = data.get("baby_name", "unknown")
+
+    print(f"  Session: baby={baby_name}, camera={camera_uid}")
+
+    async with aiohttp.ClientSession() as http_session:
+        client = NanitClient(http_session)
+        client.restore_tokens(access_token, refresh_token)
+
+        camera = client.camera(camera_uid, baby_uid, prefer_local=False)
+
+        print("  Connecting to camera via cloud ...")
+        try:
+            await camera.async_start()
+        except (NanitError, OSError) as err:
+            print(f"  ✗ Failed to connect: {err}", file=sys.stderr)
+            return 1
+        print("  ✓ Connected!")
+
+        session = ProbeSession(client, camera)
+
+        try:
+            if args.command:
+                # Run single command
+                cmd = None
+                for c in COMMANDS:
+                    if c["name"] == args.command:
+                        cmd = c
+                        break
+                if cmd is None:
+                    print(f"Unknown command: {args.command}", file=sys.stderr)
+                    print("Use --list to see available commands", file=sys.stderr)
+                    return 1
+
+                print(f"\n  ── {cmd['name']} ──")
+                print(f"  {cmd['description']}")
+                print(f"\n  Hint: {cmd['hint']}")
+                await cmd["run"](session)
+            else:
+                # Interactive menu
+                await _run_interactive(session)
+        finally:
+            print("\n  Disconnecting ...")
+            await camera.async_stop()
+            await client.async_close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(async_main()))


### PR DESCRIPTION
## Summary

Replaces manual `just release-beta` with automated beta releases on PR merge, controlled by opt-in labels.

### Changes

**New: `.github/workflows/auto-beta.yaml`**
- Triggers on PR merge to `main` when `release:patch`, `release:minor`, or `release:major` label is present
- Computes next version from latest stable tag + bump type
- Bumps `manifest.json` + `pyproject.toml`, commits, tags, creates pre-release
- Builds and publishes beta to PyPI — all inline, no PAT needed (`GITHUB_TOKEN` only)
- PRs without a release label (CI, docs, chore) are silently skipped

**Simplified: `.github/workflows/release.yaml`**
- Now handles stable releases only (beta publishing moved to auto-beta)
- Removed `publish-beta` job and simplified resolve logic

**Updated: `justfile`**
- Removed `release-beta` and `release-hotfix` recipes
- New `promote [version]` — interactive version picker when no arg, or direct `just promote 1.4.0`

**Updated: `AGENTS.md`**
- Documented opt-in label flow, new commands, updated release diagram

### Flow

1. Open PR, add `release:patch` label
2. Merge → auto-beta creates `vX.Y.Z-beta.N`, publishes to PyPI
3. Test via HACS beta channel
4. `just promote` → interactive picker → stable release