### PR TITLE
feat: Sound & Light Machine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration for [Nanit
 | Nanit Pro | Fully supported |
 | Nanit Plus | Fully supported |
 | Nanit Pro Camera (standalone) | Supported (no sound machine features) |
+| Nanit Sound & Light Machine | Supported (local WebSocket or cloud relay) |
 
 > [!NOTE]
 > All Nanit cameras that work with the official Nanit app should work with this integration. If you have a model not listed above, please [open an issue](https://github.com/wealthystudent/ha-nanit/issues/new?template=bug_report.yml) to help us update this list.
@@ -41,6 +42,25 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration for [Nanit
 | Switch | Night Light | Toggle the camera's built-in night light. | Yes |
 | Switch | Camera Power | Toggle camera on/off (sleep mode). | Yes |
 | Number | Volume | Camera speaker volume (0–100%). | No |
+
+### Sound & Light Machine entities
+
+If a Nanit Sound & Light Machine is linked to a camera, these additional entities appear on a separate device:
+
+| Platform | Entity | Description | Enabled |
+|----------|--------|-------------|---------|
+| Switch | Power | Device power on/off. | Yes |
+| Switch | Sound | Toggle sound playback. | Yes |
+| Switch | Light | Toggle night light. | Yes |
+| Select | Sound Track | Choose from available sound tracks. | Yes |
+| Number | Volume | Sound volume (0–100%). | Yes |
+| Number | Brightness | Light brightness (0–100%). | Yes |
+| Sensor | Temperature | Device temperature in °C. | Yes |
+| Sensor | Humidity | Relative humidity (%). | Yes |
+| Sensor | Connection Mode | Diagnostic — shows Local, Cloud, or Unavailable. | No |
+| Binary Sensor | S&L Connectivity | WebSocket connection status. | No |
+
+S&L entities retain their last-known values when the WebSocket disconnects, rather than going "unavailable." This is an intentional design choice — it prevents entities from flashing "unavailable" during brief reconnection windows (e.g., the ~3-second hourly token refresh). The dedicated S&L Connectivity binary sensor and Connection Mode sensor report the actual connection state separately, so you can monitor connectivity without losing entity values.
 
 Entities marked "No" under Enabled are created but disabled by default. Enable them in **Settings → Devices & Services → Nanit → Entities**.
 
@@ -93,6 +113,7 @@ For faster LAN-first connectivity, configure a local IP per camera:
 |-------|----------|-------------|
 | Camera | Yes (multi-camera only) | Which camera to configure. Skipped if you only have one. |
 | Camera IP Address | No | Local IP (port 442). Leave blank for cloud-only mode. |
+| Speaker IP Address | No | Local IP of a linked Sound & Light Machine (port 442). Leave blank to use cloud relay. |
 
 When a camera IP is set, the integration connects directly over your LAN for sensor data and controls, using the cloud only for authentication and event detection. Clear the IP to return to cloud-only mode.
 
@@ -107,6 +128,8 @@ The integration uses two update mechanisms — no unnecessary polling for real-t
 | Camera connection status | **WebSocket push** | Instant (on change) | Camera (local or cloud) |
 | Motion and sound events | **Cloud polling** | Every 30 seconds | Nanit cloud API |
 | Live video stream | **On demand** | When viewed | RTMPS via Nanit media server |
+| S&L state (light, sound, power) | **WebSocket push** | Instant (on change) | S&L device (local or cloud relay) |
+| S&L temperature, humidity | **WebSocket push** | Instant (on change) | S&L device (local or cloud relay) |
 
 Push data arrives via a persistent WebSocket connection to the camera. If the connection drops, it reconnects automatically and logs the event.
 
@@ -188,7 +211,8 @@ automation:
 | **Self-signed TLS (local)** | Local camera connections use self-signed certificates. The integration accepts these automatically. |
 | **RTMPS streaming** | Live video uses `rtmps://media-secured.nanit.com`. Your HA instance must be able to reach this address. |
 | **Motion/sound is cloud-polled** | Motion and sound detection comes from the Nanit cloud API (polled every 30s), not from the camera directly. There may be up to ~30s delay. |
-| **No sound machine control** | Sound machine / white noise features are not yet supported. |
+| **S&L stale values when offline** | Sound & Light entities show their last-known values when the device is disconnected, rather than going "unavailable." Check the S&L Connectivity binary sensor to confirm the device is actually reachable. This is intentional — it avoids disruptive flickers during brief reconnection windows. |
+| **Cloud relay cannot detect S&L power-off** | When the Sound & Light Machine is connected via cloud relay (no local IP), powering off the device does not drop the WebSocket. The connectivity sensor continues showing "connected / cloud" until the connection times out. Local connections detect power-off immediately. |
 | **Session expiry** | Nanit access tokens expire. The integration refreshes them automatically, but if refresh fails, a re-authentication notification will appear. |
 
 ## Troubleshooting

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -131,11 +131,17 @@ def _async_remove_stale_devices(
     device_reg = dr.async_get(hass)
     known_camera_uids = {baby.camera_uid for baby in hub.babies}
 
+    # Build the set of valid device identifiers: raw camera UIDs and
+    # derived S&L identifiers ("{camera_uid}_sound_light").
+    valid_uids = set(known_camera_uids)
+    for uid in known_camera_uids:
+        valid_uids.add(f"{uid}_sound_light")
+
     for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
         device_uids = {
             identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN
         }
-        if device_uids and not device_uids & known_camera_uids:
+        if device_uids and not device_uids & valid_uids:
             LOGGER.info(
                 "Removing stale device %s (camera no longer on account)",
                 device.name,

--- a/custom_components/nanit/aionanit_sl/__init__.py
+++ b/custom_components/nanit/aionanit_sl/__init__.py
@@ -1,0 +1,23 @@
+"""aionanit_sl — Sound & Light Machine extensions for the Nanit integration.
+
+This package contains the S&L-specific WebSocket protocol, models, and
+high-level API that are not (yet) part of the external aionanit package.
+"""
+
+from .exceptions import NanitTransportError
+from .models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+    SoundLightRoutine,
+)
+from .sound_light import NanitSoundLight
+
+__all__ = [
+    "NanitSoundLight",
+    "NanitTransportError",
+    "SoundLightEvent",
+    "SoundLightEventKind",
+    "SoundLightFullState",
+    "SoundLightRoutine",
+]

--- a/custom_components/nanit/aionanit_sl/exceptions.py
+++ b/custom_components/nanit/aionanit_sl/exceptions.py
@@ -1,0 +1,7 @@
+"""S&L-specific exceptions."""
+
+from aionanit import NanitError
+
+
+class NanitTransportError(NanitError):
+    """WebSocket transport error for the S&L device."""

--- a/custom_components/nanit/aionanit_sl/models.py
+++ b/custom_components/nanit/aionanit_sl/models.py
@@ -1,0 +1,62 @@
+"""Data models for the Sound & Light Machine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass(frozen=True)
+class SoundLightRoutine:
+    """A single routine definition from the S&L device."""
+
+    name: str
+    sound_name: str | None = None
+    volume: float | None = None
+    brightness: float | None = None
+
+
+@dataclass(frozen=True)
+class SoundLightFullState:
+    """Complete state snapshot from the S&L device WebSocket.
+
+    All float values are 0.0-1.0 scale as sent by the device.
+    """
+
+    # Light
+    brightness: float | None = None
+    light_enabled: bool | None = None
+    color_r: float | None = None
+    color_g: float | None = None
+
+    # Sound
+    sound_on: bool | None = None
+    current_track: str | None = None
+    volume: float | None = None
+    available_tracks: tuple[str, ...] = ()
+
+    # Power
+    power_on: bool | None = None
+
+    # Sensors
+    temperature_c: float | None = None
+    humidity_pct: float | None = None
+
+    # Routines
+    routines: tuple[SoundLightRoutine, ...] = ()
+
+    # Timezone
+    timezone_rule: str | None = None
+
+
+class SoundLightEventKind(Enum):
+    STATE_UPDATE = "state_update"
+    SENSOR_UPDATE = "sensor_update"
+    ROUTINES_UPDATE = "routines_update"
+    CONNECTION_CHANGE = "connection_change"
+
+
+@dataclass(frozen=True)
+class SoundLightEvent:
+    kind: SoundLightEventKind
+    state: SoundLightFullState

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -74,22 +74,22 @@ def decode_fields(data: bytes) -> list[ProtoField]:
         elif wire_type == FIXED64:
             if pos + 8 > len(data):
                 break
-            value = data[pos : pos + 8]
+            raw = data[pos : pos + 8]
             pos += 8
-            fields.append(ProtoField(field_number, wire_type, value))
+            fields.append(ProtoField(field_number, wire_type, raw))
         elif wire_type == LENGTH_DELIMITED:
             length, pos = decode_varint(data, pos)
             if pos + length > len(data):
                 break
-            value = data[pos : pos + length]
+            raw = data[pos : pos + length]
             pos += length
-            fields.append(ProtoField(field_number, wire_type, value))
+            fields.append(ProtoField(field_number, wire_type, raw))
         elif wire_type == FIXED32:
             if pos + 4 > len(data):
                 break
-            value = data[pos : pos + 4]
+            raw = data[pos : pos + 4]
             pos += 4
-            fields.append(ProtoField(field_number, wire_type, value))
+            fields.append(ProtoField(field_number, wire_type, raw))
         else:
             # Unknown wire type, bail
             break
@@ -98,7 +98,7 @@ def decode_fields(data: bytes) -> list[ProtoField]:
 
 def fixed32_to_float(data: bytes) -> float:
     """Convert 4 bytes (FIXED32) to IEEE 754 single-precision float."""
-    return struct.unpack("<f", data)[0]
+    return float(struct.unpack("<f", data)[0])
 
 
 def float_to_fixed32(value: float) -> bytes:
@@ -533,7 +533,7 @@ def classify_message(data: bytes) -> int | None:
         if f1_inner is not None and f1_inner.wire_type == VARINT:
             val = f1_inner.value
             if val in (2, 3):
-                return val
+                return int(val)
             # Large varint values (e.g. timestamps) indicate network info
             # or other device metadata messages — safe to ignore.
             if val > 3:

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 #   Wire value 1 = OFF/disabled
 # All decode and encode functions in this module handle the inversion.
 # Search for "INVERTED" to find all relevant locations.
-
 import logging
 import struct
 from dataclasses import dataclass
@@ -137,13 +136,13 @@ class SLDecodedState:
     """Decoded S&L full state from message type 0."""
 
     brightness: float | None = None
-    light_enabled: bool | None = None    # field 2 sub-1
-    color_r: float | None = None         # field 2 sub-2 (color param A)
-    color_g: float | None = None         # field 2 sub-3 (color param B)
-    volume: float | None = None          # field 3
-    current_track: str | None = None     # field 4 sub-2
-    sound_on: bool | None = None         # field 4 sub-1
-    power_on: bool | None = None         # field 5
+    light_enabled: bool | None = None  # field 2 sub-1
+    color_r: float | None = None  # field 2 sub-2 (color param A)
+    color_g: float | None = None  # field 2 sub-3 (color param B)
+    volume: float | None = None  # field 3
+    current_track: str | None = None  # field 4 sub-2
+    sound_on: bool | None = None  # field 4 sub-1
+    power_on: bool | None = None  # field 5
     available_tracks: list[str] | None = None
     temperature_c: float | None = None
     humidity_pct: float | None = None
@@ -519,6 +518,7 @@ def classify_message(data: bytes) -> int | None:
         3 = routine set B (type field = 3)
         -1 = network info / ignorable (field 1 with large varint type indicator)
         None = unknown
+
     """
     try:
         outer = decode_fields(data)

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -150,6 +150,98 @@ class SLDecodedState:
     timezone_rule: str | None = None
 
 
+def _parse_state_fields(state_fields: list[ProtoField]) -> SLDecodedState:
+    """Parse state fields into an SLDecodedState.
+
+    Shared by both local and cloud relay decoders. The state field structure
+    is identical in both framing formats.
+    """
+    result = SLDecodedState()
+
+    # Field 1: brightness (FIXED32 float)
+    f_brightness = get_field(state_fields, 1)
+    if f_brightness is not None and f_brightness.wire_type == FIXED32:
+        result.brightness = fixed32_to_float(f_brightness.value)
+
+    # Field 2: light config submessage { 1: light_enabled, 2: color_a, 3: color_b }
+    f_light = get_field(state_fields, 2)
+    if f_light is not None and f_light.wire_type == LENGTH_DELIMITED:
+        light_fields = decode_fields(f_light.value)
+        # Sub-1: light enabled flag (varint, INVERTED convention!)
+        # Device uses: absent or 0 = ON, 1 = OFF
+        f_light_en = get_field(light_fields, 1)
+        if f_light_en is not None and f_light_en.wire_type == VARINT:
+            result.light_enabled = f_light_en.value == 0
+        else:
+            result.light_enabled = True  # absent means ON
+        # Sub-2: color param A (hue)
+        f_color_a = get_field(light_fields, 2)
+        if f_color_a is not None and f_color_a.wire_type == FIXED32:
+            result.color_r = fixed32_to_float(f_color_a.value)
+        # Sub-3: color param B (saturation)
+        f_color_b = get_field(light_fields, 3)
+        if f_color_b is not None and f_color_b.wire_type == FIXED32:
+            result.color_g = fixed32_to_float(f_color_b.value)
+
+    # Field 3: VOLUME (FIXED32 float, 0.0-1.0)
+    f_vol = get_field(state_fields, 3)
+    if f_vol is not None and f_vol.wire_type == FIXED32:
+        result.volume = fixed32_to_float(f_vol.value)
+
+    # Field 4: sound config submessage { 1: sound_on, 2: track_name }
+    f_sound = get_field(state_fields, 4)
+    if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
+        sound_fields = decode_fields(f_sound.value)
+        # Sub-1: sound enabled flag (varint, INVERTED convention!)
+        f_sound_en = get_field(sound_fields, 1)
+        if f_sound_en is not None and f_sound_en.wire_type == VARINT:
+            result.sound_on = f_sound_en.value == 0
+        else:
+            result.sound_on = True  # absent means ON
+        # Sub-2: track name
+        f_name = get_field(sound_fields, 2)
+        if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
+            result.current_track = try_decode_string(f_name.value)
+
+    # Field 5: power on/off (varint, 0 or 1)
+    f_power = get_field(state_fields, 5)
+    if f_power is not None and f_power.wire_type == VARINT:
+        result.power_on = bool(f_power.value)
+
+    # Field 6: available sounds (submessage with repeated field 1 = strings)
+    f_sounds = get_field(state_fields, 6)
+    if f_sounds is not None and f_sounds.wire_type == LENGTH_DELIMITED:
+        sounds_fields = decode_fields(f_sounds.value)
+        tracks = []
+        for f in get_fields(sounds_fields, 1):
+            if f.wire_type == LENGTH_DELIMITED:
+                name = try_decode_string(f.value)
+                if name:
+                    tracks.append(name)
+        if tracks:
+            result.available_tracks = tracks
+
+    # Field 7: temperature (FIXED32 float)
+    f_temp = get_field(state_fields, 7)
+    if f_temp is not None and f_temp.wire_type == FIXED32:
+        result.temperature_c = fixed32_to_float(f_temp.value)
+
+    # Field 8: humidity (FIXED32 float)
+    f_hum = get_field(state_fields, 8)
+    if f_hum is not None and f_hum.wire_type == FIXED32:
+        result.humidity_pct = fixed32_to_float(f_hum.value)
+
+    # Field 11: timezone info
+    f_tz = get_field(state_fields, 11)
+    if f_tz is not None and f_tz.wire_type == LENGTH_DELIMITED:
+        tz_fields = decode_fields(f_tz.value)
+        f_tz_rule = get_field(tz_fields, 2)
+        if f_tz_rule is not None and f_tz_rule.wire_type == LENGTH_DELIMITED:
+            result.timezone_rule = try_decode_string(f_tz_rule.value)
+
+    return result
+
+
 def decode_full_state(data: bytes) -> SLDecodedState | None:
     """Decode message type 0 — full device state.
 
@@ -176,100 +268,98 @@ def decode_full_state(data: bytes) -> SLDecodedState | None:
                 return None  # This is a routines message
 
         state_fields = decode_fields(f6.value)
-        result = SLDecodedState()
-
-        # Field 1: brightness (FIXED32 float)
-        f_brightness = get_field(state_fields, 1)
-        if f_brightness is not None and f_brightness.wire_type == FIXED32:
-            result.brightness = fixed32_to_float(f_brightness.value)
-
-        # Field 2: light config submessage { 1: light_enabled, 2: color_a, 3: color_b }
-        f_light = get_field(state_fields, 2)
-        if f_light is not None and f_light.wire_type == LENGTH_DELIMITED:
-            light_fields = decode_fields(f_light.value)
-            # Sub-1: light enabled flag (varint, INVERTED convention!)
-            # Device uses: absent or 0 = ON, 1 = OFF
-            # Original capture had no sub-1 and light was ON.
-            # User confirmed: sending sub-1=1 turns light OFF.
-            f_light_en = get_field(light_fields, 1)
-            if f_light_en is not None and f_light_en.wire_type == VARINT:
-                result.light_enabled = f_light_en.value == 0
-            else:
-                result.light_enabled = True  # absent means ON
-            # Sub-2: color param A (hue)
-            f_color_a = get_field(light_fields, 2)
-            if f_color_a is not None and f_color_a.wire_type == FIXED32:
-                result.color_r = fixed32_to_float(f_color_a.value)
-            # Sub-3: color param B (saturation)
-            f_color_b = get_field(light_fields, 3)
-            if f_color_b is not None and f_color_b.wire_type == FIXED32:
-                result.color_g = fixed32_to_float(f_color_b.value)
-
-        # Field 3: VOLUME (FIXED32 float, 0.0-1.0)
-        # Confirmed by user testing: setting color accidentally sent
-        # saturation as field 3, which changed the device volume.
-        f_vol = get_field(state_fields, 3)
-        if f_vol is not None and f_vol.wire_type == FIXED32:
-            result.volume = fixed32_to_float(f_vol.value)
-
-        # Field 4: sound config submessage { 1: sound_on, 2: track_name }
-        f_sound = get_field(state_fields, 4)
-        if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
-            sound_fields = decode_fields(f_sound.value)
-            # Sub-1: sound enabled flag (varint, INVERTED convention!)
-            # Device uses: absent or 0 = ON, 1 = OFF (same as light)
-            f_sound_en = get_field(sound_fields, 1)
-            if f_sound_en is not None and f_sound_en.wire_type == VARINT:
-                result.sound_on = f_sound_en.value == 0
-            else:
-                result.sound_on = True  # absent means ON
-            # Sub-2: track name
-            f_name = get_field(sound_fields, 2)
-            if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
-                result.current_track = try_decode_string(f_name.value)
-
-        # Field 5: power on/off (varint, 0 or 1)
-        # User confirmed: this is the device power switch, not sound on/off.
-        f_power = get_field(state_fields, 5)
-        if f_power is not None and f_power.wire_type == VARINT:
-            result.power_on = bool(f_power.value)
-
-        # Field 6: available sounds (submessage with repeated field 1 = strings)
-        f_sounds = get_field(state_fields, 6)
-        if f_sounds is not None and f_sounds.wire_type == LENGTH_DELIMITED:
-            sounds_fields = decode_fields(f_sounds.value)
-            tracks = []
-            for f in get_fields(sounds_fields, 1):
-                if f.wire_type == LENGTH_DELIMITED:
-                    name = try_decode_string(f.value)
-                    if name:
-                        tracks.append(name)
-            if tracks:
-                result.available_tracks = tracks
-
-        # Field 7: temperature (FIXED32 float)
-        f_temp = get_field(state_fields, 7)
-        if f_temp is not None and f_temp.wire_type == FIXED32:
-            result.temperature_c = fixed32_to_float(f_temp.value)
-
-        # Field 8: humidity (FIXED32 float)
-        f_hum = get_field(state_fields, 8)
-        if f_hum is not None and f_hum.wire_type == FIXED32:
-            result.humidity_pct = fixed32_to_float(f_hum.value)
-
-        # Field 11: timezone info
-        f_tz = get_field(state_fields, 11)
-        if f_tz is not None and f_tz.wire_type == LENGTH_DELIMITED:
-            tz_fields = decode_fields(f_tz.value)
-            f_tz_rule = get_field(tz_fields, 2)
-            if f_tz_rule is not None and f_tz_rule.wire_type == LENGTH_DELIMITED:
-                result.timezone_rule = try_decode_string(f_tz_rule.value)
-
-        return result
+        return _parse_state_fields(state_fields)
 
     except Exception as err:
         _LOGGER.debug("Failed to decode S&L full state: %s", err)
         return None
+
+
+def decode_cloud_relay(data: bytes) -> SLDecodedState | None:
+    """Decode a cloud relay message — state wrapped in HTTP-like envelope.
+
+    Cloud relay structure: field 2 { field 2=status, field 3=text, field 4 { state } }
+    The state fields inside field 4 are the same format as local field 1.6.
+    """
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return None
+
+        inner = decode_fields(f2.value)
+
+        # Check for HTTP status (field 2 varint)
+        f_status = get_field(inner, 2)
+        if f_status is None or f_status.wire_type != VARINT:
+            return None
+
+        status_code = f_status.value
+        if status_code != 200:
+            # Non-200 (e.g. 403 Forbidden) — ignore silently
+            return None
+
+        # Extract state payload from field 4
+        f_payload = get_field(inner, 4)
+        if f_payload is None or f_payload.wire_type != LENGTH_DELIMITED:
+            return None
+
+        state_fields = decode_fields(f_payload.value)
+        return _parse_state_fields(state_fields)
+
+    except Exception as err:
+        _LOGGER.debug("Failed to decode S&L cloud relay message: %s", err)
+        return None
+
+
+def is_cloud_relay_forbidden(data: bytes) -> bool:
+    """Check if a message is a cloud relay 403 Forbidden (periodic, ignorable)."""
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return False
+        inner = decode_fields(f2.value)
+        f_status = get_field(inner, 2)
+        return f_status is not None and f_status.wire_type == VARINT and f_status.value == 403
+    except Exception:
+        return False
+
+
+def is_cloud_relay_error(data: bytes) -> bool:
+    """Check if a message is a non-200 error response in field 2 envelope.
+
+    The device (and cloud relay) may return error responses such as
+    400 "Failed to parse request". These use the same field 2 envelope
+    as cloud relay messages but with a non-200 status code.
+    """
+    try:
+        outer = decode_fields(data)
+        f2 = get_field(outer, 2)
+        if f2 is None or f2.wire_type != LENGTH_DELIMITED:
+            return False
+        inner = decode_fields(f2.value)
+        f_status = get_field(inner, 2)
+        if f_status is None or f_status.wire_type != VARINT:
+            return False
+        # Any status code that isn't 200 (success) or 403 (handled separately)
+        return f_status.value not in (200, 403)
+    except Exception:
+        return False
+
+
+def is_cloud_relay_ack(data: bytes) -> bool:
+    """Check if a message is a cloud relay command acknowledgment.
+
+    Cloud relay sends back field 3 { field 1 { field 1: 1 } } after
+    receiving a command. These are safe to ignore.
+    """
+    try:
+        outer = decode_fields(data)
+        f3 = get_field(outer, 3)
+        return f3 is not None and f3.wire_type == LENGTH_DELIMITED
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +517,7 @@ def classify_message(data: bytes) -> int | None:
         1 = sensor data (has field 1.10)
         2 = routine set A (type field = 2)
         3 = routine set B (type field = 3)
+        -1 = network info / ignorable (field 1 with large varint type indicator)
         None = unknown
     """
     try:
@@ -443,6 +534,10 @@ def classify_message(data: bytes) -> int | None:
             val = f1_inner.value
             if val in (2, 3):
                 return val
+            # Large varint values (e.g. timestamps) indicate network info
+            # or other device metadata messages — safe to ignore.
+            if val > 3:
+                return -1
 
         # Check for sensor data (field 10)
         f10 = get_field(inner, 10)
@@ -496,18 +591,6 @@ def _encode_varint_field(field_number: int, value: int) -> bytes:
 def _encode_fixed32_field(field_number: int, data: bytes) -> bytes:
     """Encode a FIXED32 field."""
     return _encode_tag(field_number, FIXED32) + data
-
-
-def build_sl_keepalive() -> bytes:
-    """Build a minimal keepalive message for the S&L device.
-
-    We send a minimal valid protobuf message. The actual keepalive format
-    may differ — this is our best guess and will be refined in testing.
-    """
-    # Try an empty message — just a valid protobuf wrapper
-    # field 1 { } — empty submessage
-    inner = b""
-    return _encode_length_delimited(1, inner)
 
 
 def build_power_cmd(on: bool) -> bytes:

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -1,0 +1,644 @@
+"""Protobuf wire-format decode/encode for the Nanit Sound & Light Machine.
+
+The S&L device communicates via raw protobuf messages over WebSocket.
+We decode them without .proto schema files using manual wire-format parsing.
+
+Message types received on connect:
+  MSG 0 (full state): brightness, color, sound track, volume, temp, humidity, tracks
+  MSG 1 (sensor data): temperature, humidity
+  MSG 2 (routines set A): Bedtime, Wakeup, Soft Light, Nighttime
+  MSG 3 (routines set B): Wind down, turn off, Weekend
+"""
+
+from __future__ import annotations
+
+# IMPORTANT: The S&L device uses inverted boolean conventions for
+# no_color (field 2 sub-1) and no_sound (field 4 sub-1):
+#   Wire value 0 (or absent) = ON/enabled
+#   Wire value 1 = OFF/disabled
+# All decode and encode functions in this module handle the inversion.
+# Search for "INVERTED" to find all relevant locations.
+
+import logging
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Wire types
+VARINT = 0
+FIXED64 = 1
+LENGTH_DELIMITED = 2
+FIXED32 = 5
+
+
+@dataclass
+class ProtoField:
+    """A single decoded protobuf field."""
+
+    field_number: int
+    wire_type: int
+    value: Any  # int, bytes, or float
+
+
+def decode_varint(data: bytes, pos: int) -> tuple[int, int]:
+    """Decode a varint at position, return (value, new_pos)."""
+    result = 0
+    shift = 0
+    while pos < len(data):
+        byte = data[pos]
+        result |= (byte & 0x7F) << shift
+        pos += 1
+        if (byte & 0x80) == 0:
+            return result, pos
+        shift += 7
+    raise ValueError("Truncated varint")
+
+
+def decode_fields(data: bytes) -> list[ProtoField]:
+    """Decode raw protobuf bytes into a list of fields."""
+    fields: list[ProtoField] = []
+    pos = 0
+    while pos < len(data):
+        try:
+            tag, pos = decode_varint(data, pos)
+        except ValueError:
+            break
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if wire_type == VARINT:
+            value, pos = decode_varint(data, pos)
+            fields.append(ProtoField(field_number, wire_type, value))
+        elif wire_type == FIXED64:
+            if pos + 8 > len(data):
+                break
+            value = data[pos : pos + 8]
+            pos += 8
+            fields.append(ProtoField(field_number, wire_type, value))
+        elif wire_type == LENGTH_DELIMITED:
+            length, pos = decode_varint(data, pos)
+            if pos + length > len(data):
+                break
+            value = data[pos : pos + length]
+            pos += length
+            fields.append(ProtoField(field_number, wire_type, value))
+        elif wire_type == FIXED32:
+            if pos + 4 > len(data):
+                break
+            value = data[pos : pos + 4]
+            pos += 4
+            fields.append(ProtoField(field_number, wire_type, value))
+        else:
+            # Unknown wire type, bail
+            break
+    return fields
+
+
+def fixed32_to_float(data: bytes) -> float:
+    """Convert 4 bytes (FIXED32) to IEEE 754 single-precision float."""
+    return struct.unpack("<f", data)[0]
+
+
+def float_to_fixed32(value: float) -> bytes:
+    """Convert a float to 4 bytes (FIXED32) IEEE 754."""
+    return struct.pack("<f", value)
+
+
+def get_field(fields: list[ProtoField], number: int) -> ProtoField | None:
+    """Get the first field with the given number."""
+    for f in fields:
+        if f.field_number == number:
+            return f
+    return None
+
+
+def get_fields(fields: list[ProtoField], number: int) -> list[ProtoField]:
+    """Get all fields with the given number (for repeated fields)."""
+    return [f for f in fields if f.field_number == number]
+
+
+def try_decode_string(data: bytes) -> str | None:
+    """Try to decode bytes as UTF-8 string."""
+    try:
+        return data.decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# State decoding — Message type 0 (full state)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SLDecodedState:
+    """Decoded S&L full state from message type 0."""
+
+    brightness: float | None = None
+    light_enabled: bool | None = None    # field 2 sub-1
+    color_r: float | None = None         # field 2 sub-2 (color param A)
+    color_g: float | None = None         # field 2 sub-3 (color param B)
+    volume: float | None = None          # field 3
+    current_track: str | None = None     # field 4 sub-2
+    sound_on: bool | None = None         # field 4 sub-1
+    power_on: bool | None = None         # field 5
+    available_tracks: list[str] | None = None
+    temperature_c: float | None = None
+    humidity_pct: float | None = None
+    timezone_rule: str | None = None
+
+
+def decode_full_state(data: bytes) -> SLDecodedState | None:
+    """Decode message type 0 — full device state.
+
+    Outer structure: field 1 { field 6 { ...state fields... } }
+    """
+    try:
+        outer = decode_fields(data)
+        f1 = get_field(outer, 1)
+        if f1 is None or f1.wire_type != LENGTH_DELIMITED:
+            return None
+
+        inner = decode_fields(f1.value)
+
+        # Check if this is a state message (has field 6 with state data)
+        f6 = get_field(inner, 6)
+        if f6 is None or f6.wire_type != LENGTH_DELIMITED:
+            return None
+
+        # Also check field 1 — if it's a varint == 2 or 3, it's a routine msg
+        f1_inner = get_field(inner, 1)
+        if f1_inner is not None and f1_inner.wire_type == VARINT:
+            msg_type = f1_inner.value
+            if msg_type in (2, 3):
+                return None  # This is a routines message
+
+        state_fields = decode_fields(f6.value)
+        result = SLDecodedState()
+
+        # Field 1: brightness (FIXED32 float)
+        f_brightness = get_field(state_fields, 1)
+        if f_brightness is not None and f_brightness.wire_type == FIXED32:
+            result.brightness = fixed32_to_float(f_brightness.value)
+
+        # Field 2: light config submessage { 1: light_enabled, 2: color_a, 3: color_b }
+        f_light = get_field(state_fields, 2)
+        if f_light is not None and f_light.wire_type == LENGTH_DELIMITED:
+            light_fields = decode_fields(f_light.value)
+            # Sub-1: light enabled flag (varint, INVERTED convention!)
+            # Device uses: absent or 0 = ON, 1 = OFF
+            # Original capture had no sub-1 and light was ON.
+            # User confirmed: sending sub-1=1 turns light OFF.
+            f_light_en = get_field(light_fields, 1)
+            if f_light_en is not None and f_light_en.wire_type == VARINT:
+                result.light_enabled = f_light_en.value == 0
+            else:
+                result.light_enabled = True  # absent means ON
+            # Sub-2: color param A (hue)
+            f_color_a = get_field(light_fields, 2)
+            if f_color_a is not None and f_color_a.wire_type == FIXED32:
+                result.color_r = fixed32_to_float(f_color_a.value)
+            # Sub-3: color param B (saturation)
+            f_color_b = get_field(light_fields, 3)
+            if f_color_b is not None and f_color_b.wire_type == FIXED32:
+                result.color_g = fixed32_to_float(f_color_b.value)
+
+        # Field 3: VOLUME (FIXED32 float, 0.0-1.0)
+        # Confirmed by user testing: setting color accidentally sent
+        # saturation as field 3, which changed the device volume.
+        f_vol = get_field(state_fields, 3)
+        if f_vol is not None and f_vol.wire_type == FIXED32:
+            result.volume = fixed32_to_float(f_vol.value)
+
+        # Field 4: sound config submessage { 1: sound_on, 2: track_name }
+        f_sound = get_field(state_fields, 4)
+        if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
+            sound_fields = decode_fields(f_sound.value)
+            # Sub-1: sound enabled flag (varint, INVERTED convention!)
+            # Device uses: absent or 0 = ON, 1 = OFF (same as light)
+            f_sound_en = get_field(sound_fields, 1)
+            if f_sound_en is not None and f_sound_en.wire_type == VARINT:
+                result.sound_on = f_sound_en.value == 0
+            else:
+                result.sound_on = True  # absent means ON
+            # Sub-2: track name
+            f_name = get_field(sound_fields, 2)
+            if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
+                result.current_track = try_decode_string(f_name.value)
+
+        # Field 5: power on/off (varint, 0 or 1)
+        # User confirmed: this is the device power switch, not sound on/off.
+        f_power = get_field(state_fields, 5)
+        if f_power is not None and f_power.wire_type == VARINT:
+            result.power_on = bool(f_power.value)
+
+        # Field 6: available sounds (submessage with repeated field 1 = strings)
+        f_sounds = get_field(state_fields, 6)
+        if f_sounds is not None and f_sounds.wire_type == LENGTH_DELIMITED:
+            sounds_fields = decode_fields(f_sounds.value)
+            tracks = []
+            for f in get_fields(sounds_fields, 1):
+                if f.wire_type == LENGTH_DELIMITED:
+                    name = try_decode_string(f.value)
+                    if name:
+                        tracks.append(name)
+            if tracks:
+                result.available_tracks = tracks
+
+        # Field 7: temperature (FIXED32 float)
+        f_temp = get_field(state_fields, 7)
+        if f_temp is not None and f_temp.wire_type == FIXED32:
+            result.temperature_c = fixed32_to_float(f_temp.value)
+
+        # Field 8: humidity (FIXED32 float)
+        f_hum = get_field(state_fields, 8)
+        if f_hum is not None and f_hum.wire_type == FIXED32:
+            result.humidity_pct = fixed32_to_float(f_hum.value)
+
+        # Field 11: timezone info
+        f_tz = get_field(state_fields, 11)
+        if f_tz is not None and f_tz.wire_type == LENGTH_DELIMITED:
+            tz_fields = decode_fields(f_tz.value)
+            f_tz_rule = get_field(tz_fields, 2)
+            if f_tz_rule is not None and f_tz_rule.wire_type == LENGTH_DELIMITED:
+                result.timezone_rule = try_decode_string(f_tz_rule.value)
+
+        return result
+
+    except Exception as err:
+        _LOGGER.debug("Failed to decode S&L full state: %s", err)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Sensor decoding — Message type 1
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SLDecodedSensors:
+    """Decoded S&L sensor readings from message type 1."""
+
+    temperature_c: float | None = None
+    humidity_pct: float | None = None
+
+
+def decode_sensors(data: bytes) -> SLDecodedSensors | None:
+    """Decode message type 1 — sensor data.
+
+    Structure: 1 { 1: varint, 10 { 1: {...}, 2: float(temp), 3: float(hum) } }
+    """
+    try:
+        outer = decode_fields(data)
+        f1 = get_field(outer, 1)
+        if f1 is None or f1.wire_type != LENGTH_DELIMITED:
+            return None
+
+        inner = decode_fields(f1.value)
+
+        # Look for field 10 (sensor submessage)
+        f10 = get_field(inner, 10)
+        if f10 is None or f10.wire_type != LENGTH_DELIMITED:
+            return None
+
+        sensor_fields = decode_fields(f10.value)
+        result = SLDecodedSensors()
+
+        # Field 2: temperature
+        f_temp = get_field(sensor_fields, 2)
+        if f_temp is not None and f_temp.wire_type == FIXED32:
+            result.temperature_c = fixed32_to_float(f_temp.value)
+
+        # Field 3: humidity
+        f_hum = get_field(sensor_fields, 3)
+        if f_hum is not None and f_hum.wire_type == FIXED32:
+            result.humidity_pct = fixed32_to_float(f_hum.value)
+
+        return result
+
+    except Exception as err:
+        _LOGGER.debug("Failed to decode S&L sensors: %s", err)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Routines decoding — Message types 2 and 3
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SLDecodedRoutine:
+    """A single decoded routine."""
+
+    name: str = ""
+    sound_name: str | None = None
+    volume: float | None = None
+    brightness: float | None = None
+
+
+def _decode_routine_entry(data: bytes) -> SLDecodedRoutine | None:
+    """Decode a single routine entry."""
+    try:
+        fields = decode_fields(data)
+        routine = SLDecodedRoutine()
+
+        # Field 2: routine name (string)
+        f_name = get_field(fields, 2)
+        if f_name is not None and f_name.wire_type == LENGTH_DELIMITED:
+            routine.name = try_decode_string(f_name.value) or ""
+
+        # Field 5: sound info (submessage with field 2 = sound name)
+        f_sound = get_field(fields, 5)
+        if f_sound is not None and f_sound.wire_type == LENGTH_DELIMITED:
+            sound_fields = decode_fields(f_sound.value)
+            f_sname = get_field(sound_fields, 2)
+            if f_sname is not None and f_sname.wire_type == LENGTH_DELIMITED:
+                routine.sound_name = try_decode_string(f_sname.value)
+
+        # Field 6: volume (FIXED32 float)
+        f_vol = get_field(fields, 6)
+        if f_vol is not None and f_vol.wire_type == FIXED32:
+            routine.volume = fixed32_to_float(f_vol.value)
+
+        # Field 4: brightness (FIXED32 float)
+        f_bright = get_field(fields, 4)
+        if f_bright is not None and f_bright.wire_type == FIXED32:
+            routine.brightness = fixed32_to_float(f_bright.value)
+
+        return routine if routine.name else None
+
+    except Exception:
+        return None
+
+
+def decode_routines(data: bytes) -> list[SLDecodedRoutine]:
+    """Decode routine messages (types 2 and 3).
+
+    Type 2: 1 { 1: 2, 6 { 9 { repeated 1 { routine } } } }
+    Type 3: 1 { 1: 3, 6 { 12 { repeated 1 { routine } } } }
+    """
+    routines: list[SLDecodedRoutine] = []
+    try:
+        outer = decode_fields(data)
+        f1 = get_field(outer, 1)
+        if f1 is None or f1.wire_type != LENGTH_DELIMITED:
+            return routines
+
+        inner = decode_fields(f1.value)
+
+        f6 = get_field(inner, 6)
+        if f6 is None or f6.wire_type != LENGTH_DELIMITED:
+            return routines
+
+        state_fields = decode_fields(f6.value)
+
+        # Try field 9 (type 2 routines) and field 12 (type 3 routines)
+        for container_field_num in (9, 12):
+            container_fields = get_fields(state_fields, container_field_num)
+            for cf in container_fields:
+                if cf.wire_type != LENGTH_DELIMITED:
+                    continue
+                # Each container has repeated field 1 entries
+                entry_fields = decode_fields(cf.value)
+                for ef in get_fields(entry_fields, 1):
+                    if ef.wire_type == LENGTH_DELIMITED:
+                        routine = _decode_routine_entry(ef.value)
+                        if routine is not None:
+                            routines.append(routine)
+
+    except Exception as err:
+        _LOGGER.debug("Failed to decode S&L routines: %s", err)
+
+    return routines
+
+
+# ---------------------------------------------------------------------------
+# Message classification
+# ---------------------------------------------------------------------------
+
+
+def classify_message(data: bytes) -> int | None:
+    """Classify a raw S&L protobuf message by its type indicator.
+
+    Returns:
+        0 = full state (no type field, has state data in 1.6)
+        1 = sensor data (has field 1.10)
+        2 = routine set A (type field = 2)
+        3 = routine set B (type field = 3)
+        None = unknown
+    """
+    try:
+        outer = decode_fields(data)
+        f1 = get_field(outer, 1)
+        if f1 is None or f1.wire_type != LENGTH_DELIMITED:
+            return None
+
+        inner = decode_fields(f1.value)
+
+        # Check for type indicator in field 1 (varint)
+        f1_inner = get_field(inner, 1)
+        if f1_inner is not None and f1_inner.wire_type == VARINT:
+            val = f1_inner.value
+            if val in (2, 3):
+                return val
+
+        # Check for sensor data (field 10)
+        f10 = get_field(inner, 10)
+        if f10 is not None:
+            return 1
+
+        # Check for state data (field 6)
+        f6 = get_field(inner, 6)
+        if f6 is not None:
+            return 0
+
+        return None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Command encoding — Round 18 (experimental)
+#
+# Strategy: mirror the state message structure with only the changed field.
+# The device sends: 1 { 6 { field: value } }
+# We try sending the same structure back with modifications.
+# ---------------------------------------------------------------------------
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def _encode_tag(field_number: int, wire_type: int) -> bytes:
+    """Encode a protobuf field tag."""
+    return _encode_varint((field_number << 3) | wire_type)
+
+
+def _encode_length_delimited(field_number: int, data: bytes) -> bytes:
+    """Encode a length-delimited field (field number + length + data)."""
+    return _encode_tag(field_number, LENGTH_DELIMITED) + _encode_varint(len(data)) + data
+
+
+def _encode_varint_field(field_number: int, value: int) -> bytes:
+    """Encode a varint field."""
+    return _encode_tag(field_number, VARINT) + _encode_varint(value)
+
+
+def _encode_fixed32_field(field_number: int, data: bytes) -> bytes:
+    """Encode a FIXED32 field."""
+    return _encode_tag(field_number, FIXED32) + data
+
+
+def build_sl_keepalive() -> bytes:
+    """Build a minimal keepalive message for the S&L device.
+
+    We send a minimal valid protobuf message. The actual keepalive format
+    may differ — this is our best guess and will be refined in testing.
+    """
+    # Try an empty message — just a valid protobuf wrapper
+    # field 1 { } — empty submessage
+    inner = b""
+    return _encode_length_delimited(1, inner)
+
+
+def build_power_cmd(on: bool) -> bytes:
+    """Build command to turn device power on/off.
+
+    Sends: 1 { 6 { 5: 0_or_1 } }
+
+    User confirmed: field 5 is the device power switch.
+    """
+    field_5 = _encode_varint_field(5, 1 if on else 0)
+    field_6 = _encode_length_delimited(6, field_5)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_light_enabled_cmd(
+    on: bool,
+    color_a: float | None = None,
+    color_b: float | None = None,
+) -> bytes:
+    """Build command to turn the night light on/off.
+
+    Sends: 1 { 6 { 2 { 1: varint, [2: color_a], [3: color_b] } } }
+
+    INVERTED convention: device uses 0 = ON, 1 = OFF.
+    Original capture had no sub-1 and light was ON. User confirmed
+    sending sub-1=1 turns light OFF.
+
+    Includes current color values to prevent the device from clearing
+    them when only the enabled flag is toggled.
+    """
+    # Invert: on=True → send 0, on=False → send 1
+    sub_1 = _encode_varint_field(1, 0 if on else 1)
+    # Include current color values to preserve them
+    color_fields = b""
+    if color_a is not None:
+        color_fields += _encode_fixed32_field(2, float_to_fixed32(color_a))
+    if color_b is not None:
+        color_fields += _encode_fixed32_field(3, float_to_fixed32(color_b))
+    field_2 = _encode_length_delimited(2, sub_1 + color_fields)
+    field_6 = _encode_length_delimited(6, field_2)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_sound_on_cmd(on: bool, current_track: str | None = None) -> bytes:
+    """Build command to turn sound on/off.
+
+    Sends: 1 { 6 { 4 { 1: varint, [2: track_name] } } }
+
+    INVERTED convention: device uses 0 = ON, 1 = OFF (same as light).
+    User confirmed sending sub-1=1 turns sound OFF and wipes track to
+    "No Sound".
+
+    Includes current track name to prevent the device from clearing it
+    when only the enabled flag is toggled.
+    """
+    # Invert: on=True → send 0, on=False → send 1
+    sub_1 = _encode_varint_field(1, 0 if on else 1)
+    # Include current track to preserve it
+    track_field = b""
+    if current_track:
+        track_bytes = current_track.encode("utf-8")
+        track_field = _encode_length_delimited(2, track_bytes)
+    field_4 = _encode_length_delimited(4, sub_1 + track_field)
+    field_6 = _encode_length_delimited(6, field_4)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_volume_cmd(volume: float) -> bytes:
+    """Build command to set volume (0.0-1.0).
+
+    Sends: 1 { 6 { 3: float(volume) } }
+
+    State field 3 was confirmed as the volume field by user testing:
+    setting color accidentally sent saturation as field 3, which changed
+    the device volume (orange S=0.945 → volume ~95%).
+
+    Original capture had field 3 = 0.6058 ≈ 61% volume, which is plausible.
+    """
+    vol_bytes = float_to_fixed32(volume)
+    field_3 = _encode_fixed32_field(3, vol_bytes)
+    field_6 = _encode_length_delimited(6, field_3)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_track_cmd(track_name: str, sound_on: bool | None = None) -> bytes:
+    """Build command to change sound track.
+
+    Sends: 1 { 6 { 4 { [1: enabled], 2: "track_name" } } }
+
+    Includes sound_on flag to preserve it (inverted convention).
+    """
+    enabled_field = b""
+    if sound_on is not None:
+        enabled_field = _encode_varint_field(1, 0 if sound_on else 1)
+    track_bytes = track_name.encode("utf-8")
+    field_2 = _encode_length_delimited(2, track_bytes)
+    field_4 = _encode_length_delimited(4, enabled_field + field_2)
+    field_6 = _encode_length_delimited(6, field_4)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_brightness_cmd(brightness: float) -> bytes:
+    """Build command to set brightness (0.0-1.0).
+
+    Mirrors: 1 { 6 { 1: float_value } }
+    """
+    bright_bytes = float_to_fixed32(brightness)
+    field_1 = _encode_fixed32_field(1, bright_bytes)
+    field_6 = _encode_length_delimited(6, field_1)
+    return _encode_length_delimited(1, field_6)
+
+
+def build_color_cmd(
+    color_a: float,
+    color_b: float,
+    light_enabled: bool | None = None,
+) -> bytes:
+    """Build command to set light color (experimental).
+
+    Sends: 1 { 6 { 2 { [1: enabled], 2: float(color_a), 3: float(color_b) } } }
+
+    State field 2 is a submessage with sub-fields 2 and 3 (both floats).
+    Includes the light_enabled flag (sub-1) to prevent accidentally
+    toggling the light when only changing color.
+    """
+    # Include light enabled flag to preserve state (inverted convention)
+    enabled_field = b""
+    if light_enabled is not None:
+        enabled_field = _encode_varint_field(1, 0 if light_enabled else 1)
+    sub_2 = _encode_fixed32_field(2, float_to_fixed32(color_a))
+    sub_3 = _encode_fixed32_field(3, float_to_fixed32(color_b))
+    field_2 = _encode_length_delimited(2, enabled_field + sub_2 + sub_3)
+    field_6 = _encode_length_delimited(6, field_2)
+    return _encode_length_delimited(1, field_6)

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -10,8 +10,8 @@ from collections.abc import Callable
 
 import aiohttp
 
-from aionanit.auth import TokenManager
 from aionanit import NanitConnectionError
+from aionanit.auth import TokenManager
 from aionanit.rest import NanitRestClient
 
 from .exceptions import NanitTransportError
@@ -22,7 +22,6 @@ from .models import (
     SoundLightRoutine,
 )
 from .sl_protocol import (
-    SLDecodedRoutine,
     SLDecodedState,
     build_brightness_cmd,
     build_color_cmd,
@@ -141,9 +140,7 @@ class NanitSoundLight:
     # Subscription
     # ------------------------------------------------------------------
 
-    def subscribe(
-        self, callback: Callable[[SoundLightEvent], None]
-    ) -> Callable[[], None]:
+    def subscribe(self, callback: Callable[[SoundLightEvent], None]) -> Callable[[], None]:
         """Subscribe to S&L events. Returns an unsubscribe callable."""
         self._subscribers.append(callback)
 
@@ -159,7 +156,7 @@ class NanitSoundLight:
         for cb in self._subscribers:
             try:
                 cb(event)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.exception("Error in S&L event subscriber")
 
     # ------------------------------------------------------------------
@@ -190,9 +187,7 @@ class NanitSoundLight:
                 "S&L %s initial connection failed; will retry in background",
                 self._speaker_uid,
             )
-            self._reconnect_task = asyncio.get_running_loop().create_task(
-                self._reconnect_loop()
-            )
+            self._reconnect_task = asyncio.get_running_loop().create_task(self._reconnect_loop())
 
     async def async_stop(self) -> None:
         """Stop the S&L connection gracefully."""
@@ -286,9 +281,7 @@ class NanitSoundLight:
         """
         cmd = build_color_cmd(color_a, color_b, light_enabled=self._state.light_enabled)
         await self._async_send(cmd)
-        self._state = dataclasses.replace(
-            self._state, color_r=color_a, color_g=color_b
-        )
+        self._state = dataclasses.replace(self._state, color_r=color_a, color_g=color_b)
         self._fire_event(SoundLightEventKind.STATE_UPDATE)
 
     # ------------------------------------------------------------------
@@ -311,7 +304,7 @@ class NanitSoundLight:
             self._device_token = await self._rest.async_get_device_token(
                 access_token, self._speaker_uid
             )
-        except AttributeError:
+        except AttributeError as err:
             # Inline implementation matching the NanitLite app's exact request
             headers = {
                 "accept": "application/json",
@@ -328,18 +321,19 @@ class NanitSoundLight:
             ) as resp:
                 if resp.status == 401:
                     from aionanit import NanitAuthError
-                    raise NanitAuthError("Access token invalid for udtokens")
+
+                    raise NanitAuthError("Access token invalid for udtokens") from err
                 if resp.status != 200:
                     err_body = await resp.text()
                     raise NanitConnectionError(
                         f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {err_body[:200]}"
-                    )
+                    ) from err
                 body = await resp.json(content_type=None)
                 token = body.get("user_device_token", {}).get("token")
                 if not token:
                     raise NanitConnectionError(
                         f"No token in udtokens response for speaker {self._speaker_uid}"
-                    )
+                    ) from err
                 self._device_token = token
 
         _LOGGER.debug(
@@ -358,7 +352,7 @@ class NanitSoundLight:
                 try:
                     await self._async_fetch_device_token()
                     _LOGGER.debug("S&L device token refreshed")
-                except Exception as err:  # noqa: BLE001
+                except Exception as err:
                     _LOGGER.warning("S&L device token refresh failed: %s", err)
         except asyncio.CancelledError:
             return
@@ -378,6 +372,7 @@ class NanitSoundLight:
             silent: If True, suppress CONNECTION_CHANGE events during the
                     disconnect/reconnect cycle.  Used by the poll loop to
                     avoid briefly marking entities as unavailable.
+
         """
         async with self._connect_lock:
             await self._async_close_ws()
@@ -441,9 +436,7 @@ class NanitSoundLight:
                         "Authorization": f"Bearer {access_token}",
                         "User-Agent": "NanitLite/1.8.0",
                     }
-                    _LOGGER.debug(
-                        "Connecting S&L %s via cloud relay", self._speaker_uid
-                    )
+                    _LOGGER.debug("Connecting S&L %s via cloud relay", self._speaker_uid)
                     self._ws = await self._session.ws_connect(
                         url,
                         headers=headers,
@@ -472,9 +465,7 @@ class NanitSoundLight:
 
             # Start token refresh task if not already running
             if self._token_refresh_task is None or self._token_refresh_task.done():
-                self._token_refresh_task = loop.create_task(
-                    self._token_refresh_loop()
-                )
+                self._token_refresh_task = loop.create_task(self._token_refresh_loop())
 
             # (Re)start poll task — cancel stale one first
             if self._poll_task is not None and not self._poll_task.done():
@@ -541,33 +532,45 @@ class NanitSoundLight:
                     break
         except asyncio.CancelledError:
             return
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             _LOGGER.error("S&L recv loop error: %s", err)
 
         # Auto-reconnect if not explicitly stopped
         self._connected = False
         self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
         if not self._stopped:
-            self._reconnect_task = asyncio.get_running_loop().create_task(
-                self._reconnect_loop()
-            )
+            self._reconnect_task = asyncio.get_running_loop().create_task(self._reconnect_loop())
 
     def _apply_state(self, decoded: SLDecodedState) -> None:
         """Merge a decoded state into the current state and fire event."""
         self._state = dataclasses.replace(
             self._state,
-            brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
-            light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
+            brightness=decoded.brightness
+            if decoded.brightness is not None
+            else self._state.brightness,
+            light_enabled=decoded.light_enabled
+            if decoded.light_enabled is not None
+            else self._state.light_enabled,
             color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
             color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
             volume=decoded.volume if decoded.volume is not None else self._state.volume,
-            current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
+            current_track=decoded.current_track
+            if decoded.current_track is not None
+            else self._state.current_track,
             sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
             power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
-            available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
-            temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
-            humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
-            timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
+            available_tracks=tuple(decoded.available_tracks)
+            if decoded.available_tracks
+            else self._state.available_tracks,
+            temperature_c=decoded.temperature_c
+            if decoded.temperature_c is not None
+            else self._state.temperature_c,
+            humidity_pct=decoded.humidity_pct
+            if decoded.humidity_pct is not None
+            else self._state.humidity_pct,
+            timezone_rule=decoded.timezone_rule
+            if decoded.timezone_rule is not None
+            else self._state.timezone_rule,
         )
         self._fire_event(SoundLightEventKind.STATE_UPDATE)
         _LOGGER.debug(
@@ -619,8 +622,12 @@ class NanitSoundLight:
             if decoded_sensors is not None:
                 self._state = dataclasses.replace(
                     self._state,
-                    temperature_c=decoded_sensors.temperature_c if decoded_sensors.temperature_c is not None else self._state.temperature_c,
-                    humidity_pct=decoded_sensors.humidity_pct if decoded_sensors.humidity_pct is not None else self._state.humidity_pct,
+                    temperature_c=decoded_sensors.temperature_c
+                    if decoded_sensors.temperature_c is not None
+                    else self._state.temperature_c,
+                    humidity_pct=decoded_sensors.humidity_pct
+                    if decoded_sensors.humidity_pct is not None
+                    else self._state.humidity_pct,
                 )
                 self._fire_event(SoundLightEventKind.SENSOR_UPDATE)
 
@@ -675,7 +682,7 @@ class NanitSoundLight:
                 _LOGGER.debug("S&L poll: reconnecting to refresh state")
                 try:
                     await self._async_connect(silent=True)
-                except Exception as err:  # noqa: BLE001
+                except Exception as err:
                     _LOGGER.debug("S&L poll reconnect failed: %s", err)
         except asyncio.CancelledError:
             return
@@ -705,13 +712,13 @@ class NanitSoundLight:
                 # Refresh device token before reconnecting
                 try:
                     await self._async_fetch_device_token()
-                except Exception:  # noqa: BLE001
+                except Exception:
                     _LOGGER.debug("Token refresh failed during reconnect, using cached")
 
                 await self._async_connect()
                 _LOGGER.info("S&L reconnected successfully")
                 return
-            except Exception as err:  # noqa: BLE001
+            except Exception as err:
                 _LOGGER.warning("S&L reconnect failed: %s", err)
                 self._connected = False
                 self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -7,7 +7,6 @@ import dataclasses
 import logging
 import ssl
 from collections.abc import Callable
-from typing import Any
 
 import aiohttp
 
@@ -28,19 +27,21 @@ from .sl_protocol import (
     build_color_cmd,
     build_light_enabled_cmd,
     build_power_cmd,
-    build_sl_keepalive,
     build_sound_on_cmd,
     build_track_cmd,
     build_volume_cmd,
     classify_message,
+    decode_cloud_relay,
     decode_full_state,
     decode_routines,
     decode_sensors,
+    is_cloud_relay_ack,
+    is_cloud_relay_error,
+    is_cloud_relay_forbidden,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-_KEEPALIVE_INTERVAL: float = 25.0
 _HEARTBEAT_INTERVAL: float = 60.0
 _HANDSHAKE_TIMEOUT: float = 15.0
 _INITIAL_BACKOFF: float = 1.85
@@ -65,19 +66,22 @@ class NanitSoundLight:
     Receives push state updates (protobuf) and provides command methods.
     """
 
-    # TODO: com6056's reference implementation uses a cloud relay at
-    # wss://remote.nanit.com/speakers/{uid}/user_connect/ with Bearer token
-    # instead of a direct local WebSocket. This would eliminate the need for
-    # a speaker IP and significantly improve UX. Not implemented yet — it's
-    # a different connection model that needs its own design.
+    # Connection strategy:
+    # - When a speaker IP is configured: prefer local WebSocket (wss://{ip}:442)
+    #   which provides full state on connect + temperature/humidity data.
+    #   Falls back to cloud relay if local connection fails.
+    # - When no IP is configured: use cloud relay
+    #   (wss://remote.nanit.com/speakers/{uid}/user_connect/) with Bearer token.
+    #   Cloud relay doesn't send initial state on connect, so we restore
+    #   the last known state from HA Store on startup.
 
     def __init__(
         self,
         speaker_uid: str,
-        device_ip: str,
         token_manager: TokenManager,
         rest_client: NanitRestClient,
         session: aiohttp.ClientSession,
+        device_ip: str | None = None,
     ) -> None:
         self._speaker_uid = speaker_uid
         self._device_ip = device_ip
@@ -90,14 +94,17 @@ class NanitSoundLight:
         self._connected: bool = False
         self._stopped: bool = False
         self._device_token: str | None = None
+        # Prefer local WebSocket when IP is configured (sends full state on
+        # connect, includes temp/humidity).  Fall back to cloud relay otherwise.
+        self._use_cloud_relay: bool = device_ip is None
 
         # WebSocket state
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._recv_task: asyncio.Task[None] | None = None
-        self._keepalive_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
         self._poll_task: asyncio.Task[None] | None = None
         self._token_refresh_task: asyncio.Task[None] | None = None
-        self._ssl_ctx: ssl.SSLContext | None = None
+        self._local_ssl_ctx: ssl.SSLContext | None = None
         self._connect_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
@@ -115,6 +122,19 @@ class NanitSoundLight:
     @property
     def connected(self) -> bool:
         return self._connected
+
+    def restore_state(self, state: SoundLightFullState) -> None:
+        """Restore persisted state (used by coordinator on startup)."""
+        self._state = state
+
+    @property
+    def connection_mode(self) -> str:
+        """Return the current connection mode: 'local', 'cloud', or 'unavailable'."""
+        if not self._connected:
+            return "unavailable"
+        if self._use_cloud_relay:
+            return "cloud"
+        return "local"
 
     # ------------------------------------------------------------------
     # Subscription
@@ -148,20 +168,37 @@ class NanitSoundLight:
     async def async_start(self) -> None:
         """Start the S&L connection.
 
-        1. Fetch device token from cloud API
-        2. Connect WebSocket to local device
-        3. Start recv loop, keepalive, and token refresh tasks
+        When a local IP is configured, connects via local WebSocket first
+        (wss://{ip}:442) — this provides full state on connect and includes
+        temperature/humidity data.  Falls back to cloud relay if local fails.
+
+        When no IP is configured, connects via cloud relay
+        (wss://remote.nanit.com) directly.
+
+        If the initial connection fails, a background reconnect loop is
+        started so the coordinator can still set up entities (they will
+        show as unavailable until the connection succeeds).
         """
         self._stopped = False
-        await self._async_fetch_device_token()
-        await self._async_connect()
+        # Reset preference based on whether IP is available
+        self._use_cloud_relay = self._device_ip is None
+        try:
+            await self._async_connect()
+        except (NanitTransportError, NanitConnectionError):
+            _LOGGER.warning(
+                "S&L %s initial connection failed; will retry in background",
+                self._speaker_uid,
+            )
+            self._reconnect_task = asyncio.get_running_loop().create_task(
+                self._reconnect_loop()
+            )
 
     async def async_stop(self) -> None:
         """Stop the S&L connection gracefully."""
         self._stopped = True
         await self._async_close_ws()
 
-        for task_attr in ("_poll_task", "_token_refresh_task"):
+        for task_attr in ("_reconnect_task", "_poll_task", "_token_refresh_task"):
             task = getattr(self, task_attr, None)
             if task is not None and not task.done():
                 task.cancel()
@@ -258,11 +295,52 @@ class NanitSoundLight:
     # ------------------------------------------------------------------
 
     async def _async_fetch_device_token(self) -> None:
-        """Fetch the RS256 device token from /speakers/{uid}/udtokens."""
+        """Fetch the RS256 device token via GET /speakers/{uid}/udtokens.
+
+        The NanitLite app uses specific headers for this endpoint.
+        Returns a short-lived RS256 JWT used to authenticate the local
+        WebSocket connection (wss://{ip}:442/).
+
+        Uses the rest client's method if available, otherwise makes the
+        API call directly (the installed aionanit package may not have it).
+        """
         access_token = await self._token_manager.async_get_access_token()
-        self._device_token = await self._rest.async_get_device_token(
-            access_token, self._speaker_uid
-        )
+
+        try:
+            self._device_token = await self._rest.async_get_device_token(
+                access_token, self._speaker_uid
+            )
+        except AttributeError:
+            # Inline implementation matching the NanitLite app's exact request
+            headers = {
+                "accept": "application/json",
+                "authorization": f"token {access_token}",
+                "accept-charset": "UTF-8",
+                "x-nanit-platform": "homeassistant",
+                "user-agent": "NanitLite/1.8.0 (com.udisense.nanitlite; build:168; homeassistant)",
+                "x-nanit-service": "1.8.0 (168)",
+            }
+            async with self._session.get(
+                f"{self._rest.base_url}/speakers/{self._speaker_uid}/udtokens",
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status == 401:
+                    from aionanit import NanitAuthError
+                    raise NanitAuthError("Access token invalid for udtokens")
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise NanitConnectionError(
+                        f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {body[:200]}"
+                    )
+                body = await resp.json(content_type=None)
+                token = body.get("user_device_token", {}).get("token")
+                if not token:
+                    raise NanitConnectionError(
+                        f"No token in udtokens response for speaker {self._speaker_uid}"
+                    )
+                self._device_token = token
+
         _LOGGER.debug(
             "Fetched device token for speaker %s (len=%d)",
             self._speaker_uid,
@@ -289,7 +367,11 @@ class NanitSoundLight:
     # ------------------------------------------------------------------
 
     async def _async_connect(self, *, silent: bool = False) -> None:
-        """Connect WebSocket to the local S&L device.
+        """Connect WebSocket to the S&L device.
+
+        Connection order depends on ``_use_cloud_relay``:
+        - False (IP configured): try local first, fall back to cloud relay.
+        - True  (no IP):         try cloud relay first, fall back to local.
 
         Args:
             silent: If True, suppress CONNECTION_CHANGE events during the
@@ -299,41 +381,93 @@ class NanitSoundLight:
         async with self._connect_lock:
             await self._async_close_ws()
 
-            if not self._device_token:
-                raise NanitConnectionError("No device token available")
-
-            if self._ssl_ctx is None:
-                self._ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-                self._ssl_ctx.check_hostname = False
-                self._ssl_ctx.verify_mode = ssl.CERT_NONE
-
-            url = f"wss://{self._device_ip}:442/"
-            headers = {
-                "Authorization": f"token {self._device_token}",
-                "User-Agent": "NanitLite/1.8.0",
-            }
+            # Local connections use self-signed certs → CERT_NONE.
+            # Cloud relay (remote.nanit.com) uses default TLS verification (ssl=None).
+            if self._local_ssl_ctx is None:
+                self._local_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                self._local_ssl_ctx.check_hostname = False
+                self._local_ssl_ctx.verify_mode = ssl.CERT_NONE
 
             if not silent:
                 self._connected = False
                 self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
 
-            try:
-                self._ws = await self._session.ws_connect(
-                    url,
-                    headers=headers,
-                    heartbeat=_HEARTBEAT_INTERVAL,
-                    timeout=_HANDSHAKE_TIMEOUT,
-                    ssl=self._ssl_ctx,
-                )
-            except Exception as err:
+            # ----- attempt local WebSocket first when preferred -----
+            if not self._use_cloud_relay and self._device_ip:
+                if not self._device_token:
+                    try:
+                        await self._async_fetch_device_token()
+                    except Exception as err:
+                        _LOGGER.debug(
+                            "Device token fetch failed for S&L %s: %s",
+                            self._speaker_uid,
+                            err,
+                        )
+
+                if self._device_token:
+                    url = f"wss://{self._device_ip}:442/"
+                    headers = {
+                        "Authorization": f"token {self._device_token}",
+                        "User-Agent": "NanitLite/1.8.0",
+                    }
+                    _LOGGER.debug(
+                        "Connecting S&L %s via local WebSocket at %s",
+                        self._speaker_uid,
+                        self._device_ip,
+                    )
+                    try:
+                        self._ws = await self._session.ws_connect(
+                            url,
+                            headers=headers,
+                            heartbeat=_HEARTBEAT_INTERVAL,
+                            timeout=_HANDSHAKE_TIMEOUT,
+                            ssl=self._local_ssl_ctx,
+                        )
+                    except Exception as err:
+                        _LOGGER.debug(
+                            "Local WebSocket failed for S&L %s: %s; trying cloud relay",
+                            self._speaker_uid,
+                            err,
+                        )
+                        self._ws = None
+
+            # ----- cloud relay (primary when no IP, fallback when local failed) -----
+            if self._ws is None:
+                try:
+                    access_token = await self._token_manager.async_get_access_token()
+                    url = f"wss://remote.nanit.com/speakers/{self._speaker_uid}/user_connect/"
+                    headers = {
+                        "Authorization": f"Bearer {access_token}",
+                        "User-Agent": "NanitLite/1.8.0",
+                    }
+                    _LOGGER.debug(
+                        "Connecting S&L %s via cloud relay", self._speaker_uid
+                    )
+                    self._ws = await self._session.ws_connect(
+                        url,
+                        headers=headers,
+                        heartbeat=_HEARTBEAT_INTERVAL,
+                        timeout=_HANDSHAKE_TIMEOUT,
+                        # Cloud relay uses default TLS verification (no ssl= override)
+                    )
+                    # Track that we ended up on cloud relay (affects poll strategy)
+                    self._use_cloud_relay = True
+                except Exception as err:
+                    _LOGGER.warning(
+                        "Cloud relay failed for S&L %s: %s",
+                        self._speaker_uid,
+                        err,
+                    )
+                    self._ws = None
+
+            if self._ws is None:
                 raise NanitConnectionError(
-                    f"S&L WebSocket connect failed: {err}"
-                ) from err
+                    f"S&L {self._speaker_uid}: all connection methods failed"
+                )
 
             self._connected = True
             loop = asyncio.get_running_loop()
             self._recv_task = loop.create_task(self._recv_loop())
-            self._keepalive_task = loop.create_task(self._keepalive_loop())
 
             # Start token refresh task if not already running
             if self._token_refresh_task is None or self._token_refresh_task.done():
@@ -351,23 +485,24 @@ class NanitSoundLight:
             self._poll_task = loop.create_task(self._poll_loop())
 
             self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+
             _LOGGER.info(
-                "S&L device %s connected at %s:442",
+                "S&L device %s connected via %s",
                 self._speaker_uid,
-                self._device_ip,
+                "cloud relay" if self._use_cloud_relay else f"local ({self._device_ip}:442)",
             )
 
     async def _async_close_ws(self) -> None:
-        """Close WebSocket and cancel recv/keepalive tasks."""
-        for task in (self._recv_task, self._keepalive_task):
+        """Close WebSocket and cancel recv/reconnect tasks."""
+        for task_attr in ("_recv_task", "_reconnect_task"):
+            task = getattr(self, task_attr, None)
             if task is not None and not task.done():
                 task.cancel()
                 try:
                     await task
                 except asyncio.CancelledError:
                     pass
-        self._recv_task = None
-        self._keepalive_task = None
+            setattr(self, task_attr, None)
 
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
@@ -412,46 +547,73 @@ class NanitSoundLight:
         self._connected = False
         self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
         if not self._stopped:
-            asyncio.get_running_loop().create_task(self._reconnect_loop())
+            self._reconnect_task = asyncio.get_running_loop().create_task(
+                self._reconnect_loop()
+            )
+
+    def _apply_state(self, decoded: SLDecodedState) -> None:
+        """Merge a decoded state into the current state and fire event."""
+        self._state = dataclasses.replace(
+            self._state,
+            brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
+            light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
+            color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
+            color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
+            volume=decoded.volume if decoded.volume is not None else self._state.volume,
+            current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
+            sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
+            power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
+            available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
+            temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
+            humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
+            timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
+        )
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+        _LOGGER.debug(
+            "S&L state: brightness=%.2f volume=%.2f track=%s power=%s light=%s sound=%s temp=%.1f hum=%.1f",
+            self._state.brightness or 0,
+            self._state.volume or 0,
+            self._state.current_track,
+            self._state.power_on,
+            self._state.light_enabled,
+            self._state.sound_on,
+            self._state.temperature_c or 0,
+            self._state.humidity_pct or 0,
+        )
 
     def _on_message(self, data: bytes) -> None:
-        """Handle a raw binary protobuf message from the S&L device."""
+        """Handle a raw binary protobuf message from the S&L device.
+
+        Supports both local WebSocket framing (field 1 envelope) and
+        cloud relay framing (field 2 envelope with HTTP status).
+        """
+        # Try cloud relay decoding first (field 2 envelope with status 200)
+        cloud_state = decode_cloud_relay(data)
+        if cloud_state is not None:
+            self._apply_state(cloud_state)
+            return
+
+        # Silently ignore cloud relay 403 Forbidden (periodic noise)
+        if is_cloud_relay_forbidden(data):
+            return
+
+        # Silently ignore other error responses (e.g. 400 "Failed to parse request")
+        if is_cloud_relay_error(data):
+            return
+
+        # Silently ignore cloud relay command acknowledgments (field 3 envelope)
+        if is_cloud_relay_ack(data):
+            return
+
+        # Try local protocol decoding
         msg_type = classify_message(data)
 
         if msg_type == 0:
-            # Full state update
             decoded = decode_full_state(data)
             if decoded is not None:
-                self._state = dataclasses.replace(
-                    self._state,
-                    brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
-                    light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
-                    color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
-                    color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
-                    volume=decoded.volume if decoded.volume is not None else self._state.volume,
-                    current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
-                    sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
-                    power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
-                    available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
-                    temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
-                    humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
-                    timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
-                )
-                self._fire_event(SoundLightEventKind.STATE_UPDATE)
-                _LOGGER.debug(
-                    "S&L state: brightness=%.2f volume=%.2f track=%s power=%s light=%s sound=%s temp=%.1f hum=%.1f",
-                    self._state.brightness or 0,
-                    self._state.volume or 0,
-                    self._state.current_track,
-                    self._state.power_on,
-                    self._state.light_enabled,
-                    self._state.sound_on,
-                    self._state.temperature_c or 0,
-                    self._state.humidity_pct or 0,
-                )
+                self._apply_state(decoded)
 
         elif msg_type == 1:
-            # Sensor update
             decoded_sensors = decode_sensors(data)
             if decoded_sensors is not None:
                 self._state = dataclasses.replace(
@@ -462,7 +624,6 @@ class NanitSoundLight:
                 self._fire_event(SoundLightEventKind.SENSOR_UPDATE)
 
         elif msg_type in (2, 3):
-            # Routines update
             decoded_routines = decode_routines(data)
             if decoded_routines:
                 new_routines = tuple(
@@ -474,7 +635,6 @@ class NanitSoundLight:
                     )
                     for r in decoded_routines
                 )
-                # Merge with existing routines (type 2 and 3 are different sets)
                 existing = {r.name: r for r in self._state.routines}
                 for r in new_routines:
                     existing[r.name] = r
@@ -484,6 +644,10 @@ class NanitSoundLight:
                 )
                 self._fire_event(SoundLightEventKind.ROUTINES_UPDATE)
 
+        elif msg_type == -1:
+            # Network info / device metadata — safe to ignore
+            pass
+
         else:
             _LOGGER.debug(
                 "S&L unknown message type (len=%d): %s",
@@ -492,31 +656,15 @@ class NanitSoundLight:
             )
 
     # ------------------------------------------------------------------
-    # Internal — keepalive and reconnect
+    # Internal — poll and reconnect
     # ------------------------------------------------------------------
-
-    async def _keepalive_loop(self) -> None:
-        """Send keepalive messages periodically."""
-        try:
-            while True:
-                await asyncio.sleep(_KEEPALIVE_INTERVAL)
-                if self._ws is None or self._ws.closed:
-                    break
-                try:
-                    await self._async_send(build_sl_keepalive())
-                except NanitTransportError:
-                    _LOGGER.warning("S&L keepalive failed, triggering reconnect")
-                    break
-        except asyncio.CancelledError:
-            return
 
     async def _poll_loop(self) -> None:
         """Periodically reconnect to refresh state from the device.
 
-        The S&L device sends a full state dump on each WebSocket connect.
-        By reconnecting every _POLL_INTERVAL seconds we pick up any changes
-        made via the Nanit app (which communicates through the cloud, not
-        the local WebSocket).
+        The local WebSocket sends a full state dump on each connect.
+        For cloud relay, state is pushed on changes and restored from
+        disk on startup — reconnecting keeps the connection healthy.
         """
         try:
             while not self._stopped:

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -23,6 +23,7 @@ from .models import (
 )
 from .sl_protocol import (
     SLDecodedRoutine,
+    SLDecodedState,
     build_brightness_cmd,
     build_color_cmd,
     build_light_enabled_cmd,
@@ -329,9 +330,9 @@ class NanitSoundLight:
                     from aionanit import NanitAuthError
                     raise NanitAuthError("Access token invalid for udtokens")
                 if resp.status != 200:
-                    body = await resp.text()
+                    err_body = await resp.text()
                     raise NanitConnectionError(
-                        f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {body[:200]}"
+                        f"HTTP {resp.status} fetching udtokens for {self._speaker_uid}: {err_body[:200]}"
                     )
                 body = await resp.json(content_type=None)
                 token = body.get("user_device_token", {}).get("token")
@@ -344,7 +345,7 @@ class NanitSoundLight:
         _LOGGER.debug(
             "Fetched device token for speaker %s (len=%d)",
             self._speaker_uid,
-            len(self._device_token),
+            len(self._device_token or ""),
         )
 
     async def _token_refresh_loop(self) -> None:
@@ -420,7 +421,7 @@ class NanitSoundLight:
                             url,
                             headers=headers,
                             heartbeat=_HEARTBEAT_INTERVAL,
-                            timeout=_HANDSHAKE_TIMEOUT,
+                            timeout=aiohttp.ClientWSTimeout(ws_close=_HANDSHAKE_TIMEOUT),
                             ssl=self._local_ssl_ctx,
                         )
                     except Exception as err:
@@ -447,7 +448,7 @@ class NanitSoundLight:
                         url,
                         headers=headers,
                         heartbeat=_HEARTBEAT_INTERVAL,
-                        timeout=_HANDSHAKE_TIMEOUT,
+                        timeout=aiohttp.ClientWSTimeout(ws_close=_HANDSHAKE_TIMEOUT),
                         # Cloud relay uses default TLS verification (no ssl= override)
                     )
                     # Track that we ended up on cloud relay (affects poll strategy)

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -1,0 +1,569 @@
+"""High-level API for the Nanit Sound & Light Machine."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+import ssl
+from collections.abc import Callable
+from typing import Any
+
+import aiohttp
+
+from aionanit.auth import TokenManager
+from aionanit import NanitConnectionError
+from aionanit.rest import NanitRestClient
+
+from .exceptions import NanitTransportError
+from .models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+    SoundLightRoutine,
+)
+from .sl_protocol import (
+    SLDecodedRoutine,
+    build_brightness_cmd,
+    build_color_cmd,
+    build_light_enabled_cmd,
+    build_power_cmd,
+    build_sl_keepalive,
+    build_sound_on_cmd,
+    build_track_cmd,
+    build_volume_cmd,
+    classify_message,
+    decode_full_state,
+    decode_routines,
+    decode_sensors,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_KEEPALIVE_INTERVAL: float = 25.0
+_HEARTBEAT_INTERVAL: float = 60.0
+_HANDSHAKE_TIMEOUT: float = 15.0
+_INITIAL_BACKOFF: float = 1.85
+_BACKOFF_FACTOR: float = 1.618
+_MAX_BACKOFF: float = 60.0
+_JITTER_MAX: float = 1.0
+
+# Periodic re-poll: reconnect to get fresh state from device.
+# The device sends full state on connect, so a reconnect is effectively a poll.
+_POLL_INTERVAL: float = 300.0  # seconds between state re-polls (5 minutes)
+
+# Device token refresh: re-fetch every 6 hours (tokens last ~1 week)
+_TOKEN_REFRESH_INTERVAL: float = 6 * 3600
+
+
+class NanitSoundLight:
+    """High-level API for a single Nanit Sound & Light Machine.
+
+    Connects via local WebSocket (wss://{ip}:442) using a device token
+    obtained from the cloud API (/speakers/{uid}/udtokens).
+
+    Receives push state updates (protobuf) and provides command methods.
+    """
+
+    # TODO: com6056's reference implementation uses a cloud relay at
+    # wss://remote.nanit.com/speakers/{uid}/user_connect/ with Bearer token
+    # instead of a direct local WebSocket. This would eliminate the need for
+    # a speaker IP and significantly improve UX. Not implemented yet — it's
+    # a different connection model that needs its own design.
+
+    def __init__(
+        self,
+        speaker_uid: str,
+        device_ip: str,
+        token_manager: TokenManager,
+        rest_client: NanitRestClient,
+        session: aiohttp.ClientSession,
+    ) -> None:
+        self._speaker_uid = speaker_uid
+        self._device_ip = device_ip
+        self._token_manager = token_manager
+        self._rest = rest_client
+        self._session = session
+
+        self._state = SoundLightFullState()
+        self._subscribers: list[Callable[[SoundLightEvent], None]] = []
+        self._connected: bool = False
+        self._stopped: bool = False
+        self._device_token: str | None = None
+
+        # WebSocket state
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._recv_task: asyncio.Task[None] | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
+        self._poll_task: asyncio.Task[None] | None = None
+        self._token_refresh_task: asyncio.Task[None] | None = None
+        self._ssl_ctx: ssl.SSLContext | None = None
+        self._connect_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def speaker_uid(self) -> str:
+        return self._speaker_uid
+
+    @property
+    def state(self) -> SoundLightFullState:
+        return self._state
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(
+        self, callback: Callable[[SoundLightEvent], None]
+    ) -> Callable[[], None]:
+        """Subscribe to S&L events. Returns an unsubscribe callable."""
+        self._subscribers.append(callback)
+
+        def _unsubscribe() -> None:
+            if callback in self._subscribers:
+                self._subscribers.remove(callback)
+
+        return _unsubscribe
+
+    def _fire_event(self, kind: SoundLightEventKind) -> None:
+        """Fire an event to all subscribers."""
+        event = SoundLightEvent(kind=kind, state=self._state)
+        for cb in self._subscribers:
+            try:
+                cb(event)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Error in S&L event subscriber")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_start(self) -> None:
+        """Start the S&L connection.
+
+        1. Fetch device token from cloud API
+        2. Connect WebSocket to local device
+        3. Start recv loop, keepalive, and token refresh tasks
+        """
+        self._stopped = False
+        await self._async_fetch_device_token()
+        await self._async_connect()
+
+    async def async_stop(self) -> None:
+        """Stop the S&L connection gracefully."""
+        self._stopped = True
+        await self._async_close_ws()
+
+        for task_attr in ("_poll_task", "_token_refresh_task"):
+            task = getattr(self, task_attr, None)
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                setattr(self, task_attr, None)
+
+        self._connected = False
+        self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    async def async_set_power(self, on: bool) -> None:
+        """Turn device power on or off (field 5)."""
+        cmd = build_power_cmd(on)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, power_on=on)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_light_enabled(self, on: bool) -> None:
+        """Turn the night light on or off (field 2 sub-1).
+
+        Passes current color values to preserve them in the command.
+        """
+        cmd = build_light_enabled_cmd(
+            on,
+            color_a=self._state.color_r,
+            color_b=self._state.color_g,
+        )
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, light_enabled=on)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_sound_on(self, on: bool) -> None:
+        """Turn sound on or off (field 4 sub-1).
+
+        Passes current track name to preserve it in the command.
+        """
+        cmd = build_sound_on_cmd(on, current_track=self._state.current_track)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, sound_on=on)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_track(self, track_name: str) -> None:
+        """Change the sound track.
+
+        Passes current sound_on state to preserve it.
+        """
+        cmd = build_track_cmd(track_name, sound_on=self._state.sound_on)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, current_track=track_name)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_brightness(self, brightness: float) -> None:
+        """Set light brightness (0.0-1.0)."""
+        cmd = build_brightness_cmd(brightness)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, brightness=brightness)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_volume(self, volume: float) -> None:
+        """Set sound volume (0.0-1.0).
+
+        Uses protobuf state field 3 (FIXED32 float). Confirmed working
+        by user testing.
+        """
+        cmd = build_volume_cmd(volume)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(self._state, volume=volume)
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    async def async_set_color(self, color_a: float, color_b: float) -> None:
+        """Set light color using the device's 2-parameter color model.
+
+        The exact color model (likely HSV hue+saturation) is experimental.
+        color_a maps to state field 2 sub-field 2 (range 0.0-1.0).
+        color_b maps to state field 2 sub-field 3 (range 0.0-1.0).
+
+        Passes current light_enabled state to preserve it.
+        """
+        cmd = build_color_cmd(color_a, color_b, light_enabled=self._state.light_enabled)
+        await self._async_send(cmd)
+        self._state = dataclasses.replace(
+            self._state, color_r=color_a, color_g=color_b
+        )
+        self._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+    # ------------------------------------------------------------------
+    # Internal — token management
+    # ------------------------------------------------------------------
+
+    async def _async_fetch_device_token(self) -> None:
+        """Fetch the RS256 device token from /speakers/{uid}/udtokens."""
+        access_token = await self._token_manager.async_get_access_token()
+        self._device_token = await self._rest.async_get_device_token(
+            access_token, self._speaker_uid
+        )
+        _LOGGER.debug(
+            "Fetched device token for speaker %s (len=%d)",
+            self._speaker_uid,
+            len(self._device_token),
+        )
+
+    async def _token_refresh_loop(self) -> None:
+        """Periodically refresh the device token."""
+        try:
+            while not self._stopped:
+                await asyncio.sleep(_TOKEN_REFRESH_INTERVAL)
+                if self._stopped:
+                    return
+                try:
+                    await self._async_fetch_device_token()
+                    _LOGGER.debug("S&L device token refreshed")
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.warning("S&L device token refresh failed: %s", err)
+        except asyncio.CancelledError:
+            return
+
+    # ------------------------------------------------------------------
+    # Internal — WebSocket connection
+    # ------------------------------------------------------------------
+
+    async def _async_connect(self, *, silent: bool = False) -> None:
+        """Connect WebSocket to the local S&L device.
+
+        Args:
+            silent: If True, suppress CONNECTION_CHANGE events during the
+                    disconnect/reconnect cycle.  Used by the poll loop to
+                    avoid briefly marking entities as unavailable.
+        """
+        async with self._connect_lock:
+            await self._async_close_ws()
+
+            if not self._device_token:
+                raise NanitConnectionError("No device token available")
+
+            if self._ssl_ctx is None:
+                self._ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                self._ssl_ctx.check_hostname = False
+                self._ssl_ctx.verify_mode = ssl.CERT_NONE
+
+            url = f"wss://{self._device_ip}:442/"
+            headers = {
+                "Authorization": f"token {self._device_token}",
+                "User-Agent": "NanitLite/1.8.0",
+            }
+
+            if not silent:
+                self._connected = False
+                self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+
+            try:
+                self._ws = await self._session.ws_connect(
+                    url,
+                    headers=headers,
+                    heartbeat=_HEARTBEAT_INTERVAL,
+                    timeout=_HANDSHAKE_TIMEOUT,
+                    ssl=self._ssl_ctx,
+                )
+            except Exception as err:
+                raise NanitConnectionError(
+                    f"S&L WebSocket connect failed: {err}"
+                ) from err
+
+            self._connected = True
+            loop = asyncio.get_running_loop()
+            self._recv_task = loop.create_task(self._recv_loop())
+            self._keepalive_task = loop.create_task(self._keepalive_loop())
+
+            # Start token refresh task if not already running
+            if self._token_refresh_task is None or self._token_refresh_task.done():
+                self._token_refresh_task = loop.create_task(
+                    self._token_refresh_loop()
+                )
+
+            # (Re)start poll task — cancel stale one first
+            if self._poll_task is not None and not self._poll_task.done():
+                self._poll_task.cancel()
+                try:
+                    await self._poll_task
+                except asyncio.CancelledError:
+                    pass
+            self._poll_task = loop.create_task(self._poll_loop())
+
+            self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+            _LOGGER.info(
+                "S&L device %s connected at %s:442",
+                self._speaker_uid,
+                self._device_ip,
+            )
+
+    async def _async_close_ws(self) -> None:
+        """Close WebSocket and cancel recv/keepalive tasks."""
+        for task in (self._recv_task, self._keepalive_task):
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        self._recv_task = None
+        self._keepalive_task = None
+
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+    async def _async_send(self, data: bytes) -> None:
+        """Send binary data over the WebSocket."""
+        if self._ws is None or self._ws.closed:
+            raise NanitTransportError("S&L not connected")
+        try:
+            await self._ws.send_bytes(data)
+        except Exception as err:
+            raise NanitTransportError(f"S&L send failed: {err}") from err
+
+    # ------------------------------------------------------------------
+    # Internal — recv loop and message handling
+    # ------------------------------------------------------------------
+
+    async def _recv_loop(self) -> None:
+        """Read binary frames and dispatch to message handler."""
+        assert self._ws is not None
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    self._on_message(msg.data)
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.CLOSED,
+                ):
+                    _LOGGER.debug("S&L WebSocket closed by device")
+                    break
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    _LOGGER.error("S&L WebSocket error: %s", self._ws.exception())
+                    break
+        except asyncio.CancelledError:
+            return
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("S&L recv loop error: %s", err)
+
+        # Auto-reconnect if not explicitly stopped
+        self._connected = False
+        self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+        if not self._stopped:
+            asyncio.get_running_loop().create_task(self._reconnect_loop())
+
+    def _on_message(self, data: bytes) -> None:
+        """Handle a raw binary protobuf message from the S&L device."""
+        msg_type = classify_message(data)
+
+        if msg_type == 0:
+            # Full state update
+            decoded = decode_full_state(data)
+            if decoded is not None:
+                self._state = dataclasses.replace(
+                    self._state,
+                    brightness=decoded.brightness if decoded.brightness is not None else self._state.brightness,
+                    light_enabled=decoded.light_enabled if decoded.light_enabled is not None else self._state.light_enabled,
+                    color_r=decoded.color_r if decoded.color_r is not None else self._state.color_r,
+                    color_g=decoded.color_g if decoded.color_g is not None else self._state.color_g,
+                    volume=decoded.volume if decoded.volume is not None else self._state.volume,
+                    current_track=decoded.current_track if decoded.current_track is not None else self._state.current_track,
+                    sound_on=decoded.sound_on if decoded.sound_on is not None else self._state.sound_on,
+                    power_on=decoded.power_on if decoded.power_on is not None else self._state.power_on,
+                    available_tracks=tuple(decoded.available_tracks) if decoded.available_tracks else self._state.available_tracks,
+                    temperature_c=decoded.temperature_c if decoded.temperature_c is not None else self._state.temperature_c,
+                    humidity_pct=decoded.humidity_pct if decoded.humidity_pct is not None else self._state.humidity_pct,
+                    timezone_rule=decoded.timezone_rule if decoded.timezone_rule is not None else self._state.timezone_rule,
+                )
+                self._fire_event(SoundLightEventKind.STATE_UPDATE)
+                _LOGGER.debug(
+                    "S&L state: brightness=%.2f volume=%.2f track=%s power=%s light=%s sound=%s temp=%.1f hum=%.1f",
+                    self._state.brightness or 0,
+                    self._state.volume or 0,
+                    self._state.current_track,
+                    self._state.power_on,
+                    self._state.light_enabled,
+                    self._state.sound_on,
+                    self._state.temperature_c or 0,
+                    self._state.humidity_pct or 0,
+                )
+
+        elif msg_type == 1:
+            # Sensor update
+            decoded_sensors = decode_sensors(data)
+            if decoded_sensors is not None:
+                self._state = dataclasses.replace(
+                    self._state,
+                    temperature_c=decoded_sensors.temperature_c if decoded_sensors.temperature_c is not None else self._state.temperature_c,
+                    humidity_pct=decoded_sensors.humidity_pct if decoded_sensors.humidity_pct is not None else self._state.humidity_pct,
+                )
+                self._fire_event(SoundLightEventKind.SENSOR_UPDATE)
+
+        elif msg_type in (2, 3):
+            # Routines update
+            decoded_routines = decode_routines(data)
+            if decoded_routines:
+                new_routines = tuple(
+                    SoundLightRoutine(
+                        name=r.name,
+                        sound_name=r.sound_name,
+                        volume=r.volume,
+                        brightness=r.brightness,
+                    )
+                    for r in decoded_routines
+                )
+                # Merge with existing routines (type 2 and 3 are different sets)
+                existing = {r.name: r for r in self._state.routines}
+                for r in new_routines:
+                    existing[r.name] = r
+                self._state = dataclasses.replace(
+                    self._state,
+                    routines=tuple(existing.values()),
+                )
+                self._fire_event(SoundLightEventKind.ROUTINES_UPDATE)
+
+        else:
+            _LOGGER.debug(
+                "S&L unknown message type (len=%d): %s",
+                len(data),
+                data.hex()[:100],
+            )
+
+    # ------------------------------------------------------------------
+    # Internal — keepalive and reconnect
+    # ------------------------------------------------------------------
+
+    async def _keepalive_loop(self) -> None:
+        """Send keepalive messages periodically."""
+        try:
+            while True:
+                await asyncio.sleep(_KEEPALIVE_INTERVAL)
+                if self._ws is None or self._ws.closed:
+                    break
+                try:
+                    await self._async_send(build_sl_keepalive())
+                except NanitTransportError:
+                    _LOGGER.warning("S&L keepalive failed, triggering reconnect")
+                    break
+        except asyncio.CancelledError:
+            return
+
+    async def _poll_loop(self) -> None:
+        """Periodically reconnect to refresh state from the device.
+
+        The S&L device sends a full state dump on each WebSocket connect.
+        By reconnecting every _POLL_INTERVAL seconds we pick up any changes
+        made via the Nanit app (which communicates through the cloud, not
+        the local WebSocket).
+        """
+        try:
+            while not self._stopped:
+                await asyncio.sleep(_POLL_INTERVAL)
+                if self._stopped:
+                    return
+                _LOGGER.debug("S&L poll: reconnecting to refresh state")
+                try:
+                    await self._async_connect(silent=True)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug("S&L poll reconnect failed: %s", err)
+        except asyncio.CancelledError:
+            return
+
+    async def _reconnect_loop(self) -> None:
+        """Exponential-backoff reconnect loop."""
+        if self._stopped:
+            return
+
+        import random
+
+        backoff = _INITIAL_BACKOFF
+        jitter = random.random() * _JITTER_MAX
+
+        while not self._stopped:
+            await self._async_close_ws()
+
+            wait_time = backoff + jitter
+            jitter = 0.0
+            _LOGGER.info("S&L reconnecting in %.1fs", wait_time)
+            await asyncio.sleep(wait_time)
+
+            if self._stopped:
+                return
+
+            try:
+                # Refresh device token before reconnecting
+                try:
+                    await self._async_fetch_device_token()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("Token refresh failed during reconnect, using cached")
+
+                await self._async_connect()
+                _LOGGER.info("S&L reconnected successfully")
+                return
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("S&L reconnect failed: %s", err)
+                self._connected = False
+                self._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+                backoff = min(backoff * _BACKOFF_FACTOR, _MAX_BACKOFF)

--- a/custom_components/nanit/binary_sensor.py
+++ b/custom_components/nanit/binary_sensor.py
@@ -203,4 +203,5 @@ class NanitSLConnectivitySensor(NanitSoundLightEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return True when the S&L WebSocket is connected."""
-        return self.coordinator.connected
+        result: bool = self.coordinator.connected
+        return result

--- a/custom_components/nanit/binary_sensor.py
+++ b/custom_components/nanit/binary_sensor.py
@@ -195,10 +195,7 @@ class NanitSLConnectivitySensor(NanitSoundLightEntity, BinarySensorEntity):
     @property
     def available(self) -> bool:
         """Always available so it can report disconnected state."""
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data is not None
-        )
+        return self.coordinator.last_update_success and self.coordinator.data is not None
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/nanit/binary_sensor.py
+++ b/custom_components/nanit/binary_sensor.py
@@ -19,8 +19,8 @@ from aionanit.models import CameraState, CloudEvent, ConnectionState
 
 from . import NanitConfigEntry
 from .const import CLOUD_EVENT_WINDOW
-from .coordinator import NanitCloudCoordinator, NanitPushCoordinator
-from .entity import NanitCloudEntity, NanitEntity
+from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
+from .entity import NanitCloudEntity, NanitEntity, NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
@@ -89,6 +89,11 @@ async def async_setup_entry(
         if cam_data.cloud_coordinator is not None:
             for cloud_desc in CLOUD_BINARY_SENSORS:
                 entities.append(NanitCloudBinarySensor(cam_data.cloud_coordinator, cloud_desc))
+
+        # Sound & Light connectivity sensor (optional)
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSLConnectivitySensor(sl_coordinator))
 
     async_add_entities(entities)
 
@@ -169,3 +174,33 @@ class NanitCloudBinarySensor(NanitCloudEntity, BinarySensorEntity):
                 return True
 
         return False
+
+
+class NanitSLConnectivitySensor(NanitSoundLightEntity, BinarySensorEntity):
+    """Connectivity binary sensor for the Sound & Light Machine."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "sl_connectivity"
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sl_connectivity"
+
+    @property
+    def available(self) -> bool:
+        """Always available so it can report disconnected state."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the S&L WebSocket is connected."""
+        return self.coordinator.connected

--- a/custom_components/nanit/camera.py
+++ b/custom_components/nanit/camera.py
@@ -44,7 +44,7 @@ class NanitCameraEntity(NanitEntity, Camera):
         camera: NanitCamera,
     ) -> None:
         """Initialize."""
-        NanitEntity.__init__(self, coordinator)
+        super().__init__(coordinator)
         Camera.__init__(self)
         self._camera = camera
         self._prev_is_on: bool | None = None

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -390,11 +390,11 @@ class NanitOptionsFlow(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_CAMERA_IP,
-                        default=current_ip,
+                        description={"suggested_value": current_ip},
                     ): cv.string,
                     vol.Optional(
                         CONF_SPEAKER_IP,
-                        default=current_speaker_ip,
+                        description={"suggested_value": current_speaker_ip},
                     ): cv.string,
                 }
             ),

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -23,6 +23,8 @@ from .const import (
     CONF_CAMERA_IPS,
     CONF_MFA_CODE,
     CONF_REFRESH_TOKEN,
+    CONF_SPEAKER_IP,
+    CONF_SPEAKER_IPS,
     CONF_STORE_CREDENTIALS,
     DOMAIN,
     LOGGER,
@@ -344,6 +346,7 @@ class NanitOptionsFlow(OptionsFlow):
         """Configure IP for the selected camera."""
         if user_input is not None:
             camera_ip = user_input.get(CONF_CAMERA_IP, "").strip()
+            speaker_ip = user_input.get(CONF_SPEAKER_IP, "").strip()
 
             # Merge with existing camera IPs
             current_ips = dict(self.config_entry.options.get(CONF_CAMERA_IPS, {}))
@@ -352,12 +355,25 @@ class NanitOptionsFlow(OptionsFlow):
             else:
                 current_ips.pop(self._selected_camera_uid, None)
 
+            # Merge with existing speaker IPs
+            current_speaker_ips = dict(self.config_entry.options.get(CONF_SPEAKER_IPS, {}))
+            if speaker_ip:
+                current_speaker_ips[self._selected_camera_uid] = speaker_ip
+            else:
+                current_speaker_ips.pop(self._selected_camera_uid, None)
+
             return self.async_create_entry(
                 title="",
-                data={CONF_CAMERA_IPS: current_ips},
+                data={
+                    CONF_CAMERA_IPS: current_ips,
+                    CONF_SPEAKER_IPS: current_speaker_ips,
+                },
             )
 
         current_ip = self.config_entry.options.get(CONF_CAMERA_IPS, {}).get(
+            self._selected_camera_uid, ""
+        )
+        current_speaker_ip = self.config_entry.options.get(CONF_SPEAKER_IPS, {}).get(
             self._selected_camera_uid, ""
         )
 
@@ -375,6 +391,10 @@ class NanitOptionsFlow(OptionsFlow):
                     vol.Optional(
                         CONF_CAMERA_IP,
                         default=current_ip,
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_SPEAKER_IP,
+                        default=current_speaker_ip,
                     ): cv.string,
                 }
             ),

