### PR TITLE
fix: improve camera stream reliability and add snapshot caching

### DIFF
--- a/custom_components/nanit/camera.py
+++ b/custom_components/nanit/camera.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.core import HomeAssistant
@@ -17,6 +19,11 @@ from .entity import NanitEntity
 PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
+
+_STREAM_START_ATTEMPTS = 3
+_STREAM_RETRY_DELAY = 2.0
+_SNAPSHOT_CACHE_TTL = 60.0
+_SNAPSHOT_PREFETCH_AGE = 30.0
 
 
 async def async_setup_entry(
@@ -49,6 +56,8 @@ class NanitCameraEntity(NanitEntity, Camera):
         self._camera = camera
         self._prev_is_on: bool | None = None
         self._attr_unique_id = f"{camera.uid}_camera"
+        self._cached_snapshot: bytes | None = None
+        self._cached_snapshot_at: float = 0.0
 
     @property
     def is_on(self) -> bool:
@@ -78,51 +87,111 @@ class NanitCameraEntity(NanitEntity, Camera):
             _LOGGER.debug("Invalidating cached stream after power state change")
             self.stream = None
 
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
     async def stream_source(self) -> str | None:
         """Return the RTMPS stream URL.
 
-        The RTMPS URL embeds a fresh access token and can be consumed directly
-        by the HA Stream integration.  PUT_STREAMING is fired in the background
-        so the URL is returned immediately without waiting for the camera ACK.
+        Sends PUT_STREAMING *before* returning the URL so the camera is
+        already pushing to the RTMPS ingest when HA opens the connection.
+        This eliminates the race condition where HA tries to connect before
+        the camera has started streaming.
         """
         if not self.is_on:
             return None
+
+        if not await self._async_start_streaming_safe():
+            return None
+
         try:
-            url: str = await self._camera.async_get_stream_rtmps_url()
+            return await self._camera.async_get_stream_rtmps_url()
         except Exception:  # noqa: BLE001
             _LOGGER.warning("Failed to build RTMPS stream URL", exc_info=True)
             return None
 
-        self.hass.async_create_background_task(
-            self._async_start_streaming_safe(),
-            name=f"nanit_start_streaming_{self._camera.uid}",
-        )
-        return url
+    async def _async_start_streaming_safe(self) -> bool:
+        """Send PUT_STREAMING with retry.  Returns True on success."""
+        for attempt in range(1, _STREAM_START_ATTEMPTS + 1):
+            try:
+                await self._camera.async_start_streaming()
+                return True
+            except Exception:  # noqa: BLE001
+                if attempt < _STREAM_START_ATTEMPTS:
+                    _LOGGER.debug(
+                        "PUT_STREAMING attempt %d/%d failed for camera %s, retrying in %.0fs",
+                        attempt,
+                        _STREAM_START_ATTEMPTS,
+                        self._camera.uid,
+                        _STREAM_RETRY_DELAY,
+                    )
+                    await asyncio.sleep(_STREAM_RETRY_DELAY)
+                else:
+                    _LOGGER.warning(
+                        "PUT_STREAMING failed after %d attempts for camera %s",
+                        _STREAM_START_ATTEMPTS,
+                        self._camera.uid,
+                        exc_info=True,
+                    )
+        return False
 
-    async def _async_start_streaming_safe(self) -> None:
-        """Send PUT_STREAMING, logging failures without raising."""
-        try:
-            await self._camera.async_start_streaming()
-        except Exception:  # noqa: BLE001
-            _LOGGER.warning(
-                "PUT_STREAMING failed for camera %s — the stream may not load. "
-                "Check debug logs for details",
-                self._camera.uid,
-                exc_info=True,
-            )
+    # ------------------------------------------------------------------
+    # Snapshot (with caching)
+    # ------------------------------------------------------------------
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
-        """Return a still image from the camera."""
+        """Return a still image, using a cached snapshot when possible.
+
+        Cache strategy:
+        - Fresh cache (< TTL): return immediately.
+        - Stale cache (> TTL): attempt a fresh fetch; return stale on failure.
+        - No cache: fetch synchronously.
+
+        A background prefetch is scheduled when the cache reaches
+        ``_SNAPSHOT_PREFETCH_AGE`` so subsequent requests hit a warm cache.
+        """
         if not self.is_on:
             return None
+
+        now = time.monotonic()
+        cache_age = now - self._cached_snapshot_at
+
+        if self._cached_snapshot is not None and cache_age < _SNAPSHOT_CACHE_TTL:
+            if cache_age >= _SNAPSHOT_PREFETCH_AGE:
+                self.hass.async_create_background_task(
+                    self._async_refresh_snapshot(),
+                    name=f"nanit_snapshot_refresh_{self._camera.uid}",
+                )
+            return self._cached_snapshot
+
+        fresh = await self._async_fetch_snapshot()
+        if fresh is not None:
+            return fresh
+
+        return self._cached_snapshot
+
+    async def _async_refresh_snapshot(self) -> None:
+        """Background task: update the snapshot cache without blocking callers."""
+        await self._async_fetch_snapshot()
+
+    async def _async_fetch_snapshot(self) -> bytes | None:
+        """Fetch a snapshot from the cloud and update the cache."""
         try:
-            image: bytes | None = await self._camera.async_get_snapshot()
-            return image
+            image = await self._camera.async_get_snapshot()
         except Exception:  # noqa: BLE001
-            _LOGGER.debug("Failed to get camera snapshot", exc_info=True)
+            _LOGGER.debug("Failed to fetch snapshot for %s", self._camera.uid)
             return None
+        if image is not None:
+            self._cached_snapshot = image
+            self._cached_snapshot_at = time.monotonic()
+        return image
+
+    # ------------------------------------------------------------------
+    # On/off
+    # ------------------------------------------------------------------
 
     async def async_turn_on(self) -> None:
         """Turn the camera on (disable sleep/standby mode)."""

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -6,6 +6,7 @@ babies/cameras on the account and creates a camera + coordinators for each.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -140,23 +141,26 @@ class NanitHub:
 
         # Create camera + coordinators for each baby
         failed_cameras: list[str] = []
-        for baby in babies:
-            try:
-                await self._setup_camera(
-                    baby,
-                    camera_ips.get(baby.camera_uid),
-                    speaker_ips.get(baby.camera_uid),
-                    speaker_uid_map.get(baby.camera_uid),
-                )
-            except NanitAuthError:
-                # Auth errors are account-level — propagate immediately
-                raise
-            except (NanitConnectionError, NanitCameraUnavailable) as err:
+        tasks = [
+            self._setup_camera(
+                baby,
+                camera_ips.get(baby.camera_uid),
+                speaker_ips.get(baby.camera_uid),
+                speaker_uid_map.get(baby.camera_uid),
+            )
+            for baby in babies
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for baby, result in zip(babies, results, strict=True):
+            if isinstance(result, NanitAuthError):
+                raise result
+            if isinstance(result, NanitConnectionError | NanitCameraUnavailable):
                 _LOGGER.warning(
                     "Camera %s (%s) failed to connect: %s",
                     baby.name,
                     baby.camera_uid,
-                    err,
+                    result,
                 )
                 failed_cameras.append(sanitize_name(baby.name))
                 ir.async_create_issue(
@@ -169,9 +173,11 @@ class NanitHub:
                     translation_key="camera_connection_failed",
                     translation_placeholders={
                         "camera_name": sanitize_name(baby.name),
-                        "error": str(err),
+                        "error": str(result),
                     },
                 )
+            elif isinstance(result, BaseException):
+                raise result
 
         if not self._camera_data and failed_cameras:
             raise NanitConnectionError(

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -302,15 +302,11 @@ async def test_camera_stream_source_returns_url_when_on() -> None:
     camera.async_get_stream_rtmps_url = AsyncMock(return_value="rtmps://stream-url")
     camera.async_start_streaming = AsyncMock()
     entity = NanitCameraEntity(coordinator, camera)
-    entity.hass = MagicMock()
-    entity.hass.async_create_background_task = MagicMock(
-        side_effect=lambda coro, **kw: coro.close(),
-    )
 
     source = await entity.stream_source()
 
     assert source == "rtmps://stream-url"
-    entity.hass.async_create_background_task.assert_called_once()
+    camera.async_start_streaming.assert_awaited_once()
 
 
 async def test_camera_stream_source_returns_none_when_camera_off() -> None:
@@ -332,13 +328,10 @@ async def test_camera_stream_source_returns_none_when_camera_api_fails() -> None
     camera.async_get_stream_rtmps_url = AsyncMock(side_effect=RuntimeError("offline"))
     camera.async_start_streaming = AsyncMock()
     entity = NanitCameraEntity(coordinator, camera)
-    entity.hass = MagicMock()
-    entity.hass.async_create_background_task = MagicMock()
 
     source = await entity.stream_source()
 
     assert source is None
-    entity.hass.async_create_background_task.assert_not_called()
 
 
 async def test_camera_start_streaming_safe_logs_failure_without_raising() -> None:
@@ -347,9 +340,11 @@ async def test_camera_start_streaming_safe_logs_failure_without_raising() -> Non
     camera.async_start_streaming = AsyncMock(side_effect=RuntimeError("ws closed"))
     entity = NanitCameraEntity(coordinator, camera)
 
-    await entity._async_start_streaming_safe()
+    with patch("custom_components.nanit.camera._STREAM_RETRY_DELAY", 0):
+        result = await entity._async_start_streaming_safe()
 
-    camera.async_start_streaming.assert_awaited_once()
+    assert result is False
+    assert camera.async_start_streaming.await_count == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Race condition fix**: Await `PUT_STREAMING` *before* returning the RTMPS URL so the camera is already pushing when HA opens the connection. Previously the command was fire-and-forget in a background task.
- **Retry logic**: `PUT_STREAMING` now retries 3 times with 2s delay between attempts, returning `None` (no stream) only after all attempts fail.
- **Snapshot caching**: Cache camera snapshots for 60s with background prefetch at 30s. Dashboard thumbnails load instantly instead of hitting the cloud API on every render. Stale cache served as fallback on fetch failure.
- **Parallel camera setup**: `hub.py` sets up cameras concurrently via `asyncio.gather` instead of sequentially, reducing startup time for multi-camera accounts.

## Changed files

| File | Change |
|------|--------|
| `custom_components/nanit/camera.py` | Race condition fix, retry logic, snapshot caching |
| `custom_components/nanit/hub.py` | Parallel camera setup via `asyncio.gather` |
| `tests/unit/test_entities.py` | Updated 3 tests to match new streaming behavior |

## Verification

- `just check` passes: lint, format, mypy, 305 integration tests + 199 library tests
- Coverage: 81% (threshold: 80%)