### PR TITLE
chore: fix release pipeline to work with branch protection

### DIFF
--- a/.github/workflows/auto-beta.yaml
+++ b/.github/workflows/auto-beta.yaml
@@ -21,10 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/project/aionanit/
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -77,7 +73,6 @@ jobs:
           if [ -n "$highest_beta_version" ]; then
             final=$(printf '%s\n%s\n' "$new" "$highest_beta_version" | sort -V | tail -1)
             new="$final"
-            IFS='.' read -r major minor patch <<< "$new"
           fi
 
           beta_num=1
@@ -88,47 +83,16 @@ jobs:
             fi
           done
 
-          semver="${new}-beta.${beta_num}"
-          pep440="${major}.${minor}.${patch}b${beta_num}"
-          tag="v${semver}"
-
-          echo "semver=${semver}" >> "$GITHUB_OUTPUT"
-          echo "pep440=${pep440}" >> "$GITHUB_OUTPUT"
+          tag="v${new}-beta.${beta_num}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "Computed: ${tag} (PEP 440: ${pep440})"
+          echo "Computed: ${tag}"
 
-      - name: Update version files
-        env:
-          SEMVER: ${{ steps.version.outputs.semver }}
-          PEP440: ${{ steps.version.outputs.pep440 }}
-        run: |
-          jq --arg v "$SEMVER" --arg r "aionanit>=$PEP440" \
-            '.version = $v | .requirements = [$r]' \
-            custom_components/nanit/manifest.json > /tmp/manifest.json
-          mv /tmp/manifest.json custom_components/nanit/manifest.json
-
-          sed -i "s/^version = \".*\"/version = \"$PEP440\"/" packages/aionanit/pyproject.toml
-
-      - name: Validate modified files
-        run: |
-          python3 -c "import json; json.load(open('custom_components/nanit/manifest.json'))"
-          python3 -c "
-          import tomllib
-          tomllib.load(open('packages/aionanit/pyproject.toml', 'rb'))
-          "
-          echo "Version files are valid."
-
-      - name: Commit, tag, and push
+      - name: Create tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
-          SEMVER: ${{ steps.version.outputs.semver }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-          git commit -m "chore: bump version to ${SEMVER} [skip ci]"
           git tag "${TAG}"
-          git push && git push --tags
+          git push origin "${TAG}"
 
       - name: Create GitHub pre-release
         env:
@@ -140,18 +104,3 @@ jobs:
             --generate-notes \
             --prerelease \
             --latest=false
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-
-      - name: Build aionanit package
-        run: |
-          pip install build
-          python -m build packages/aionanit
-
-      - name: Publish beta to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: packages/aionanit/dist/
-          skip-existing: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Stable release tag to (re)publish, e.g. v1.4.0"
+        description: "Release tag to (re)publish, e.g. v1.4.1 or v1.4.1-beta.1"
         required: true
         type: string
 
@@ -26,6 +26,8 @@ jobs:
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
       is_stable: ${{ steps.meta.outputs.is_stable }}
+      semver: ${{ steps.meta.outputs.semver }}
+      pep440: ${{ steps.meta.outputs.pep440 }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,8 +39,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="${{ env.TAG }}"
-          is_pre=$(gh release view "${tag}" --json isPrerelease -q .isPrerelease)
+          version="${tag#v}"
+
+          if [[ "$version" == *-beta.* ]]; then
+            base="${version%-beta.*}"
+            beta_num="${version##*-beta.}"
+            pep440="${base}b${beta_num}"
+          else
+            pep440="$version"
+          fi
+
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "semver=${version}" >> "$GITHUB_OUTPUT"
+          echo "pep440=${pep440}" >> "$GITHUB_OUTPUT"
+
+          is_pre=$(gh release view "${tag}" --json isPrerelease -q .isPrerelease)
           if [ "${is_pre}" = "false" ] && [[ "${tag}" == v* ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
@@ -103,6 +118,12 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.tag }}
 
+      - name: Inject version from tag
+        env:
+          PEP440: ${{ needs.resolve.outputs.pep440 }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"$PEP440\"/" packages/aionanit/pyproject.toml
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -134,6 +155,12 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.tag }}
 
+      - name: Inject version from tag
+        env:
+          PEP440: ${{ needs.resolve.outputs.pep440 }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"$PEP440\"/" packages/aionanit/pyproject.toml
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -162,6 +189,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Inject version from tag
+        env:
+          SEMVER: ${{ needs.resolve.outputs.semver }}
+          PEP440: ${{ needs.resolve.outputs.pep440 }}
+        run: |
+          jq --arg v "$SEMVER" --arg r "aionanit>=$PEP440" \
+            '.version = $v | .requirements = [$r]' \
+            custom_components/nanit/manifest.json > /tmp/manifest.json
+          mv /tmp/manifest.json custom_components/nanit/manifest.json
 
       - name: Create integration zip
         run: zip -r nanit.zip custom_components/nanit/

--- a/justfile
+++ b/justfile
@@ -160,18 +160,12 @@ promote version="":
         exit 1
     fi
 
-    # Update version files to stable
-    sed -E -i '' 's/"version": "[^"]+"/"version": "'"${target}"'"/' custom_components/nanit/manifest.json
-    sed -E -i '' 's/^version = "[^"]+"/version = "'"${target}"'"/' packages/aionanit/pyproject.toml
-    sed -E -i '' 's/"aionanit>=[^"]*"/"aionanit>='"${target}"'"/' custom_components/nanit/manifest.json
-
-    git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-    git commit -m "chore: bump version to ${target}"
-    git tag -m "v${target}" "v${target}"
-    git push && git push --tags
+    # Create stable tag at the same commit as the beta
+    git tag -m "v${target}" "v${target}" "${beta_sha}"
+    git push origin "v${target}"
     gh release create "v${target}" --title "v${target}" --generate-notes --latest
     echo ""
-    echo "✅ v${target} released. GitHub Actions will publish to PyPI and attach artifacts."
+    echo "✅ v${target} released. GitHub Actions will run CI, publish to PyPI, and attach artifacts."
 
 release-retry tag="":
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- **auto-beta** was failing because it pushed version bump commits directly to `main`, violating the signed-commit branch protection ruleset (no PR, unsigned commit, no CI checks)
- Redesigned so version is derived from **git tags at build time** — no version files are ever modified on `main`

## Changes

### `auto-beta.yaml`
- Removed: version file updates, validation step, commit/push to main, PyPI build/publish
- Now only: compute version → `git tag` → `git push origin <tag>` → `gh release create --prerelease`
- Tags push to `refs/tags/*` which is NOT covered by branch protection

### `release.yaml`
- Added `semver` and `pep440` outputs to the `resolve` job (computed from tag name)
- Added "Inject version from tag" step to `publish-beta`, `publish-stable`, and `attach-artifact` jobs
- Version injection uses `jq` (manifest.json) and `sed` (pyproject.toml) — in CI workspace only, never committed

### `justfile`
- `promote` recipe: removed sed/git-add/commit/push commands, now only creates stable tag from beta tag and pushes it

## New Flow
```
PR merged (with release:* label)
  → auto-beta: compute version → create tag → push tag → create pre-release
    → release.yaml (triggered by release published)
      → resolve: extract semver/pep440 from tag
      → inject version → build → publish to PyPI

just promote:
  → create stable tag at beta commit → push tag → create release
    → release.yaml fires for stable path
```

## Testing
- `just check` passes: 504 tests (305 integration + 199 library), lint, format, mypy all clean, 81% coverage
- No application code changes — workflow/CI only