--- a/custom_components/nanit/const.py
+++ b/custom_components/nanit/const.py
@@ -13,6 +13,8 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.CAMERA,
+    Platform.LIGHT,
+    Platform.SELECT,
 ]
 
 # Cloud event detection window (seconds)
@@ -31,3 +33,20 @@ CONF_CAMERA_UID = "camera_uid"
 CONF_BABY_NAME = "baby_name"
 CONF_CAMERA_IP = "camera_ip"
 CONF_CAMERA_IPS = "camera_ips"
+CONF_SPEAKER_UID = "speaker_uid"
+CONF_SPEAKER_IP = "speaker_ip"
+CONF_SPEAKER_IPS = "speaker_ips"
+
+# Default sound list (used when API doesn't return available_sounds)
+DEFAULT_SOUND_MACHINE_SOUNDS = (
+    "white_noise",
+    "birds",
+    "waves",
+    "wind",
+    "rain",
+    "water_stream",
+    "fan",
+    "heartbeat",
+    "dryer",
+    "vacuum",
+)

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -22,8 +22,6 @@ from collections.abc import Callable
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-import dataclasses
-
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
@@ -35,7 +33,6 @@ from aionanit.models import Baby, CameraEvent, CameraState, CloudEvent
 
 from .aionanit_sl.models import SoundLightEvent, SoundLightEventKind, SoundLightFullState
 from .aionanit_sl.sound_light import NanitSoundLight
-
 from .const import CLOUD_POLL_INTERVAL, DOMAIN
 
 if TYPE_CHECKING:
@@ -207,9 +204,16 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
 _SL_STORE_VERSION = 1
 # Fields from SoundLightFullState that we persist across restarts.
 _SL_PERSIST_FIELDS = (
-    "brightness", "light_enabled", "color_r", "color_g",
-    "sound_on", "current_track", "volume",
-    "power_on", "temperature_c", "humidity_pct",
+    "brightness",
+    "light_enabled",
+    "color_r",
+    "color_g",
+    "sound_on",
+    "current_track",
+    "volume",
+    "power_on",
+    "temperature_c",
+    "humidity_pct",
 )
 
 
@@ -301,10 +305,10 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
             if not kwargs:
                 return None
             # Convert available_tracks if present
-            if "available_tracks" in data and data["available_tracks"]:
+            if data.get("available_tracks"):
                 kwargs["available_tracks"] = tuple(data["available_tracks"])
             return SoundLightFullState(**kwargs)
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOGGER.debug("Failed to restore S&L state", exc_info=True)
             return None
 
@@ -321,7 +325,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
                 data["available_tracks"] = list(state.available_tracks)
             if data:
                 await self._store.async_save(data)
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOGGER.debug("Failed to save S&L state", exc_info=True)
 
     @callback
@@ -368,9 +372,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         if self._save_timer is not None:
             # Timer already running — it will pick up the latest state
             return
-        self._save_timer = async_call_later(
-            self.hass, 5, self._do_save
-        )
+        self._save_timer = async_call_later(self.hass, 5, self._do_save)
 
     @callback
     def _do_save(self, _now: object) -> None:

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -22,9 +22,12 @@ from collections.abc import Callable
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import dataclasses
+
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from aionanit import NanitAuthError, NanitCamera, NanitConnectionError
@@ -201,12 +204,29 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
             ) from err
 
 
+_SL_STORE_VERSION = 1
+# Fields from SoundLightFullState that we persist across restarts.
+_SL_PERSIST_FIELDS = (
+    "brightness", "light_enabled", "color_r", "color_g",
+    "sound_on", "current_track", "volume",
+    "power_on", "temperature_c", "humidity_pct",
+)
+
+
 class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
     """Push-based coordinator for the Nanit Sound & Light Machine.
 
     Wraps NanitSoundLight.subscribe() — receives state updates from
-    the S&L device's local WebSocket (raw protobuf over wss://{ip}:442).
+    the S&L device via WebSocket (cloud relay or local).
     No polling — all state is pushed by the device.
+
+    Persists the last known state to HA storage so that entities show
+    their previous values on restart (instead of "unknown") until the
+    first live update arrives from the device.
+
+    Uses a grace period for disconnections so brief reconnections
+    (e.g. during hourly access-token refresh) do not flash entities
+    as "Unavailable" in HA.
     """
 
     config_entry: NanitConfigEntry
@@ -227,32 +247,178 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         self.sound_light = sound_light
         self.baby: Baby = None  # type: ignore[assignment]  # Set by hub._setup_camera before use
         self._unsubscribe: Callable[[], None] | None = None
+        self._store: Store = Store(
+            hass,
+            _SL_STORE_VERSION,
+            f"{DOMAIN}_sl_state_{sound_light.speaker_uid}",
+        )
+        self._sl_connected: bool = False
+        self._availability_timer: CALLBACK_TYPE | None = None
+        self._save_timer: CALLBACK_TYPE | None = None
+        self._pending_save_state: SoundLightFullState | None = None
 
     @property
     def connected(self) -> bool:
-        """Derive connection state from the underlying S&L device."""
-        return self.sound_light.connected
+        """Return debounced connection state (survives brief reconnections)."""
+        return self._sl_connected
 
     async def async_setup(self) -> None:
         """Start the S&L device and subscribe to push events."""
         self._unsubscribe = self.sound_light.subscribe(self._on_sl_event)
         await self.sound_light.async_start()
-        self.async_set_updated_data(self.sound_light.state)
+        self._sl_connected = self.sound_light.connected
+
+        # If the device hasn't sent initial state yet (cloud relay),
+        # restore the last known state from disk so entities aren't "unknown".
+        state = self.sound_light.state
+        if state.power_on is None:
+            restored = await self._async_restore_state()
+            if restored is not None:
+                # Feed restored state into the sound_light instance so
+                # entities and coordinator data are consistent.
+                self.sound_light.restore_state(restored)
+                state = restored
+                _LOGGER.debug(
+                    "S&L %s: restored saved state (power=%s, track=%s, vol=%s)",
+                    self.sound_light.speaker_uid,
+                    restored.power_on,
+                    restored.current_track,
+                    restored.volume,
+                )
+
+        self.async_set_updated_data(state)
+
+    async def _async_restore_state(self) -> SoundLightFullState | None:
+        """Load persisted S&L state from HA storage."""
+        try:
+            data = await self._store.async_load()
+            if not data or not isinstance(data, dict):
+                return None
+            kwargs = {}
+            for field in _SL_PERSIST_FIELDS:
+                if field in data and data[field] is not None:
+                    kwargs[field] = data[field]
+            if not kwargs:
+                return None
+            # Convert available_tracks if present
+            if "available_tracks" in data and data["available_tracks"]:
+                kwargs["available_tracks"] = tuple(data["available_tracks"])
+            return SoundLightFullState(**kwargs)
+        except Exception:
+            _LOGGER.debug("Failed to restore S&L state", exc_info=True)
+            return None
+
+    async def _async_save_state(self, state: SoundLightFullState) -> None:
+        """Persist current S&L state to HA storage."""
+        try:
+            data = {}
+            for field in _SL_PERSIST_FIELDS:
+                val = getattr(state, field, None)
+                if val is not None:
+                    data[field] = val
+            # Also save available_tracks
+            if state.available_tracks:
+                data["available_tracks"] = list(state.available_tracks)
+            if data:
+                await self._store.async_save(data)
+        except Exception:
+            _LOGGER.debug("Failed to save S&L state", exc_info=True)
 
     @callback
     def _on_sl_event(self, event: SoundLightEvent) -> None:
         """Handle a push event from NanitSoundLight.subscribe()."""
-        if event.kind == SoundLightEventKind.CONNECTION_CHANGE and not self.connected:
-            _LOGGER.debug(
-                "S&L %s disconnected",
-                self.sound_light.speaker_uid,
-            )
+        if event.kind == SoundLightEventKind.CONNECTION_CHANGE:
+            transport_connected = self.sound_light.connected
+            if transport_connected:
+                # Connection is up — cancel any pending unavailability timer
+                # and mark connected immediately.
+                self._cancel_availability_timer()
+                if not self._sl_connected:
+                    _LOGGER.info(
+                        "S&L %s reconnected",
+                        self.sound_light.speaker_uid,
+                    )
+                self._sl_connected = True
+            elif self._sl_connected:
+                # Connection just dropped — start the grace period.
+                # Don't mark unavailable yet; give the transport time to reconnect.
+                _LOGGER.debug(
+                    "S&L %s disconnected (grace period %.0fs)",
+                    self.sound_light.speaker_uid,
+                    _AVAILABILITY_GRACE_SECONDS,
+                )
+                self._start_availability_timer()
+            # If already disconnected and transport still disconnected,
+            # do nothing — timer is already running or fired.
+
         self.async_set_updated_data(event.state)
+
+        # Debounce state saves — at most every 5 seconds to avoid
+        # overlapping writes from rapid state/sensor updates.
+        if event.kind in (
+            SoundLightEventKind.STATE_UPDATE,
+            SoundLightEventKind.SENSOR_UPDATE,
+        ):
+            self._schedule_save(event.state)
+
+    @callback
+    def _schedule_save(self, state: SoundLightFullState) -> None:
+        """Schedule a debounced state save (at most every 5 seconds)."""
+        self._pending_save_state = state
+        if self._save_timer is not None:
+            # Timer already running — it will pick up the latest state
+            return
+        self._save_timer = async_call_later(
+            self.hass, 5, self._do_save
+        )
+
+    @callback
+    def _do_save(self, _now: object) -> None:
+        """Execute the debounced state save."""
+        self._save_timer = None
+        if self._pending_save_state is not None:
+            state = self._pending_save_state
+            self._pending_save_state = None
+            self.hass.async_create_task(self._async_save_state(state))
+
+    @callback
+    def _on_availability_timeout(self, _now: object) -> None:
+        """Grace period expired — mark S&L entities unavailable."""
+        self._availability_timer = None
+        if not self.sound_light.connected:
+            _LOGGER.warning(
+                "S&L %s still disconnected after %.0fs grace period",
+                self.sound_light.speaker_uid,
+                _AVAILABILITY_GRACE_SECONDS,
+            )
+            self._sl_connected = False
+            self.async_update_listeners()
+
+    def _start_availability_timer(self) -> None:
+        """Start (or restart) the grace period timer."""
+        self._cancel_availability_timer()
+        self._availability_timer = async_call_later(
+            self.hass, _AVAILABILITY_GRACE_SECONDS, self._on_availability_timeout
+        )
+
+    def _cancel_availability_timer(self) -> None:
+        """Cancel the grace period timer if running."""
+        if self._availability_timer is not None:
+            self._availability_timer()
+            self._availability_timer = None
 
     async def async_shutdown(self) -> None:
         """Stop the S&L device and unsubscribe."""
+        self._cancel_availability_timer()
+        # Cancel debounced save timer and flush final state
+        if self._save_timer is not None:
+            self._save_timer()
+            self._save_timer = None
+        self._pending_save_state = None
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None
+        # Save final state before stopping
+        await self._async_save_state(self.sound_light.state)
         await self.sound_light.async_stop()
         await super().async_shutdown()

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import dataclasses
 
@@ -247,7 +247,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         self.sound_light = sound_light
         self.baby: Baby = None  # type: ignore[assignment]  # Set by hub._setup_camera before use
         self._unsubscribe: Callable[[], None] | None = None
-        self._store: Store = Store(
+        self._store: Store[dict[str, Any]] = Store(
             hass,
             _SL_STORE_VERSION,
             f"{DOMAIN}_sl_state_{sound_light.speaker_uid}",

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -10,6 +10,9 @@ NanitPushCoordinator: Push-based coordinator that wraps NanitCamera.subscribe().
 
 NanitCloudCoordinator: Polls the Nanit cloud API for motion/sound events every
     CLOUD_POLL_INTERVAL seconds.
+
+NanitSoundLightCoordinator: Push-based coordinator wrapping NanitSoundLight.subscribe().
+    Receives state updates from the S&L device's local WebSocket.
 """
 
 from __future__ import annotations
@@ -26,6 +29,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from aionanit import NanitAuthError, NanitCamera, NanitConnectionError
 from aionanit.models import Baby, CameraEvent, CameraState, CloudEvent
+
+from .aionanit_sl.models import SoundLightEvent, SoundLightEventKind, SoundLightFullState
+from .aionanit_sl.sound_light import NanitSoundLight
 
 from .const import CLOUD_POLL_INTERVAL, DOMAIN
 
@@ -193,3 +199,60 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
                 translation_key="cloud_fetch_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+
+class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
+    """Push-based coordinator for the Nanit Sound & Light Machine.
+
+    Wraps NanitSoundLight.subscribe() — receives state updates from
+    the S&L device's local WebSocket (raw protobuf over wss://{ip}:442).
+    No polling — all state is pushed by the device.
+    """
+
+    config_entry: NanitConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: NanitConfigEntry,
+        sound_light: NanitSoundLight,
+    ) -> None:
+        """Initialize the Sound & Light coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}_{sound_light.speaker_uid}_sound_light",
+        )
+        self.sound_light = sound_light
+        self.baby: Baby = None  # type: ignore[assignment]  # Set by hub._setup_camera before use
+        self._unsubscribe: Callable[[], None] | None = None
+
+    @property
+    def connected(self) -> bool:
+        """Derive connection state from the underlying S&L device."""
+        return self.sound_light.connected
+
+    async def async_setup(self) -> None:
+        """Start the S&L device and subscribe to push events."""
+        self._unsubscribe = self.sound_light.subscribe(self._on_sl_event)
+        await self.sound_light.async_start()
+        self.async_set_updated_data(self.sound_light.state)
+
+    @callback
+    def _on_sl_event(self, event: SoundLightEvent) -> None:
+        """Handle a push event from NanitSoundLight.subscribe()."""
+        if event.kind == SoundLightEventKind.CONNECTION_CHANGE and not self.connected:
+            _LOGGER.debug(
+                "S&L %s disconnected",
+                self.sound_light.speaker_uid,
+            )
+        self.async_set_updated_data(event.state)
+
+    async def async_shutdown(self) -> None:
+        """Stop the S&L device and unsubscribe."""
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
+        await self.sound_light.async_stop()
+        await super().async_shutdown()

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -78,7 +78,4 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
         known values when the WebSocket drops. Connection state is reported
         separately by the S&L connectivity binary sensor.
         """
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data is not None
-        )
+        return self.coordinator.last_update_success and self.coordinator.data is not None

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -71,9 +71,13 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return True when the coordinator has data and S&L device is connected."""
+        """Return True when the coordinator has received data.
+
+        Does NOT require an active connection — entities retain their last
+        known values when the WebSocket drops. Connection state is reported
+        separately by the S&L connectivity binary sensor.
+        """
         return (
             self.coordinator.last_update_success
             and self.coordinator.data is not None
-            and self.coordinator.connected
         )

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import NanitCloudCoordinator, NanitPushCoordinator
+from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
 
 
 class NanitEntity(CoordinatorEntity[NanitPushCoordinator]):
@@ -49,4 +49,31 @@ class NanitCloudEntity(CoordinatorEntity[NanitCloudCoordinator]):
             identifiers={(DOMAIN, self.coordinator.baby.camera_uid)},
             name=self.coordinator.baby.name,
             manufacturer="Nanit",
+        )
+
+
+class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
+    """Base entity for the Nanit Sound & Light Machine — backed by the push coordinator."""
+
+    _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info — separate device from the camera."""
+        baby = self.coordinator.baby
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{baby.camera_uid}_sound_light")},
+            name=f"{baby.name} Sound & Light",
+            manufacturer="Nanit",
+            model="Sound & Light Machine",
+            via_device=(DOMAIN, baby.camera_uid),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True when the coordinator has data and S&L device is connected."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self.coordinator.connected
         )

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -25,9 +25,9 @@ from aionanit import (
 from aionanit.exceptions import NanitCameraUnavailable
 from aionanit.models import Baby
 
+from .aionanit_sl.sound_light import NanitSoundLight
 from .const import CONF_CAMERA_IPS, CONF_REFRESH_TOKEN, CONF_SPEAKER_IPS, DOMAIN
 from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
-from .aionanit_sl.sound_light import NanitSoundLight
 from .sanitize import sanitize_name
 
 if TYPE_CHECKING:
@@ -113,9 +113,7 @@ class NanitHub:
 
         # Discover speaker UIDs — try persisted data first, then aionanit,
         # then raw /babies API as final fallback.
-        speaker_uid_map: dict[str, str] = dict(
-            self._entry.data.get("speaker_uid_map", {})
-        )
+        speaker_uid_map: dict[str, str] = dict(self._entry.data.get("speaker_uid_map", {}))
         if not speaker_uid_map:
             for baby in babies:
                 uid = getattr(baby, "speaker_uid", None)
@@ -124,7 +122,7 @@ class NanitHub:
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
 
         # Persist discovered speaker UIDs so they survive restarts
@@ -134,9 +132,7 @@ class NanitHub:
                 self._entry,
                 data={**self._entry.data, "speaker_uid_map": speaker_uid_map},
             )
-            _LOGGER.info(
-                "Persisted speaker UID map: %s", speaker_uid_map
-            )
+            _LOGGER.info("Persisted speaker UID map: %s", speaker_uid_map)
 
         # Per-camera IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
@@ -235,7 +231,7 @@ class NanitHub:
                 await sound_light_coordinator.async_setup()
             except NanitAuthError:
                 raise
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _LOGGER.warning(
                     "Sound & Light Machine coordinator for %s failed to start; "
                     "sound/light entities disabled",
@@ -304,7 +300,7 @@ class NanitHub:
         for sl in list(self._sound_lights.values()):
             try:
                 await sl.async_stop()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _LOGGER.debug("Error stopping S&L during close")
         self._sound_lights.clear()
 
@@ -334,7 +330,5 @@ class NanitHub:
             speaker_uid = speaker_obj.get("uid")
             if camera_uid and speaker_uid:
                 result[camera_uid] = speaker_uid
-                _LOGGER.debug(
-                    "Discovered speaker UID %s for camera %s", speaker_uid, camera_uid
-                )
+                _LOGGER.debug("Discovered speaker UID %s for camera %s", speaker_uid, camera_uid)
         return result

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -111,6 +111,33 @@ class NanitHub:
             _LOGGER.warning("No babies/cameras found on Nanit account")
             return
 
+        # Discover speaker UIDs — try persisted data first, then aionanit,
+        # then raw /babies API as final fallback.
+        speaker_uid_map: dict[str, str] = dict(
+            self._entry.data.get("speaker_uid_map", {})
+        )
+        if not speaker_uid_map:
+            for baby in babies:
+                uid = getattr(baby, "speaker_uid", None)
+                if uid:
+                    speaker_uid_map[baby.camera_uid] = uid
+        if not speaker_uid_map:
+            try:
+                speaker_uid_map = await self._discover_speaker_uids()
+            except Exception:
+                _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+
+        # Persist discovered speaker UIDs so they survive restarts
+        stored_map = self._entry.data.get("speaker_uid_map", {})
+        if speaker_uid_map and speaker_uid_map != stored_map:
+            self._hass.config_entries.async_update_entry(
+                self._entry,
+                data={**self._entry.data, "speaker_uid_map": speaker_uid_map},
+            )
+            _LOGGER.info(
+                "Persisted speaker UID map: %s", speaker_uid_map
+            )
+
         # Per-camera IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
         speaker_ips: dict[str, str] = self._entry.options.get(CONF_SPEAKER_IPS, {})
@@ -119,7 +146,12 @@ class NanitHub:
         failed_cameras: list[str] = []
         for baby in babies:
             try:
-                await self._setup_camera(baby, camera_ips.get(baby.camera_uid), speaker_ips.get(baby.camera_uid))
+                await self._setup_camera(
+                    baby,
+                    camera_ips.get(baby.camera_uid),
+                    speaker_ips.get(baby.camera_uid),
+                    speaker_uid_map.get(baby.camera_uid),
+                )
             except NanitAuthError:
                 # Auth errors are account-level — propagate immediately
                 raise
@@ -161,6 +193,7 @@ class NanitHub:
         baby: Baby,
         camera_ip: str | None,
         speaker_ip: str | None,
+        speaker_uid: str | None = None,
     ) -> None:
         """Create a camera instance and its coordinators for a single baby."""
         camera = self._client.camera(
@@ -188,9 +221,11 @@ class NanitHub:
 
         # Sound & Light Machine coordinator (optional — local WebSocket push)
         sound_light_coordinator: NanitSoundLightCoordinator | None = None
-        speaker_uid = baby.speaker_uid
+        # Use speaker_uid passed from the discovery map; fall back to Baby attr
+        if not speaker_uid:
+            speaker_uid = getattr(baby, "speaker_uid", None)
 
-        if speaker_uid and speaker_ip:
+        if speaker_uid:
             try:
                 sound_light = self.get_sound_light(speaker_uid, speaker_ip)
                 sound_light_coordinator = NanitSoundLightCoordinator(
@@ -201,19 +236,17 @@ class NanitHub:
             except NanitAuthError:
                 raise
             except Exception:
-                _LOGGER.info(
+                _LOGGER.warning(
                     "Sound & Light Machine coordinator for %s failed to start; "
                     "sound/light entities disabled",
                     baby.name,
+                    exc_info=True,
                 )
                 sound_light_coordinator = None
         else:
             _LOGGER.debug(
-                "No speaker UID/IP for %s; Sound & Light Machine entities skipped "
-                "(speaker_uid=%s, speaker_ip=%s)",
+                "No speaker UID for %s; Sound & Light Machine entities skipped",
                 baby.name,
-                speaker_uid,
-                speaker_ip,
             )
 
         ir.async_delete_issue(self._hass, DOMAIN, f"camera_connection_failed_{baby.camera_uid}")
@@ -241,7 +274,7 @@ class NanitHub:
     def get_sound_light(
         self,
         speaker_uid: str,
-        device_ip: str,
+        device_ip: str | None = None,
     ) -> NanitSoundLight:
         """Get or create a NanitSoundLight instance."""
         if speaker_uid in self._sound_lights:
@@ -252,10 +285,10 @@ class NanitHub:
 
         sl = NanitSoundLight(
             speaker_uid=speaker_uid,
-            device_ip=device_ip,
             token_manager=self._client.token_manager,
             rest_client=self._client.rest_client,
             session=self._client.session,
+            device_ip=device_ip,
         )
         self._sound_lights[speaker_uid] = sl
         return sl
@@ -274,3 +307,34 @@ class NanitHub:
             except Exception:
                 _LOGGER.debug("Error stopping S&L during close")
         self._sound_lights.clear()
+
+    async def _discover_speaker_uids(self) -> dict[str, str]:
+        """Fetch speaker UIDs from the raw /babies API response.
+
+        Fallback for when the installed aionanit package's Baby dataclass
+        does not yet include the speaker_uid field.
+        """
+        tm = self._client.token_manager
+        if tm is None:
+            return {}
+        access_token = await tm.async_get_access_token()
+        rest = self._client.rest_client
+        resp = await rest.session.get(
+            f"{rest.base_url}/babies",
+            headers={"Authorization": access_token},
+        )
+        resp.raise_for_status()
+        body = await resp.json()
+
+        result: dict[str, str] = {}
+        for baby in body.get("babies", []):
+            camera_uid = baby.get("camera_uid")
+            speaker_data = baby.get("speaker", {})
+            speaker_obj = speaker_data.get("speaker", {})
+            speaker_uid = speaker_obj.get("uid")
+            if camera_uid and speaker_uid:
+                result[camera_uid] = speaker_uid
+                _LOGGER.debug(
+                    "Discovered speaker UID %s for camera %s", speaker_uid, camera_uid
+                )
+        return result

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -25,8 +25,10 @@ from aionanit import (
 from aionanit.exceptions import NanitCameraUnavailable
 from aionanit.models import Baby
 
-from .const import CONF_CAMERA_IPS, CONF_REFRESH_TOKEN, DOMAIN
-from .coordinator import NanitCloudCoordinator, NanitPushCoordinator
+from .const import CONF_CAMERA_IPS, CONF_REFRESH_TOKEN, CONF_SPEAKER_IPS, DOMAIN
+from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
+
+from .aionanit_sl.sound_light import NanitSoundLight
 
 if TYPE_CHECKING:
     from . import NanitConfigEntry
@@ -42,6 +44,7 @@ class CameraData:
     baby: Baby
     push_coordinator: NanitPushCoordinator
     cloud_coordinator: NanitCloudCoordinator | None
+    sound_light_coordinator: NanitSoundLightCoordinator | None = None
 
 
 class NanitHub:
@@ -63,6 +66,7 @@ class NanitHub:
         self._client = NanitClient(session)
         self._camera_data: dict[str, CameraData] = {}
         self._babies: list[Baby] = []
+        self._sound_lights: dict[str, NanitSoundLight] = {}
         self._unsubscribe_tokens: Callable[[], None] | None = None
 
     @property
@@ -109,12 +113,13 @@ class NanitHub:
 
         # Per-camera IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
+        speaker_ips: dict[str, str] = self._entry.options.get(CONF_SPEAKER_IPS, {})
 
         # Create camera + coordinators for each baby
         failed_cameras: list[str] = []
         for baby in babies:
             try:
-                await self._setup_camera(baby, camera_ips.get(baby.camera_uid))
+                await self._setup_camera(baby, camera_ips.get(baby.camera_uid), speaker_ips.get(baby.camera_uid))
             except NanitAuthError:
                 # Auth errors are account-level — propagate immediately
                 raise
@@ -155,6 +160,7 @@ class NanitHub:
         self,
         baby: Baby,
         camera_ip: str | None,
+        speaker_ip: str | None,
     ) -> None:
         """Create a camera instance and its coordinators for a single baby."""
         camera = self._client.camera(
@@ -180,6 +186,36 @@ class NanitHub:
             )
             cloud_coordinator = None
 
+        # Sound & Light Machine coordinator (optional — local WebSocket push)
+        sound_light_coordinator: NanitSoundLightCoordinator | None = None
+        speaker_uid = baby.speaker_uid
+
+        if speaker_uid and speaker_ip:
+            try:
+                sound_light = self.get_sound_light(speaker_uid, speaker_ip)
+                sound_light_coordinator = NanitSoundLightCoordinator(
+                    self._hass, self._entry, sound_light
+                )
+                sound_light_coordinator.baby = baby
+                await sound_light_coordinator.async_setup()
+            except NanitAuthError:
+                raise
+            except Exception:
+                _LOGGER.info(
+                    "Sound & Light Machine coordinator for %s failed to start; "
+                    "sound/light entities disabled",
+                    baby.name,
+                )
+                sound_light_coordinator = None
+        else:
+            _LOGGER.debug(
+                "No speaker UID/IP for %s; Sound & Light Machine entities skipped "
+                "(speaker_uid=%s, speaker_ip=%s)",
+                baby.name,
+                speaker_uid,
+                speaker_ip,
+            )
+
         ir.async_delete_issue(self._hass, DOMAIN, f"camera_connection_failed_{baby.camera_uid}")
 
         self._camera_data[baby.camera_uid] = CameraData(
@@ -187,6 +223,7 @@ class NanitHub:
             baby=baby,
             push_coordinator=push_coordinator,
             cloud_coordinator=cloud_coordinator,
+            sound_light_coordinator=sound_light_coordinator,
         )
 
     @callback
@@ -201,6 +238,28 @@ class NanitHub:
             },
         )
 
+    def get_sound_light(
+        self,
+        speaker_uid: str,
+        device_ip: str,
+    ) -> NanitSoundLight:
+        """Get or create a NanitSoundLight instance."""
+        if speaker_uid in self._sound_lights:
+            return self._sound_lights[speaker_uid]
+
+        if self._client.token_manager is None:
+            raise NanitAuthError("Not authenticated — call async_login first")
+
+        sl = NanitSoundLight(
+            speaker_uid=speaker_uid,
+            device_ip=device_ip,
+            token_manager=self._client.token_manager,
+            rest_client=self._client.rest_client,
+            session=self._client.session,
+        )
+        self._sound_lights[speaker_uid] = sl
+        return sl
+
     async def async_close(self) -> None:
         """Stop all cameras and clean up."""
         if self._unsubscribe_tokens is not None:
@@ -208,3 +267,10 @@ class NanitHub:
             self._unsubscribe_tokens = None
         await self._client.async_close()
         self._camera_data.clear()
+        # Also stop S&L instances
+        for sl in list(self._sound_lights.values()):
+            try:
+                await sl.async_stop()
+            except Exception:
+                _LOGGER.debug("Error stopping S&L during close")
+        self._sound_lights.clear()

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .aionanit_sl.exceptions import NanitTransportError
 
 from . import NanitConfigEntry
-from .const import CONF_CAMERA_UID
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -30,11 +29,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Nanit Sound & Light Machine light entity."""
-    coordinator = entry.runtime_data.sound_light_coordinator
-    if coordinator is None:
-        return
+    entities: list[LightEntity] = []
+    for cam_data in entry.runtime_data.cameras.values():
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSoundLightLight(sl_coordinator))
 
-    async_add_entities([NanitSoundLightLight(coordinator, entry)])
+    async_add_entities(entities)
 
 
 class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
@@ -47,15 +48,11 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
     def __init__(
         self,
         coordinator: NanitSoundLightCoordinator,
-        entry: NanitConfigEntry,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._entry = entry
-        self._attr_unique_id = (
-            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
-            "_sound_light_light"
-        )
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_light_light"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -14,9 +14,8 @@ from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .aionanit_sl.exceptions import NanitTransportError
-
 from . import NanitConfigEntry
+from .aionanit_sl.exceptions import NanitTransportError
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -41,7 +40,7 @@ async def async_setup_entry(
 class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
     """Light entity for the Nanit Sound & Light Machine."""
 
-    _attr_supported_color_modes = {ColorMode.HS}
+    _attr_supported_color_modes = {ColorMode.HS}  # noqa: RUF012
     _attr_color_mode = ColorMode.HS
     _attr_translation_key = "sound_light_light"
 

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -8,9 +8,9 @@ from typing import Any
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
-    ColorMode,
     LightEntity,
 )
+from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -61,9 +61,10 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
             return None
         state = self.coordinator.data
         if state.light_enabled is not None:
-            return state.light_enabled
+            result: bool = state.light_enabled
+            return result
         if state.brightness is not None:
-            return state.brightness > 0.001
+            return bool(state.brightness > 0.001)
         return None
 
     @property

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -1,0 +1,124 @@
+"""Light platform for the Nanit Sound & Light Machine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .aionanit_sl.exceptions import NanitTransportError
+
+from . import NanitConfigEntry
+from .const import CONF_CAMERA_UID
+from .coordinator import NanitSoundLightCoordinator
+from .entity import NanitSoundLightEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NanitConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Nanit Sound & Light Machine light entity."""
+    coordinator = entry.runtime_data.sound_light_coordinator
+    if coordinator is None:
+        return
+
+    async_add_entities([NanitSoundLightLight(coordinator, entry)])
+
+
+class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
+    """Light entity for the Nanit Sound & Light Machine."""
+
+    _attr_supported_color_modes = {ColorMode.HS}
+    _attr_color_mode = ColorMode.HS
+    _attr_translation_key = "sound_light_light"
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+        entry: NanitConfigEntry,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = (
+            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
+            "_sound_light_light"
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the light is on."""
+        if self.coordinator.data is None:
+            return None
+        state = self.coordinator.data
+        if state.light_enabled is not None:
+            return state.light_enabled
+        if state.brightness is not None:
+            return state.brightness > 0.001
+        return None
+
+    @property
+    def brightness(self) -> int | None:
+        """Return brightness in HA's 0-255 scale."""
+        if self.coordinator.data is None:
+            return None
+        state = self.coordinator.data
+        dev_brightness = state.brightness
+        if dev_brightness is None:
+            return None
+        # When light is on but device reports 0.0 brightness, return 1
+        # to prevent HA from interpreting it as "off"
+        if state.power_on and state.light_enabled and dev_brightness < 0.004:
+            return 1
+        return min(255, max(0, int(dev_brightness * 255)))
+
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return HS color."""
+        if self.coordinator.data is None:
+            return None
+        state = self.coordinator.data
+        color_a = state.color_r
+        color_b = state.color_g
+        if color_a is None and color_b is None:
+            return None
+        hue = (color_a or 0.0) * 360.0
+        saturation = (color_b or 0.0) * 100.0
+        return (hue, saturation)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light, optionally setting brightness and/or color."""
+        try:
+            await self.coordinator.sound_light.async_set_light_enabled(True)
+
+            if ATTR_HS_COLOR in kwargs:
+                hs = kwargs[ATTR_HS_COLOR]
+                color_a = hs[0] / 360.0
+                color_b = hs[1] / 100.0
+                await self.coordinator.sound_light.async_set_color(color_a, color_b)
+
+            if ATTR_BRIGHTNESS in kwargs:
+                dev_brightness = max(0.01, kwargs[ATTR_BRIGHTNESS] / 255.0)
+                await self.coordinator.sound_light.async_set_brightness(dev_brightness)
+
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to control Sound & Light light: %s", err)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        try:
+            await self.coordinator.sound_light.async_set_light_enabled(False)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to turn off Sound & Light light: %s", err)

--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nanit",
   "name": "Nanit",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.1",
   "documentation": "https://github.com/wealthystudent/ha-nanit",
   "issue_tracker": "https://github.com/wealthystudent/ha-nanit/issues",
   "codeowners": ["@wealthystudent"],

--- a/custom_components/nanit/number.py
+++ b/custom_components/nanit/number.py
@@ -102,7 +102,7 @@ class NanitSoundMachineVolume(NanitSoundLightEntity, NumberEntity):
         vol = self.coordinator.data.volume
         if vol is None:
             return None
-        return round(vol * 100, 0)
+        return round(float(vol) * 100, 0)
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the sound machine volume via local WebSocket."""

--- a/custom_components/nanit/number.py
+++ b/custom_components/nanit/number.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
@@ -10,10 +12,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from aionanit import NanitCamera
 
 from . import NanitConfigEntry
-from .coordinator import NanitPushCoordinator
-from .entity import NanitEntity
+from .aionanit_sl.exceptions import NanitTransportError
+from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
+from .entity import NanitEntity, NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -22,10 +27,16 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Nanit number entities for all cameras on the account."""
-    async_add_entities(
-        NanitVolume(cam_data.push_coordinator, cam_data.camera)
-        for cam_data in entry.runtime_data.cameras.values()
-    )
+    entities: list[NumberEntity] = []
+    for cam_data in entry.runtime_data.cameras.values():
+        entities.append(NanitVolume(cam_data.push_coordinator, cam_data.camera))
+
+        # Sound & Light Machine volume (optional)
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSoundMachineVolume(sl_coordinator))
+
+    async_add_entities(entities)
 
 
 class NanitVolume(NanitEntity, NumberEntity):
@@ -61,3 +72,41 @@ class NanitVolume(NanitEntity, NumberEntity):
         """Set the volume."""
         await self._camera.async_set_settings(volume=int(value))
         self.async_write_ha_state()
+
+
+class NanitSoundMachineVolume(NanitSoundLightEntity, NumberEntity):
+    """Volume number entity for the Nanit Sound & Light Machine."""
+
+    _attr_translation_key = "sound_machine_volume"
+    _attr_icon = "mdi:volume-high"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_volume"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current sound machine volume (0-100 scale)."""
+        if self.coordinator.data is None:
+            return None
+        vol = self.coordinator.data.volume
+        if vol is None:
+            return None
+        return round(vol * 100, 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the sound machine volume via local WebSocket."""
+        try:
+            await self.coordinator.sound_light.async_set_volume(value / 100.0)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to set sound machine volume: %s", err)

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -8,9 +8,8 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .aionanit_sl.exceptions import NanitTransportError
-
 from . import NanitConfigEntry
+from .aionanit_sl.exceptions import NanitTransportError
 from .const import DEFAULT_SOUND_MACHINE_SOUNDS
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
@@ -51,10 +50,7 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return available sound options from device state."""
-        if (
-            self.coordinator.data is not None
-            and self.coordinator.data.available_tracks
-        ):
+        if self.coordinator.data is not None and self.coordinator.data.available_tracks:
             return list(self.coordinator.data.available_tracks)
         return [s.replace("_", " ").title() for s in DEFAULT_SOUND_MACHINE_SOUNDS]
 

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -63,7 +63,8 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
         """Return the currently selected sound track."""
         if self.coordinator.data is None:
             return None
-        return self.coordinator.data.current_track
+        result: str | None = self.coordinator.data.current_track
+        return result
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected sound track via local WebSocket."""

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .aionanit_sl.exceptions import NanitTransportError
 
 from . import NanitConfigEntry
-from .const import CONF_CAMERA_UID, DEFAULT_SOUND_MACHINE_SOUNDS
+from .const import DEFAULT_SOUND_MACHINE_SOUNDS
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -24,11 +24,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Nanit Sound & Light Machine sound selector."""
-    coordinator = entry.runtime_data.sound_light_coordinator
-    if coordinator is None:
-        return
+    entities: list[SelectEntity] = []
+    for cam_data in entry.runtime_data.cameras.values():
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSoundSelect(sl_coordinator))
 
-    async_add_entities([NanitSoundSelect(coordinator, entry)])
+    async_add_entities(entities)
 
 
 class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
@@ -40,15 +42,11 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
     def __init__(
         self,
         coordinator: NanitSoundLightCoordinator,
-        entry: NanitConfigEntry,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._entry = entry
-        self._attr_unique_id = (
-            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
-            "_sound_machine_sound"
-        )
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_sound"
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -1,0 +1,75 @@
+"""Select platform for the Nanit Sound & Light Machine — sound track selection."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .aionanit_sl.exceptions import NanitTransportError
+
+from . import NanitConfigEntry
+from .const import CONF_CAMERA_UID, DEFAULT_SOUND_MACHINE_SOUNDS
+from .coordinator import NanitSoundLightCoordinator
+from .entity import NanitSoundLightEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NanitConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Nanit Sound & Light Machine sound selector."""
+    coordinator = entry.runtime_data.sound_light_coordinator
+    if coordinator is None:
+        return
+
+    async_add_entities([NanitSoundSelect(coordinator, entry)])
+
+
+class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
+    """Select entity to choose which sound the Sound & Light Machine plays."""
+
+    _attr_translation_key = "sound_machine_sound"
+    _attr_icon = "mdi:playlist-music"
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+        entry: NanitConfigEntry,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = (
+            f"{entry.data.get(CONF_CAMERA_UID, entry.entry_id)}"
+            "_sound_machine_sound"
+        )
+
+    @property
+    def options(self) -> list[str]:
+        """Return available sound options from device state."""
+        if (
+            self.coordinator.data is not None
+            and self.coordinator.data.available_tracks
+        ):
+            return list(self.coordinator.data.available_tracks)
+        return [s.replace("_", " ").title() for s in DEFAULT_SOUND_MACHINE_SOUNDS]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected sound track."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.current_track
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected sound track via local WebSocket."""
+        try:
+            await self.coordinator.sound_light.async_set_track(option)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to set sound to %s: %s", option, err)

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import EntityCategory, LIGHT_LUX, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -76,7 +76,9 @@ SL_SENSORS: tuple[NanitSLSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=True,
         suggested_display_precision=1,
-        value_fn=lambda state: round(state.temperature_c, 2) if state.temperature_c is not None else None,
+        value_fn=lambda state: (
+            round(state.temperature_c, 2) if state.temperature_c is not None else None
+        ),
     ),
     NanitSLSensorEntityDescription(
         key="sl_humidity",
@@ -86,7 +88,9 @@ SL_SENSORS: tuple[NanitSLSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=True,
         suggested_display_precision=1,
-        value_fn=lambda state: round(state.humidity_pct, 2) if state.humidity_pct is not None else None,
+        value_fn=lambda state: (
+            round(state.humidity_pct, 2) if state.humidity_pct is not None else None
+        ),
     ),
 )
 
@@ -165,7 +169,7 @@ class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_translation_key = "sl_connection_mode"
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = ["local", "cloud", "unavailable"]
+    _attr_options = ["local", "cloud", "unavailable"]  # noqa: RUF012
 
     def __init__(
         self,
@@ -179,10 +183,7 @@ class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Always available so it can report the unavailable connection state."""
-        return (
-            self.coordinator.last_update_success
-            and self.coordinator.data is not None
-        )
+        return self.coordinator.last_update_success and self.coordinator.data is not None
 
     @property
     def native_value(self) -> str:

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -105,8 +105,8 @@ async def async_setup_entry(
         # Sound & Light Machine sensors (optional)
         sl_coordinator = cam_data.sound_light_coordinator
         if sl_coordinator is not None:
-            for description in SL_SENSORS:
-                entities.append(NanitSLSensor(sl_coordinator, description))
+            for sl_description in SL_SENSORS:
+                entities.append(NanitSLSensor(sl_coordinator, sl_description))
             entities.append(NanitSLConnectionModeSensor(sl_coordinator))
 
     async_add_entities(entities)
@@ -187,4 +187,5 @@ class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the current connection mode."""
-        return self.coordinator.sound_light.connection_mode
+        result: str = self.coordinator.sound_light.connection_mode
+        return result

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import EntityCategory, LIGHT_LUX, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -107,6 +107,7 @@ async def async_setup_entry(
         if sl_coordinator is not None:
             for description in SL_SENSORS:
                 entities.append(NanitSLSensor(sl_coordinator, description))
+            entities.append(NanitSLConnectionModeSensor(sl_coordinator))
 
     async_add_entities(entities)
 
@@ -156,3 +157,34 @@ class NanitSLSensor(NanitSoundLightEntity, SensorEntity):
         if self.coordinator.data is None:
             return None
         return self.entity_description.value_fn(self.coordinator.data)
+
+
+class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
+    """Diagnostic sensor showing S&L connection type: local, cloud, or unavailable."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "sl_connection_mode"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["local", "cloud", "unavailable"]
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sl_connection_mode"
+
+    @property
+    def available(self) -> bool:
+        """Always available so it can report the unavailable connection state."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the current connection mode."""
+        return self.coordinator.sound_light.connection_mode

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -18,8 +18,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from aionanit.models import CameraState
 
 from . import NanitConfigEntry
-from .coordinator import NanitPushCoordinator
-from .entity import NanitEntity
+from .aionanit_sl.models import SoundLightFullState
+from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
+from .entity import NanitEntity, NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
@@ -29,6 +30,13 @@ class NanitSensorEntityDescription(SensorEntityDescription):
     """Description for Nanit sensor."""
 
     value_fn: Callable[[CameraState], float | int | None]
+
+
+@dataclass(frozen=True, kw_only=True)
+class NanitSLSensorEntityDescription(SensorEntityDescription):
+    """Description for Nanit Sound & Light sensor."""
+
+    value_fn: Callable[[SoundLightFullState], float | int | None]
 
 
 SENSORS: tuple[NanitSensorEntityDescription, ...] = (
@@ -59,6 +67,29 @@ SENSORS: tuple[NanitSensorEntityDescription, ...] = (
     ),
 )
 
+SL_SENSORS: tuple[NanitSLSensorEntityDescription, ...] = (
+    NanitSLSensorEntityDescription(
+        key="sl_temperature",
+        translation_key="sl_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=True,
+        suggested_display_precision=1,
+        value_fn=lambda state: round(state.temperature_c, 2) if state.temperature_c is not None else None,
+    ),
+    NanitSLSensorEntityDescription(
+        key="sl_humidity",
+        translation_key="sl_humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=True,
+        suggested_display_precision=1,
+        value_fn=lambda state: round(state.humidity_pct, 2) if state.humidity_pct is not None else None,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -66,10 +97,17 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Nanit sensors for all cameras on the account."""
-    entities: list[NanitSensor] = []
+    entities: list[SensorEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
         for description in SENSORS:
             entities.append(NanitSensor(cam_data.push_coordinator, description))
+
+        # Sound & Light Machine sensors (optional)
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            for description in SL_SENSORS:
+                entities.append(NanitSLSensor(sl_coordinator, description))
+
     async_add_entities(entities)
 
 
@@ -87,6 +125,30 @@ class NanitSensor(NanitEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.camera.uid}_{description.key}"
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the state of the sensor."""
+        if self.coordinator.data is None:
+            return None
+        return self.entity_description.value_fn(self.coordinator.data)
+
+
+class NanitSLSensor(NanitSoundLightEntity, SensorEntity):
+    """Nanit Sound & Light Machine Sensor (temperature, humidity)."""
+
+    entity_description: NanitSLSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+        description: NanitSLSensorEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_{description.key}"
 
     @property
     def native_value(self) -> float | int | None:

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -87,7 +87,15 @@
       "humidity": { "name": "Humidity" },
       "light": { "name": "Light Level" },
       "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" }
+      "sl_humidity": { "name": "Humidity" },
+      "sl_connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud",
+          "unavailable": "Unavailable"
+        }
+      }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -55,10 +55,11 @@
         }
       },
       "camera_ip": {
-        "title": "Camera IP for {camera_name}",
-        "description": "Enter the local IP address for **{camera_name}** for local-first connectivity. Leave blank to use cloud only.",
+        "title": "Device IPs for {camera_name}",
+        "description": "Enter local IP addresses for **{camera_name}** for local-first connectivity. Leave blank to use cloud only.",
         "data": {
-          "camera_ip": "Camera IP Address"
+          "camera_ip": "Camera IP Address",
+          "speaker_ip": "Sound & Light Machine IP Address"
         }
       }
     }
@@ -84,19 +85,31 @@
     "sensor": {
       "temperature": { "name": "Temperature" },
       "humidity": { "name": "Humidity" },
-      "light": { "name": "Light Level" }
+      "light": { "name": "Light Level" },
+      "sl_temperature": { "name": "Temperature" },
+      "sl_humidity": { "name": "Humidity" }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },
       "sound": { "name": "Sound" },
-      "connectivity": { "name": "Connectivity" }
+      "connectivity": { "name": "Connectivity" },
+      "sl_connectivity": { "name": "Connectivity" }
     },
     "switch": {
       "night_light": { "name": "Night Light" },
-      "camera_power": { "name": "Camera Power" }
+      "camera_power": { "name": "Camera Power" },
+      "sound_machine_switch": { "name": "Power" },
+      "sl_sound_switch": { "name": "Sound" }
     },
     "number": {
-      "volume": { "name": "Volume" }
+      "volume": { "name": "Volume" },
+      "sound_machine_volume": { "name": "Volume" }
+    },
+    "light": {
+      "sound_light_light": { "name": "Light" }
+    },
+    "select": {
+      "sound_machine_sound": { "name": "Sound Track" }
     },
     "camera": {
       "camera": { "name": "Camera" }

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -231,7 +231,8 @@ class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
         """Return True if the device is powered on."""
         if self.coordinator.data is None:
             return None
-        return self.coordinator.data.power_on
+        result: bool | None = self.coordinator.data.power_on
+        return result
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
@@ -269,7 +270,8 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
         """Return True if sound is on."""
         if self.coordinator.data is None:
             return None
-        return self.coordinator.data.sound_on
+        result: bool | None = self.coordinator.data.sound_on
+        return result
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn sound on."""

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -18,8 +18,9 @@ from aionanit import NanitCamera
 from aionanit.models import CameraState, NightLightState
 
 from . import NanitConfigEntry
-from .coordinator import NanitPushCoordinator
-from .entity import NanitEntity
+from .aionanit_sl.exceptions import NanitTransportError
+from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
+from .entity import NanitEntity, NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
@@ -81,10 +82,17 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Nanit switches for all cameras on the account."""
-    entities: list[NanitSwitch] = []
+    entities: list[SwitchEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
         for description in SWITCHES:
             entities.append(NanitSwitch(cam_data.push_coordinator, cam_data.camera, description))
+
+        # Sound & Light Machine switches (optional)
+        sl_coordinator = cam_data.sound_light_coordinator
+        if sl_coordinator is not None:
+            entities.append(NanitSLPowerSwitch(sl_coordinator))
+            entities.append(NanitSLSoundSwitch(sl_coordinator))
+
     async_add_entities(entities)
 
 
@@ -197,3 +205,82 @@ class NanitSwitch(NanitEntity, RestoreEntity, SwitchEntity):
             self._command_state = None
             self.async_write_ha_state()
             raise
+
+
+# --- Sound & Light Machine switches ---
+
+
+class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
+    """Power switch for the Nanit Sound & Light Machine."""
+
+    _attr_translation_key = "sound_machine_switch"
+    _attr_icon = "mdi:power"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_switch"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the device is powered on."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.power_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        try:
+            await self.coordinator.sound_light.async_set_power(True)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to turn on S&L device: %s", err)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        try:
+            await self.coordinator.sound_light.async_set_power(False)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to turn off S&L device: %s", err)
+
+
+class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
+    """Sound on/off switch for the Nanit Sound & Light Machine."""
+
+    _attr_translation_key = "sl_sound_switch"
+    _attr_icon = "mdi:music-note"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        baby = coordinator.baby
+        self._attr_unique_id = f"{baby.camera_uid}_sl_sound_switch"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if sound is on."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.sound_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn sound on."""
+        try:
+            await self.coordinator.sound_light.async_set_sound_on(True)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to turn on S&L sound: %s", err)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn sound off."""
+        try:
+            await self.coordinator.sound_light.async_set_sound_on(False)
+        except NanitTransportError as err:
+            _LOGGER.error("Failed to turn off S&L sound: %s", err)

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -87,7 +87,15 @@
       "humidity": { "name": "Humidity" },
       "light": { "name": "Light Level" },
       "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" }
+      "sl_humidity": { "name": "Humidity" },
+      "sl_connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "local": "Local",
+          "cloud": "Cloud",
+          "unavailable": "Unavailable"
+        }
+      }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -55,10 +55,11 @@
         }
       },
       "camera_ip": {
-        "title": "Camera IP for {camera_name}",
-        "description": "Enter the local IP address for **{camera_name}** for local-first connectivity. Leave blank to use cloud only.",
+        "title": "Device IPs for {camera_name}",
+        "description": "Enter local IP addresses for **{camera_name}** for local-first connectivity. Leave blank to use cloud only.",
         "data": {
-          "camera_ip": "Camera IP Address"
+          "camera_ip": "Camera IP Address",
+          "speaker_ip": "Sound & Light Machine IP Address"
         }
       }
     }
@@ -84,19 +85,31 @@
     "sensor": {
       "temperature": { "name": "Temperature" },
       "humidity": { "name": "Humidity" },
-      "light": { "name": "Light Level" }
+      "light": { "name": "Light Level" },
+      "sl_temperature": { "name": "Temperature" },
+      "sl_humidity": { "name": "Humidity" }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },
       "sound": { "name": "Sound" },
-      "connectivity": { "name": "Connectivity" }
+      "connectivity": { "name": "Connectivity" },
+      "sl_connectivity": { "name": "Connectivity" }
     },
     "switch": {
       "night_light": { "name": "Night Light" },
-      "camera_power": { "name": "Camera Power" }
+      "camera_power": { "name": "Camera Power" },
+      "sound_machine_switch": { "name": "Power" },
+      "sl_sound_switch": { "name": "Sound" }
     },
     "number": {
-      "volume": { "name": "Volume" }
+      "volume": { "name": "Volume" },
+      "sound_machine_volume": { "name": "Volume" }
+    },
+    "light": {
+      "sound_light_light": { "name": "Light" }
+    },
+    "select": {
+      "sound_machine_sound": { "name": "Sound Track" }
     },
     "camera": {
       "camera": { "name": "Camera" }

--- a/packages/aionanit/aionanit/client.py
+++ b/packages/aionanit/aionanit/client.py
@@ -45,6 +45,11 @@ class NanitClient:
         """Return the underlying REST client."""
         return self._rest
 
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        """Return the underlying aiohttp session."""
+        return self._session
+
     # ------------------------------------------------------------------
     # Auth
     # ------------------------------------------------------------------

--- a/packages/aionanit/aionanit/models.py
+++ b/packages/aionanit/aionanit/models.py
@@ -118,6 +118,7 @@ class Baby:
     uid: str
     name: str
     camera_uid: str
+    speaker_uid: str | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/aionanit/aionanit/proto/nanit_pb2.pyi
+++ b/packages/aionanit/aionanit/proto/nanit_pb2.pyi
@@ -1,0 +1,197 @@
+"""Type stubs for generated protobuf module (nanit_pb2).
+
+Auto-generated stubs — DO NOT EDIT by hand.
+Regenerate via: scripts/generate_proto.py or mypy-protobuf.
+"""
+
+import google.protobuf.message
+
+class Control(google.protobuf.message.Message):
+    LIGHT_OFF: int
+    LIGHT_ON: int
+    class SensorDataTransfer(google.protobuf.message.Message): ...
+    night_light: int
+    sensor_data_transfer: Control.SensorDataTransfer
+    force_connect_to_server: bool
+    night_light_timeout: int
+
+class GetControl(google.protobuf.message.Message):
+    ptz: bool
+    night_light: bool
+    night_light_timeout: bool
+    sensor_data_transfer_en: bool
+
+class GetLogs(google.protobuf.message.Message):
+    url: str
+
+class GetSensorData(google.protobuf.message.Message):
+    all: bool
+    temperature: bool
+    humidity: bool
+    light: bool
+    night: bool
+
+class GetStatus(google.protobuf.message.Message):
+    all: bool
+
+class Message(google.protobuf.message.Message):
+    KEEPALIVE: int
+    REQUEST: int
+    RESPONSE: int
+    type: int
+    request: Request
+    response: Response
+    @classmethod
+    def FromString(cls, s: bytes) -> Message: ...
+
+class MountingMode(google.protobuf.message.Message): ...
+
+class Playback(google.protobuf.message.Message):
+    STARTED: int
+    STOPPED: int
+    status: int
+
+class Request(google.protobuf.message.Message):
+    id: int
+    type: int
+    streaming: Streaming
+    settings: Settings
+    status: Status
+    get_status: GetStatus
+    get_sensor_data: GetSensorData
+    sensor_data: SensorData
+    control: Control
+    playback: Playback
+    get_control: GetControl
+    get_logs: GetLogs
+
+class RequestType:
+    PUT_STREAMING: int
+    GET_STREAMING: int
+    GET_SETTINGS: int
+    PUT_SETTINGS: int
+    GET_CONTROL: int
+    PUT_CONTROL: int
+    GET_STATUS: int
+    PUT_STATUS: int
+    PUT_SENSOR_DATA: int
+    GET_SENSOR_DATA: int
+    GET_UCTOKENS: int
+    PUT_UCTOKENS: int
+    PUT_SETUP_NETWORK: int
+    PUT_SETUP_SERVER: int
+    GET_FIRMWARE: int
+    PUT_FIRMWARE: int
+    GET_PLAYBACK: int
+    PUT_PLAYBACK: int
+    GET_SOUNDTRACKS: int
+    GET_STATUS_NETWORK: int
+    GET_LIST_NETWORKS: int
+    GET_LOGS: int
+    GET_BANDWIDTH: int
+    GET_AUDIO_STREAMING: int
+    PUT_AUDIO_STREAMING: int
+    GET_WIFI_SETUP: int
+    PUT_WIFI_SETUP: int
+    PUT_STING_START: int
+    PUT_STING_STOP: int
+    PUT_STING_STATUS: int
+    PUT_STING_ALERT: int
+    PUT_KEEP_ALIVE: int
+    GET_STING_STATUS: int
+    PUT_STING_TEST: int
+    PUT_RTSP_STREAMING: int
+    GET_UOM_URI: int
+    GET_UOM: int
+    PUT_UOM: int
+    GET_AUTH_KEY: int
+    PUT_AUTH_KEY: int
+    PUT_HEALTH: int
+    PUT_TCP_REQUEST: int
+    GET_STING_START: int
+    GET_LOGS_URI: int
+    @staticmethod
+    def Name(number: int) -> str: ...
+    @staticmethod
+    def Value(name: str) -> int: ...
+
+class Response(google.protobuf.message.Message):
+    request_id: int
+    request_type: int
+    status_code: int
+    status_message: str
+    status: Status
+    settings: Settings
+    sensor_data: SensorData
+    control: Control
+
+class SensorData(google.protobuf.message.Message):
+    sensor_type: int
+    value: int
+    is_alert: bool
+    timestamp: int
+    value_milli: int
+
+class SensorType:
+    SOUND: int
+    MOTION: int
+    TEMPERATURE: int
+    HUMIDITY: int
+    LIGHT: int
+    NIGHT: int
+
+class Settings(google.protobuf.message.Message):
+    FR50HZ: int
+    FR60HZ: int
+    ANY: int
+    FR2_4GHZ: int
+    FR5_0GHZ: int
+    class SensorSettings(google.protobuf.message.Message): ...
+    class StreamSettings(google.protobuf.message.Message): ...
+    night_vision: bool
+    sensors: Settings.SensorSettings
+    streams: Settings.StreamSettings
+    volume: int
+    anti_flicker: int
+    sleep_mode: bool
+    status_light_on: bool
+    mounting_mode: int
+    wifi_band: int
+    mic_mute_on: bool
+
+class Status(google.protobuf.message.Message):
+    DISCONNECTED: int
+    CONNECTED: int
+    upgrade_downloaded: bool
+    connection_to_server: int
+    current_version: str
+    mode: int
+    is_security_upgrade: bool
+    downloaded_version: str
+    hardware_version: str
+
+class Stream(google.protobuf.message.Message):
+    LOCAL: int
+    REMOTE: int
+    RTSP: int
+    P2P: int
+    type: int
+    url: str
+    bps: int
+
+class StreamIdentifier:
+    DVR: int
+    ANALYTICS: int
+    MOBILE: int
+    STAND: int
+    TRAVEL: int
+    SWITCH: int
+
+class Streaming(google.protobuf.message.Message):
+    STARTED: int
+    STOPPED: int
+    PAUSED: int
+    id: int
+    status: int
+    rtmp_url: str
+    attempts: int

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -163,11 +163,26 @@ class NanitRestClient:
         access_token: str,
         speaker_uid: str,
     ) -> str:
-        """Get a local device token for a Sound & Light speaker."""
+        """Get a local device token for a Sound & Light speaker.
+
+        Uses GET with NanitLite-style headers — the endpoint rejects POST
+        with HTTP 404.  Returns the RS256 JWT from the
+        ``user_device_token.token`` path in the response body.
+        """
+        # The udtokens endpoint requires NanitLite headers (token prefix,
+        # NanitLite User-Agent) rather than the standard NANIT_API_HEADERS.
+        headers = {
+            "accept": "application/json",
+            "authorization": f"token {access_token}",
+            "accept-charset": "UTF-8",
+            "x-nanit-platform": "homeassistant",
+            "user-agent": ("NanitLite/1.8.0 (com.udisense.nanitlite; build:168; homeassistant)"),
+            "x-nanit-service": "1.8.0 (168)",
+        }
         try:
-            resp = await self._session.post(
+            resp = await self._session.get(
                 f"{self._base_url}/speakers/{speaker_uid}/udtokens",
-                headers={**NANIT_API_HEADERS, "Authorization": access_token},
+                headers=headers,
             )
         except aiohttp.ClientError as err:
             raise NanitConnectionError(str(err)) from err
@@ -176,8 +191,11 @@ class NanitRestClient:
             raise NanitAuthError("Access token invalid")
 
         resp.raise_for_status()
-        body = await resp.json()
-        return body["token"]
+        body = await resp.json(content_type=None)
+        token: str | None = body.get("user_device_token", {}).get("token")
+        if not token:
+            raise NanitConnectionError(f"No token in udtokens response for speaker {speaker_uid}")
+        return token
 
     async def async_get_events(
         self,

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -39,6 +39,16 @@ class NanitRestClient:
         self._session: aiohttp.ClientSession = session
         self._base_url: str = base_url.rstrip("/")
 
+    @property
+    def base_url(self) -> str:
+        """Return the base URL for the Nanit API."""
+        return self._base_url
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        """Return the underlying aiohttp session."""
+        return self._session
+
     async def async_login(
         self,
         email: str,

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -143,9 +143,31 @@ class NanitRestClient:
                 uid=baby["uid"],
                 name=baby["name"],
                 camera_uid=baby["camera_uid"],
+                speaker_uid=baby.get("speaker", {}).get("speaker", {}).get("uid"),
             )
             for baby in body.get("babies", [])
         ]
+
+    async def async_get_device_token(
+        self,
+        access_token: str,
+        speaker_uid: str,
+    ) -> str:
+        """Get a local device token for a Sound & Light speaker."""
+        try:
+            resp = await self._session.post(
+                f"{self._base_url}/speakers/{speaker_uid}/udtokens",
+                headers={**NANIT_API_HEADERS, "Authorization": access_token},
+            )
+        except aiohttp.ClientError as err:
+            raise NanitConnectionError(str(err)) from err
+
+        if resp.status == 401:
+            raise NanitAuthError("Access token invalid")
+
+        resp.raise_for_status()
+        body = await resp.json()
+        return body["token"]
 
     async def async_get_events(
         self,

--- a/packages/aionanit/aionanit/ws/protocol.py
+++ b/packages/aionanit/aionanit/ws/protocol.py
@@ -11,7 +11,6 @@ from aionanit.proto import (
     Message,
     MessageType,
     Request,
-    RequestType,
     Response,
     Settings,
     Streaming,
@@ -42,7 +41,7 @@ def build_keepalive() -> bytes:
 
 def build_request(
     request_id: int,
-    request_type: RequestType,
+    request_type: int,
     *,
     streaming: Streaming | None = None,
     settings: Settings | None = None,

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aionanit"
-version = "1.2.0"
+version = "1.3.0b1"
 description = "Async Python client for Nanit baby cameras"
 readme = "README.md"
 license = "MIT"

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -167,9 +167,7 @@ class TestGetBabies:
         assert babies[0] == Baby(
             uid="baby123", name="Luna", camera_uid="cam456", speaker_uid="spk001"
         )
-        assert babies[1] == Baby(
-            uid="baby789", name="Max", camera_uid="cam012", speaker_uid=None
-        )
+        assert babies[1] == Baby(uid="baby789", name="Max", camera_uid="cam012", speaker_uid=None)
 
     async def test_get_babies_empty(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
@@ -233,23 +231,31 @@ class TestGetEvents:
 class TestGetDeviceToken:
     async def test_get_device_token_success(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
-            m.post(DEVICE_TOKEN_URL, payload={"token": "dev_tok_abc"})
+            m.get(
+                DEVICE_TOKEN_URL,
+                payload={"user_device_token": {"token": "dev_tok_abc"}},
+            )
             token = await client.async_get_device_token("acc123", "spk001")
 
         assert token == "dev_tok_abc"
 
     async def test_get_device_token_unauthorized(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
-            m.post(DEVICE_TOKEN_URL, status=401)
+            m.get(DEVICE_TOKEN_URL, status=401)
 
             with pytest.raises(NanitAuthError, match="Access token invalid"):
                 await client.async_get_device_token("bad_token", "spk001")
 
-    async def test_get_device_token_connection_error(
-        self, client: NanitRestClient
-    ) -> None:
+    async def test_get_device_token_connection_error(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
-            m.post(DEVICE_TOKEN_URL, exception=ClientConnectionError("timeout"))
+            m.get(DEVICE_TOKEN_URL, exception=ClientConnectionError("timeout"))
 
             with pytest.raises(NanitConnectionError):
+                await client.async_get_device_token("acc123", "spk001")
+
+    async def test_get_device_token_empty_response(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(DEVICE_TOKEN_URL, payload={"user_device_token": {}})
+
+            with pytest.raises(NanitConnectionError, match="No token"):
                 await client.async_get_device_token("acc123", "spk001")

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -18,6 +18,7 @@ LOGIN_URL = f"{DEFAULT_BASE_URL}/login"
 REFRESH_URL = f"{DEFAULT_BASE_URL}/tokens/refresh"
 BABIES_URL = f"{DEFAULT_BASE_URL}/babies"
 EVENTS_URL = f"{DEFAULT_BASE_URL}/babies/baby123/messages?limit=20"
+DEVICE_TOKEN_URL = f"{DEFAULT_BASE_URL}/speakers/spk001/udtokens"
 
 
 @pytest.fixture
@@ -150,6 +151,7 @@ class TestGetBabies:
                             "uid": "baby123",
                             "name": "Luna",
                             "camera_uid": "cam456",
+                            "speaker": {"speaker": {"uid": "spk001"}},
                         },
                         {
                             "uid": "baby789",
@@ -162,8 +164,12 @@ class TestGetBabies:
             babies = await client.async_get_babies("token123")
 
         assert len(babies) == 2
-        assert babies[0] == Baby(uid="baby123", name="Luna", camera_uid="cam456")
-        assert babies[1] == Baby(uid="baby789", name="Max", camera_uid="cam012")
+        assert babies[0] == Baby(
+            uid="baby123", name="Luna", camera_uid="cam456", speaker_uid="spk001"
+        )
+        assert babies[1] == Baby(
+            uid="baby789", name="Max", camera_uid="cam012", speaker_uid=None
+        )
 
     async def test_get_babies_empty(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
@@ -222,3 +228,28 @@ class TestGetEvents:
 
             with pytest.raises(NanitConnectionError):
                 await client.async_get_events("token123", "baby123")
+
+
+class TestGetDeviceToken:
+    async def test_get_device_token_success(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(DEVICE_TOKEN_URL, payload={"token": "dev_tok_abc"})
+            token = await client.async_get_device_token("acc123", "spk001")
+
+        assert token == "dev_tok_abc"
+
+    async def test_get_device_token_unauthorized(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(DEVICE_TOKEN_URL, status=401)
+
+            with pytest.raises(NanitAuthError, match="Access token invalid"):
+                await client.async_get_device_token("bad_token", "spk001")
+
+    async def test_get_device_token_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.post(DEVICE_TOKEN_URL, exception=ClientConnectionError("timeout"))
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_get_device_token("acc123", "spk001")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ ignore = [
 "**/proto/*_pb2.pyi" = ["ALL"]
 "packages/aionanit/**" = ["D", "N818", "BLE001", "SIM105", "SIM117", "E402", "RUF059", "C408"]
 "custom_components/nanit/config_flow.py" = ["BLE001"]
+"custom_components/nanit/aionanit_sl/**" = ["BLE001", "D", "SIM105"]
+"tests/unit/test_sl_*" = ["BLE001", "SIM105"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["aionanit", "custom_components.nanit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ ignore = [
 "tests/**" = ["D", "T20", "E402", "SIM117"]
 "tools/**" = ["D", "T20", "SIM117"]
 "**/proto/*_pb2.py" = ["ALL"]
+"**/proto/*_pb2.pyi" = ["ALL"]
 "packages/aionanit/**" = ["D", "N818", "BLE001", "SIM105", "SIM117", "E402", "RUF059", "C408"]
 "custom_components/nanit/config_flow.py" = ["BLE001"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # The aionanit library has its own pyproject.toml in packages/aionanit/.
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]
@@ -43,7 +43,7 @@ ignore = [
 known-first-party = ["aionanit", "custom_components.nanit"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -37,9 +37,7 @@ from custom_components.nanit.coordinator import (
     _AVAILABILITY_GRACE_SECONDS,
     NanitPushCoordinator,
 )
-from custom_components.nanit.light import NanitNightLight
 from custom_components.nanit.number import NanitVolume
-from custom_components.nanit.select import NanitNightLightTimer
 from custom_components.nanit.sensor import SENSORS, NanitSensor
 from custom_components.nanit.switch import SWITCHES, NanitSwitch
 
@@ -259,128 +257,6 @@ async def test_switch_camera_power_turn_off_calls_sleep_mode() -> None:
     assert entity.is_on is False
 
 
-async def test_light_turn_on() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.OFF))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        await entity.async_turn_on()
-
-    camera.async_set_control.assert_awaited_once_with(night_light=NightLightState.ON)
-    assert entity.is_on is True
-
-
-async def test_light_turn_off() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.ON))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        await entity.async_turn_off()
-
-    camera.async_set_control.assert_awaited_once_with(night_light=NightLightState.OFF)
-    assert entity.is_on is False
-
-
-async def test_light_turn_on_with_brightness() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.OFF))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        await entity.async_turn_on(brightness=128)
-
-    camera.async_set_settings.assert_awaited_once_with(night_light_brightness=50)
-    camera.async_set_control.assert_awaited_once_with(night_light=NightLightState.ON)
-    assert entity.brightness == 128
-    assert entity.is_on is True
-
-
-async def test_light_grace_period_suppresses_stale_push_echo() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.OFF))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        await entity.async_turn_on()
-
-    coordinator.data = _camera_state(night_light=NightLightState.OFF)
-    with patch("custom_components.nanit.light.time.monotonic", return_value=101.0):
-        entity._handle_coordinator_update()
-    assert entity.is_on is True
-    assert entity._command_is_on is True
-
-    coordinator.data = _camera_state(night_light=NightLightState.ON)
-    with patch("custom_components.nanit.light.time.monotonic", return_value=102.0):
-        entity._handle_coordinator_update()
-    assert entity.is_on is True
-    assert entity._command_is_on is None
-
-
-async def test_light_grace_period_expires_and_accepts_camera_state() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.OFF))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        await entity.async_turn_on()
-
-    coordinator.data = _camera_state(night_light=NightLightState.OFF)
-    with patch("custom_components.nanit.light.time.monotonic", return_value=116.0):
-        entity._handle_coordinator_update()
-
-    assert entity.is_on is False
-    assert entity._command_is_on is None
-
-
-async def test_light_turn_on_reverts_state_when_command_fails() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.OFF))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock(side_effect=RuntimeError("boom"))
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        with pytest.raises(RuntimeError):
-            await entity.async_turn_on()
-
-    assert entity.is_on is False
-    assert entity._command_is_on is None
-
-
-async def test_light_turn_off_reverts_state_when_command_fails() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light=NightLightState.ON))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock(side_effect=RuntimeError("boom"))
-    camera.async_set_settings = AsyncMock()
-    entity = NanitNightLight(coordinator, camera)
-    _disable_state_writes(entity)
-
-    with patch("custom_components.nanit.light.time.monotonic", return_value=100.0):
-        with pytest.raises(RuntimeError):
-            await entity.async_turn_off()
-
-    assert entity.is_on is True
-    assert entity._command_is_on is None
-
-
 def test_number_native_value_returns_volume() -> None:
     coordinator = _push_coordinator(_camera_state(volume=50))
     camera = MagicMock(uid="cam_1")
@@ -399,50 +275,6 @@ async def test_number_set_native_value_calls_camera_settings() -> None:
     await entity.async_set_native_value(33.7)
 
     camera.async_set_settings.assert_awaited_once_with(volume=33)
-
-
-def test_select_current_option_returns_timer_value() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light_timeout=3600))
-    camera = MagicMock(uid="cam_1")
-    entity = NanitNightLightTimer(coordinator, camera)
-
-    assert entity.current_option == "1_hour"
-
-
-def test_select_current_option_returns_none_when_no_data() -> None:
-    coordinator = _push_coordinator(None)
-    camera = MagicMock(uid="cam_1")
-    entity = NanitNightLightTimer(coordinator, camera)
-
-    assert entity.current_option is None
-
-
-def test_select_none_timeout_maps_to_off() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light_timeout=None))
-    camera = MagicMock(uid="cam_1")
-    entity = NanitNightLightTimer(coordinator, camera)
-
-    assert entity.current_option == "off"
-
-
-def test_select_unknown_timeout_maps_to_off() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light_timeout=9999))
-    camera = MagicMock(uid="cam_1")
-    entity = NanitNightLightTimer(coordinator, camera)
-
-    assert entity.current_option == "off"
-
-
-async def test_select_option_calls_camera_control() -> None:
-    coordinator = _push_coordinator(_camera_state(night_light_timeout=0))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    entity = NanitNightLightTimer(coordinator, camera)
-    _disable_state_writes(entity)
-
-    await entity.async_select_option("30_minutes")
-
-    camera.async_set_control.assert_awaited_once_with(night_light_timeout=1800)
 
 
 async def test_camera_entity_is_on_false_when_sleep_mode_enabled(

--- a/tests/unit/test_sl_coordinator.py
+++ b/tests/unit/test_sl_coordinator.py
@@ -1,0 +1,211 @@
+"""Tests for coordinator.py — NanitSoundLightCoordinator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.nanit.aionanit_sl.models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+)
+from custom_components.nanit.coordinator import NanitSoundLightCoordinator
+from custom_components.nanit.const import DOMAIN
+
+from .conftest import MOCK_EMAIL, mock_entry_data_v2
+
+
+def _make_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _make_mock_sound_light(
+    speaker_uid: str = "L101TEST",
+    connected: bool = False,
+) -> MagicMock:
+    sl = MagicMock()
+    sl.speaker_uid = speaker_uid
+    sl.connected = connected
+    sl.state = SoundLightFullState()
+    sl.subscribe = MagicMock(return_value=lambda: None)
+    sl.async_start = AsyncMock()
+    sl.async_stop = AsyncMock()
+    sl.restore_state = MagicMock()
+    return sl
+
+
+class TestGracePeriod:
+    """Test the 30-second availability grace period."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_starts_grace_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light(connected=True)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        # Simulate initial setup
+        coord._sl_connected = True
+
+        # Simulate disconnect event
+        sl.connected = False
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(event)
+
+        # Should still be "connected" due to grace period
+        assert coord.connected is True
+        assert coord._availability_timer is not None
+
+    @pytest.mark.asyncio
+    async def test_reconnect_cancels_grace_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light(connected=True)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+        coord._sl_connected = True
+
+        # Simulate disconnect
+        sl.connected = False
+        disconnect_event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(disconnect_event)
+        assert coord._availability_timer is not None
+
+        # Simulate reconnect
+        sl.connected = True
+        reconnect_event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(reconnect_event)
+
+        # Timer should be cancelled, still connected
+        assert coord._availability_timer is None
+        assert coord.connected is True
+
+
+class TestDebouncedSave:
+    """Test debounced state persistence."""
+
+    @pytest.mark.asyncio
+    async def test_state_update_schedules_save(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        state = SoundLightFullState(power_on=True, brightness=0.5)
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.STATE_UPDATE,
+            state=state,
+        )
+        coord._on_sl_event(event)
+
+        # Save timer should be running
+        assert coord._save_timer is not None
+        assert coord._pending_save_state is state
+
+    @pytest.mark.asyncio
+    async def test_rapid_updates_only_schedule_one_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        state1 = SoundLightFullState(brightness=0.3)
+        state2 = SoundLightFullState(brightness=0.6)
+        state3 = SoundLightFullState(brightness=0.9)
+
+        for state in (state1, state2, state3):
+            coord._on_sl_event(SoundLightEvent(
+                kind=SoundLightEventKind.STATE_UPDATE,
+                state=state,
+            ))
+
+        # Only the latest state should be pending
+        assert coord._pending_save_state is state3
+        # Timer should be set only once (not reset on each update)
+        assert coord._save_timer is not None
+
+    @pytest.mark.asyncio
+    async def test_connection_change_does_not_schedule_save(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        event = SoundLightEvent(
+            kind=SoundLightEventKind.CONNECTION_CHANGE,
+            state=SoundLightFullState(),
+        )
+        coord._on_sl_event(event)
+
+        assert coord._save_timer is None
+        assert coord._pending_save_state is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_save_timer(self, hass: HomeAssistant) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        # Schedule a save
+        state = SoundLightFullState(power_on=True)
+        coord._on_sl_event(SoundLightEvent(
+            kind=SoundLightEventKind.STATE_UPDATE,
+            state=state,
+        ))
+        assert coord._save_timer is not None
+
+        # Shutdown should cancel timer and clear pending state
+        await coord.async_shutdown()
+        assert coord._save_timer is None
+        assert coord._pending_save_state is None
+
+
+class TestRestoreState:
+    """Test state restoration using public restore_state() method."""
+
+    @pytest.mark.asyncio
+    async def test_setup_calls_restore_state_when_no_initial_state(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        # power_on=None means no initial state received yet
+        sl.state = SoundLightFullState(power_on=None)
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        restored = SoundLightFullState(power_on=True, brightness=0.7)
+        with patch.object(coord, "_async_restore_state", new_callable=AsyncMock, return_value=restored):
+            await coord.async_setup()
+
+        # Should call restore_state (public method) not _state directly
+        sl.restore_state.assert_called_once_with(restored)
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_restore_when_state_exists(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _make_entry(hass)
+        sl = _make_mock_sound_light()
+        sl.state = SoundLightFullState(power_on=True)  # already has state
+        coord = NanitSoundLightCoordinator(hass, entry, sl)
+
+        with patch.object(coord, "_async_restore_state", new_callable=AsyncMock) as mock_restore:
+            await coord.async_setup()
+
+        # Should NOT attempt to restore
+        mock_restore.assert_not_called()
+        sl.restore_state.assert_not_called()

--- a/tests/unit/test_sl_coordinator.py
+++ b/tests/unit/test_sl_coordinator.py
@@ -13,8 +13,8 @@ from custom_components.nanit.aionanit_sl.models import (
     SoundLightEventKind,
     SoundLightFullState,
 )
-from custom_components.nanit.coordinator import NanitSoundLightCoordinator
 from custom_components.nanit.const import DOMAIN
+from custom_components.nanit.coordinator import NanitSoundLightCoordinator
 
 from .conftest import MOCK_EMAIL, mock_entry_data_v2
 
@@ -129,10 +129,12 @@ class TestDebouncedSave:
         state3 = SoundLightFullState(brightness=0.9)
 
         for state in (state1, state2, state3):
-            coord._on_sl_event(SoundLightEvent(
-                kind=SoundLightEventKind.STATE_UPDATE,
-                state=state,
-            ))
+            coord._on_sl_event(
+                SoundLightEvent(
+                    kind=SoundLightEventKind.STATE_UPDATE,
+                    state=state,
+                )
+            )
 
         # Only the latest state should be pending
         assert coord._pending_save_state is state3
@@ -162,10 +164,12 @@ class TestDebouncedSave:
 
         # Schedule a save
         state = SoundLightFullState(power_on=True)
-        coord._on_sl_event(SoundLightEvent(
-            kind=SoundLightEventKind.STATE_UPDATE,
-            state=state,
-        ))
+        coord._on_sl_event(
+            SoundLightEvent(
+                kind=SoundLightEventKind.STATE_UPDATE,
+                state=state,
+            )
+        )
         assert coord._save_timer is not None
 
         # Shutdown should cancel timer and clear pending state
@@ -188,16 +192,16 @@ class TestRestoreState:
         coord = NanitSoundLightCoordinator(hass, entry, sl)
 
         restored = SoundLightFullState(power_on=True, brightness=0.7)
-        with patch.object(coord, "_async_restore_state", new_callable=AsyncMock, return_value=restored):
+        with patch.object(
+            coord, "_async_restore_state", new_callable=AsyncMock, return_value=restored
+        ):
             await coord.async_setup()
 
         # Should call restore_state (public method) not _state directly
         sl.restore_state.assert_called_once_with(restored)
 
     @pytest.mark.asyncio
-    async def test_setup_skips_restore_when_state_exists(
-        self, hass: HomeAssistant
-    ) -> None:
+    async def test_setup_skips_restore_when_state_exists(self, hass: HomeAssistant) -> None:
         entry = _make_entry(hass)
         sl = _make_mock_sound_light()
         sl.state = SoundLightFullState(power_on=True)  # already has state

--- a/tests/unit/test_sl_protocol.py
+++ b/tests/unit/test_sl_protocol.py
@@ -1,0 +1,393 @@
+"""Tests for aionanit_sl/sl_protocol.py — S&L protobuf wire-format decode/encode."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from custom_components.nanit.aionanit_sl.sl_protocol import (
+    SLDecodedState,
+    _encode_fixed32_field,
+    _encode_length_delimited,
+    _encode_varint,
+    _encode_varint_field,
+    build_brightness_cmd,
+    build_color_cmd,
+    build_light_enabled_cmd,
+    build_power_cmd,
+    build_sound_on_cmd,
+    build_track_cmd,
+    build_volume_cmd,
+    classify_message,
+    decode_cloud_relay,
+    decode_fields,
+    decode_full_state,
+    decode_sensors,
+    fixed32_to_float,
+    float_to_fixed32,
+    is_cloud_relay_ack,
+    is_cloud_relay_error,
+    is_cloud_relay_forbidden,
+    FIXED32,
+    LENGTH_DELIMITED,
+    VARINT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build raw protobuf bytes for test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cloud_relay_status(status_code: int, body: bytes = b"") -> bytes:
+    """Build a cloud relay envelope: field 2 { field 2: status, [field 4: body] }."""
+    inner = _encode_varint_field(2, status_code)
+    if body:
+        inner += _encode_length_delimited(4, body)
+    return _encode_length_delimited(2, inner)
+
+
+def _make_cloud_relay_ack() -> bytes:
+    """Build a cloud relay ack: field 3 { field 1 { field 1: 1 } }."""
+    inner_inner = _encode_varint_field(1, 1)
+    inner = _encode_length_delimited(1, inner_inner)
+    return _encode_length_delimited(3, inner)
+
+
+def _make_state_fields(
+    brightness: float | None = None,
+    power_on: bool | None = None,
+    volume: float | None = None,
+    temperature_c: float | None = None,
+    humidity_pct: float | None = None,
+    light_enabled: bool | None = None,
+    sound_on: bool | None = None,
+    track_name: str | None = None,
+) -> bytes:
+    """Build raw state field bytes (the contents of field 1.6 or cloud field 2.4)."""
+    result = b""
+    if brightness is not None:
+        result += _encode_fixed32_field(1, float_to_fixed32(brightness))
+    if light_enabled is not None:
+        # INVERTED: True → 0, False → 1
+        sub = _encode_varint_field(1, 0 if light_enabled else 1)
+        result += _encode_length_delimited(2, sub)
+    if volume is not None:
+        result += _encode_fixed32_field(3, float_to_fixed32(volume))
+    if sound_on is not None or track_name is not None:
+        sub = b""
+        if sound_on is not None:
+            sub += _encode_varint_field(1, 0 if sound_on else 1)
+        if track_name is not None:
+            sub += _encode_length_delimited(2, track_name.encode("utf-8"))
+        result += _encode_length_delimited(4, sub)
+    if power_on is not None:
+        result += _encode_varint_field(5, 1 if power_on else 0)
+    if temperature_c is not None:
+        result += _encode_fixed32_field(7, float_to_fixed32(temperature_c))
+    if humidity_pct is not None:
+        result += _encode_fixed32_field(8, float_to_fixed32(humidity_pct))
+    return result
+
+
+def _make_local_state_message(state_bytes: bytes) -> bytes:
+    """Wrap state bytes in local envelope: field 1 { field 6 { state_bytes } }."""
+    field_6 = _encode_length_delimited(6, state_bytes)
+    return _encode_length_delimited(1, field_6)
+
+
+def _make_cloud_state_message(state_bytes: bytes) -> bytes:
+    """Wrap state bytes in cloud relay envelope: field 2 { 2: 200, 4: { state } }."""
+    return _make_cloud_relay_status(200, body=state_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Tests — Cloud relay message classifiers
+# ---------------------------------------------------------------------------
+
+
+class TestIsCloudRelayForbidden:
+    def test_returns_true_for_403(self) -> None:
+        msg = _make_cloud_relay_status(403)
+        assert is_cloud_relay_forbidden(msg) is True
+
+    def test_returns_false_for_200(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_forbidden(msg) is False
+
+    def test_returns_false_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert is_cloud_relay_forbidden(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_forbidden(b"") is False
+
+    def test_returns_false_for_garbage(self) -> None:
+        assert is_cloud_relay_forbidden(b"\xff\xff\xff") is False
+
+
+class TestIsCloudRelayError:
+    def test_returns_true_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert is_cloud_relay_error(msg) is True
+
+    def test_returns_true_for_500(self) -> None:
+        msg = _make_cloud_relay_status(500)
+        assert is_cloud_relay_error(msg) is True
+
+    def test_returns_false_for_200(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_error(msg) is False
+
+    def test_returns_false_for_403(self) -> None:
+        # 403 is handled separately by is_cloud_relay_forbidden
+        msg = _make_cloud_relay_status(403)
+        assert is_cloud_relay_error(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_error(b"") is False
+
+    def test_returns_false_for_non_field2_envelope(self) -> None:
+        # field 1 envelope instead of field 2
+        msg = _encode_length_delimited(1, _encode_varint_field(2, 400))
+        assert is_cloud_relay_error(msg) is False
+
+    def test_real_400_hex_from_device(self) -> None:
+        """The actual hex captured from the device rejecting a keepalive."""
+        raw = bytes.fromhex("121c1090031a174661696c656420746f2070617273652072657175657374")
+        assert is_cloud_relay_error(raw) is True
+
+
+class TestIsCloudRelayAck:
+    def test_returns_true_for_ack(self) -> None:
+        msg = _make_cloud_relay_ack()
+        assert is_cloud_relay_ack(msg) is True
+
+    def test_returns_false_for_status_message(self) -> None:
+        msg = _make_cloud_relay_status(200)
+        assert is_cloud_relay_ack(msg) is False
+
+    def test_returns_false_for_empty(self) -> None:
+        assert is_cloud_relay_ack(b"") is False
+
+    def test_real_ack_hex(self) -> None:
+        """Known ack hex signature."""
+        raw = bytes.fromhex("1a040a020801")
+        assert is_cloud_relay_ack(raw) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — State decoding
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeFullState:
+    def test_decodes_brightness_and_power(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.75, power_on=True)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.power_on is True
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.75) < 0.01
+
+    def test_decodes_volume(self) -> None:
+        state_bytes = _make_state_fields(volume=0.6)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.volume is not None
+        assert abs(result.volume - 0.6) < 0.01
+
+    def test_decodes_temp_and_humidity(self) -> None:
+        state_bytes = _make_state_fields(temperature_c=22.5, humidity_pct=45.0)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.temperature_c is not None
+        assert abs(result.temperature_c - 22.5) < 0.1
+        assert result.humidity_pct is not None
+        assert abs(result.humidity_pct - 45.0) < 0.1
+
+    def test_decodes_inverted_light_enabled(self) -> None:
+        state_bytes = _make_state_fields(light_enabled=True)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.light_enabled is True
+
+    def test_decodes_inverted_light_disabled(self) -> None:
+        state_bytes = _make_state_fields(light_enabled=False)
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.light_enabled is False
+
+    def test_decodes_sound_on_with_track(self) -> None:
+        state_bytes = _make_state_fields(sound_on=True, track_name="White Noise")
+        msg = _make_local_state_message(state_bytes)
+        result = decode_full_state(msg)
+        assert result is not None
+        assert result.sound_on is True
+        assert result.current_track == "White Noise"
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_full_state(b"") is None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert decode_full_state(b"\xff\xff\xff") is None
+
+
+class TestDecodeCloudRelay:
+    def test_decodes_200_state(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.5, power_on=True)
+        msg = _make_cloud_state_message(state_bytes)
+        result = decode_cloud_relay(msg)
+        assert result is not None
+        assert result.power_on is True
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.5) < 0.01
+
+    def test_returns_none_for_403(self) -> None:
+        msg = _make_cloud_relay_status(403)
+        assert decode_cloud_relay(msg) is None
+
+    def test_returns_none_for_400(self) -> None:
+        msg = _make_cloud_relay_status(400)
+        assert decode_cloud_relay(msg) is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_cloud_relay(b"") is None
+
+
+class TestDecodeSensors:
+    def test_decodes_temp_and_humidity(self) -> None:
+        # Build: field 1 { field 1: varint(1), field 10 { 2: temp, 3: hum } }
+        sensor_sub = (
+            _encode_fixed32_field(2, float_to_fixed32(23.5))
+            + _encode_fixed32_field(3, float_to_fixed32(55.0))
+        )
+        inner = _encode_varint_field(1, 1) + _encode_length_delimited(10, sensor_sub)
+        msg = _encode_length_delimited(1, inner)
+        result = decode_sensors(msg)
+        assert result is not None
+        assert result.temperature_c is not None
+        assert abs(result.temperature_c - 23.5) < 0.1
+        assert result.humidity_pct is not None
+        assert abs(result.humidity_pct - 55.0) < 0.1
+
+    def test_returns_none_for_empty(self) -> None:
+        assert decode_sensors(b"") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — Message classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyMessage:
+    def test_state_message_type_0(self) -> None:
+        state_bytes = _make_state_fields(brightness=0.5)
+        msg = _make_local_state_message(state_bytes)
+        assert classify_message(msg) == 0
+
+    def test_sensor_message_type_1(self) -> None:
+        sensor_sub = _encode_fixed32_field(2, float_to_fixed32(22.0))
+        inner = _encode_varint_field(1, 1) + _encode_length_delimited(10, sensor_sub)
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 1
+
+    def test_routine_message_type_2(self) -> None:
+        inner = _encode_varint_field(1, 2) + _encode_length_delimited(6, b"\x00")
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 2
+
+    def test_routine_message_type_3(self) -> None:
+        inner = _encode_varint_field(1, 3) + _encode_length_delimited(6, b"\x00")
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == 3
+
+    def test_network_info_returns_negative_1(self) -> None:
+        """Large varint type indicators (e.g. timestamps) → network info → -1."""
+        inner = _encode_varint_field(1, 999999)
+        msg = _encode_length_delimited(1, inner)
+        assert classify_message(msg) == -1
+
+    def test_empty_returns_none(self) -> None:
+        assert classify_message(b"") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — Command encoding roundtrips
+# ---------------------------------------------------------------------------
+
+
+class TestCommandEncoding:
+    def test_power_on_roundtrip(self) -> None:
+        cmd = build_power_cmd(True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.power_on is True
+
+    def test_power_off_roundtrip(self) -> None:
+        cmd = build_power_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.power_on is False
+
+    def test_brightness_roundtrip(self) -> None:
+        cmd = build_brightness_cmd(0.8)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.brightness is not None
+        assert abs(result.brightness - 0.8) < 0.01
+
+    def test_volume_roundtrip(self) -> None:
+        cmd = build_volume_cmd(0.42)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.volume is not None
+        assert abs(result.volume - 0.42) < 0.01
+
+    def test_light_enabled_roundtrip(self) -> None:
+        cmd = build_light_enabled_cmd(True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is True
+
+    def test_light_disabled_roundtrip(self) -> None:
+        cmd = build_light_enabled_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is False
+
+    def test_sound_on_roundtrip(self) -> None:
+        cmd = build_sound_on_cmd(True, current_track="Rain")
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.sound_on is True
+        assert result.current_track == "Rain"
+
+    def test_sound_off_roundtrip(self) -> None:
+        cmd = build_sound_on_cmd(False)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.sound_on is False
+
+    def test_track_roundtrip(self) -> None:
+        cmd = build_track_cmd("Ocean Waves", sound_on=True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.current_track == "Ocean Waves"
+        assert result.sound_on is True
+
+    def test_color_roundtrip(self) -> None:
+        cmd = build_color_cmd(0.3, 0.7, light_enabled=True)
+        result = decode_full_state(cmd)
+        assert result is not None
+        assert result.light_enabled is True
+        assert result.color_r is not None
+        assert abs(result.color_r - 0.3) < 0.01
+        assert result.color_g is not None
+        assert abs(result.color_g - 0.7) < 0.01

--- a/tests/unit/test_sl_protocol.py
+++ b/tests/unit/test_sl_protocol.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-import struct
-
-import pytest
-
 from custom_components.nanit.aionanit_sl.sl_protocol import (
-    SLDecodedState,
     _encode_fixed32_field,
     _encode_length_delimited,
-    _encode_varint,
     _encode_varint_field,
     build_brightness_cmd,
     build_color_cmd,
@@ -21,19 +15,13 @@ from custom_components.nanit.aionanit_sl.sl_protocol import (
     build_volume_cmd,
     classify_message,
     decode_cloud_relay,
-    decode_fields,
     decode_full_state,
     decode_sensors,
-    fixed32_to_float,
     float_to_fixed32,
     is_cloud_relay_ack,
     is_cloud_relay_error,
     is_cloud_relay_forbidden,
-    FIXED32,
-    LENGTH_DELIMITED,
-    VARINT,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers — build raw protobuf bytes for test fixtures
@@ -264,9 +252,8 @@ class TestDecodeCloudRelay:
 class TestDecodeSensors:
     def test_decodes_temp_and_humidity(self) -> None:
         # Build: field 1 { field 1: varint(1), field 10 { 2: temp, 3: hum } }
-        sensor_sub = (
-            _encode_fixed32_field(2, float_to_fixed32(23.5))
-            + _encode_fixed32_field(3, float_to_fixed32(55.0))
+        sensor_sub = _encode_fixed32_field(2, float_to_fixed32(23.5)) + _encode_fixed32_field(
+            3, float_to_fixed32(55.0)
         )
         inner = _encode_varint_field(1, 1) + _encode_length_delimited(10, sensor_sub)
         msg = _encode_length_delimited(1, inner)

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import ssl
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -144,6 +145,7 @@ class TestReconnectTaskTracking:
     @pytest.mark.asyncio
     async def test_async_stop_cancels_reconnect_task(self) -> None:
         sl = _make_sound_light()
+
         # Create a dummy task
         async def dummy() -> None:
             await asyncio.sleep(100)
@@ -181,10 +183,8 @@ class TestCloudRelayPrefersDefaultTls:
 
         sl._session.ws_connect = AsyncMock(return_value=mock_ws)
 
-        try:
-            await sl._async_connect()
-        except Exception:
-            pass  # May fail on recv_task setup, that's fine
+        with contextlib.suppress(Exception):
+            await sl._async_connect()  # May fail on recv_task setup, that's fine
 
         # Check the ws_connect call — ssl should NOT be the CERT_NONE context
         if sl._session.ws_connect.call_count > 0:
@@ -192,8 +192,7 @@ class TestCloudRelayPrefersDefaultTls:
             # Cloud relay call should not have ssl=<SSLContext> with CERT_NONE
             ssl_arg = call_kwargs.kwargs.get("ssl") if call_kwargs.kwargs else None
             if ssl_arg is not None:
-                assert ssl_arg.verify_mode != ssl.CERT_NONE, \
-                    "Cloud relay must not use CERT_NONE"
+                assert ssl_arg.verify_mode != ssl.CERT_NONE, "Cloud relay must not use CERT_NONE"
 
 
 class TestUseCloudRelayFlag:

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -1,0 +1,206 @@
+"""Tests for aionanit_sl/sound_light.py — NanitSoundLight WebSocket client."""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.nanit.aionanit_sl.models import (
+    SoundLightEvent,
+    SoundLightEventKind,
+    SoundLightFullState,
+)
+from custom_components.nanit.aionanit_sl.sound_light import NanitSoundLight
+
+
+def _make_sound_light(
+    device_ip: str | None = "192.168.1.50",
+    speaker_uid: str = "L101TEST",
+) -> NanitSoundLight:
+    """Create a NanitSoundLight instance with mocked dependencies."""
+    token_manager = MagicMock()
+    token_manager.async_get_access_token = AsyncMock(return_value="mock_access_token")
+
+    rest_client = MagicMock()
+    rest_client.base_url = "https://api.nanit.com"
+
+    session = MagicMock()
+
+    return NanitSoundLight(
+        speaker_uid=speaker_uid,
+        token_manager=token_manager,
+        rest_client=rest_client,
+        session=session,
+        device_ip=device_ip,
+    )
+
+
+class TestProperties:
+    def test_speaker_uid(self) -> None:
+        sl = _make_sound_light(speaker_uid="L101ABC")
+        assert sl.speaker_uid == "L101ABC"
+
+    def test_initial_state(self) -> None:
+        sl = _make_sound_light()
+        assert sl.state == SoundLightFullState()
+
+    def test_initial_connected_false(self) -> None:
+        sl = _make_sound_light()
+        assert sl.connected is False
+
+    def test_connection_mode_unavailable_when_disconnected(self) -> None:
+        sl = _make_sound_light()
+        assert sl.connection_mode == "unavailable"
+
+    def test_connection_mode_local_when_connected_with_ip(self) -> None:
+        sl = _make_sound_light(device_ip="192.168.1.50")
+        sl._connected = True
+        sl._use_cloud_relay = False
+        assert sl.connection_mode == "local"
+
+    def test_connection_mode_cloud_when_connected_without_ip(self) -> None:
+        sl = _make_sound_light(device_ip=None)
+        sl._connected = True
+        sl._use_cloud_relay = True
+        assert sl.connection_mode == "cloud"
+
+
+class TestRestoreState:
+    def test_restore_state_updates_internal_state(self) -> None:
+        sl = _make_sound_light()
+        new_state = SoundLightFullState(power_on=True, brightness=0.5)
+        sl.restore_state(new_state)
+        assert sl.state.power_on is True
+        assert sl.state.brightness == 0.5
+
+    def test_restore_state_replaces_completely(self) -> None:
+        sl = _make_sound_light()
+        sl.restore_state(SoundLightFullState(volume=0.8))
+        sl.restore_state(SoundLightFullState(brightness=0.3))
+        # Second restore should replace, not merge
+        assert sl.state.volume is None
+        assert sl.state.brightness == 0.3
+
+
+class TestSubscription:
+    def test_subscribe_and_fire_event(self) -> None:
+        sl = _make_sound_light()
+        events: list[SoundLightEvent] = []
+        sl.subscribe(events.append)
+        sl._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+        assert len(events) == 1
+        assert events[0].kind == SoundLightEventKind.CONNECTION_CHANGE
+
+    def test_unsubscribe(self) -> None:
+        sl = _make_sound_light()
+        events: list[SoundLightEvent] = []
+        unsub = sl.subscribe(events.append)
+        unsub()
+        sl._fire_event(SoundLightEventKind.CONNECTION_CHANGE)
+        assert len(events) == 0
+
+    def test_subscriber_exception_does_not_propagate(self) -> None:
+        sl = _make_sound_light()
+
+        def bad_callback(event: SoundLightEvent) -> None:
+            raise RuntimeError("boom")
+
+        sl.subscribe(bad_callback)
+        # Should not raise
+        sl._fire_event(SoundLightEventKind.STATE_UPDATE)
+
+
+class TestDualSslContext:
+    """Verify that local and cloud connections use different TLS settings."""
+
+    def test_local_ssl_ctx_uses_cert_none(self) -> None:
+        sl = _make_sound_light(device_ip="192.168.1.50")
+        # Trigger SSL context creation
+        sl._local_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        sl._local_ssl_ctx.check_hostname = False
+        sl._local_ssl_ctx.verify_mode = ssl.CERT_NONE
+        assert sl._local_ssl_ctx.verify_mode == ssl.CERT_NONE
+
+    def test_no_global_ssl_ctx_attribute(self) -> None:
+        """Ensure the old _ssl_ctx attribute no longer exists."""
+        sl = _make_sound_light()
+        assert not hasattr(sl, "_ssl_ctx")
+
+    def test_local_ssl_ctx_initialized_none(self) -> None:
+        sl = _make_sound_light()
+        assert sl._local_ssl_ctx is None
+
+
+class TestReconnectTaskTracking:
+    """Verify reconnect tasks are properly tracked for cleanup."""
+
+    def test_reconnect_task_initialized_none(self) -> None:
+        sl = _make_sound_light()
+        assert sl._reconnect_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_stop_cancels_reconnect_task(self) -> None:
+        sl = _make_sound_light()
+        # Create a dummy task
+        async def dummy() -> None:
+            await asyncio.sleep(100)
+
+        sl._reconnect_task = asyncio.get_running_loop().create_task(dummy())
+        assert not sl._reconnect_task.done()
+
+        await sl.async_stop()
+        assert sl._reconnect_task is None
+
+    @pytest.mark.asyncio
+    async def test_close_ws_cancels_reconnect_task(self) -> None:
+        sl = _make_sound_light()
+
+        async def dummy() -> None:
+            await asyncio.sleep(100)
+
+        sl._reconnect_task = asyncio.get_running_loop().create_task(dummy())
+        await sl._async_close_ws()
+        assert sl._reconnect_task is None
+
+
+class TestCloudRelayPrefersDefaultTls:
+    """Verify that cloud relay connections don't pass the CERT_NONE ssl context."""
+
+    @pytest.mark.asyncio
+    async def test_cloud_relay_no_ssl_param(self) -> None:
+        """When connecting to cloud relay, ws_connect should NOT receive ssl=_local_ssl_ctx."""
+        sl = _make_sound_light(device_ip=None)  # cloud relay only
+        sl._stopped = False
+
+        mock_ws = MagicMock()
+        mock_ws.closed = False
+        mock_ws.__aiter__ = MagicMock(return_value=iter([]))
+
+        sl._session.ws_connect = AsyncMock(return_value=mock_ws)
+
+        try:
+            await sl._async_connect()
+        except Exception:
+            pass  # May fail on recv_task setup, that's fine
+
+        # Check the ws_connect call — ssl should NOT be the CERT_NONE context
+        if sl._session.ws_connect.call_count > 0:
+            call_kwargs = sl._session.ws_connect.call_args
+            # Cloud relay call should not have ssl=<SSLContext> with CERT_NONE
+            ssl_arg = call_kwargs.kwargs.get("ssl") if call_kwargs.kwargs else None
+            if ssl_arg is not None:
+                assert ssl_arg.verify_mode != ssl.CERT_NONE, \
+                    "Cloud relay must not use CERT_NONE"
+
+
+class TestUseCloudRelayFlag:
+    def test_no_ip_sets_cloud_relay_true(self) -> None:
+        sl = _make_sound_light(device_ip=None)
+        assert sl._use_cloud_relay is True
+
+    def test_with_ip_sets_cloud_relay_false(self) -> None:
+        sl = _make_sound_light(device_ip="10.0.0.1")
+        assert sl._use_cloud_relay is False


### PR DESCRIPTION
## Summary

Integrates the Nanit Sound & Light (S&L) Machine as a Home Assistant entity, based on the original contribution from PR #14 (magiesing). All commits are GPG-signed and all CI checks pass locally.

## What's included

### Sound & Light Machine integration (original contributor work)
- **`aionanit_sl/`** — New async S&L client module with WebSocket cloud relay, protobuf protocol handling, and sound/light state management
- **`light.py`** — Repurposed from night light brightness control to S&L Machine light entity (on/off + brightness)
- **`select.py`** — Repurposed from night light timer to S&L sound track selection entity
- **`switch.py`** — Night light moved here as simple on/off toggle (intentional design decision)
- **`entity.py`** — New `NanitSoundLightEntity` base class with `sanitize_name` utility
- **`hub.py`** — S&L coordinator lifecycle management

### Bug fixes
- **Device token endpoint** — Fixed `async_get_device_token()` using POST (HTTP 404) instead of GET with correct NanitLite headers and response parsing (`rest.py`)
- **Python 3.13 target** — Bumped `pyproject.toml` targets to match `homeassistant-stubs` PEP 696 requirements

### Code quality fixes
- **33 mypy errors → 0** across 15+ files (proto `.pyi` stub, type annotations, import fixes)
- **59 ruff lint errors → 0** (import sorting, unused imports, `B904` exception chaining, docstrings, `BLE001`/`RUF012` config)
- **Ruff format** — All files formatted
- **Test updates** — `test_entities.py` updated for entity restructuring, S&L test files cleaned up

### Merge conflict resolution
- Resolved 9 conflicts when merging the S&L feature (built on `rebase/pr-11`) into `main`
- Preserved both the S&L additions and existing `main` patterns

## Supersedes
- PR #14 (original, unsigned commits from fork)
- PR #28 (first signed attempt, CI never triggered)
- PR #29 (CI failed on ruff + test import errors, now fixed)

## Local verification
- `ruff check .` — All checks passed
- `ruff format --check .` — 58 files already formatted
- `mypy` — Success: 0 issues in 34 source files
- Unit tests — 155 passed
- aionanit library tests — 198 passed