### PR TITLE
feat: add optional diagnostic sensors for camera network info

### DIFF
--- a/custom_components/nanit/const.py
+++ b/custom_components/nanit/const.py
@@ -23,6 +23,9 @@ CLOUD_EVENT_WINDOW = 300
 # Cloud event poll interval (seconds)
 CLOUD_POLL_INTERVAL = 30
 
+# Network info poll interval (seconds)
+NETWORK_POLL_INTERVAL = 300
+
 # Config Keys
 CONF_MFA_CODE = "mfa_code"
 CONF_MFA_TOKEN = "mfa_token"

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -30,11 +30,11 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from aionanit import NanitAuthError, NanitCamera, NanitConnectionError
-from aionanit.models import Baby, CameraEvent, CameraState, CloudEvent
+from aionanit.models import Baby, CameraEvent, CameraState, CloudEvent, NetworkInfo
 
 from .aionanit_sl.models import SoundLightEvent, SoundLightEventKind, SoundLightFullState
 from .aionanit_sl.sound_light import NanitSoundLight
-from .const import CLOUD_POLL_INTERVAL, DOMAIN
+from .const import CLOUD_POLL_INTERVAL, DOMAIN, NETWORK_POLL_INTERVAL
 
 if TYPE_CHECKING:
     from . import NanitConfigEntry
@@ -200,6 +200,59 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
                 translation_key="cloud_fetch_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+
+class NanitNetworkCoordinator(DataUpdateCoordinator[NetworkInfo | None]):
+    """Polling coordinator for camera WiFi network diagnostics.
+
+    Polls GET /babies every NETWORK_POLL_INTERVAL seconds and extracts
+    the network info for a single camera.
+    """
+
+    config_entry: NanitConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: NanitConfigEntry,
+        hub: NanitHub,
+        baby: Baby,
+    ) -> None:
+        """Initialize the network coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}_{baby.camera_uid}_network",
+            update_interval=timedelta(seconds=NETWORK_POLL_INTERVAL),
+        )
+        self._hub = hub
+        self.baby = baby
+
+    async def _async_update_data(self) -> NetworkInfo | None:
+        """Fetch network info from the Nanit API."""
+        try:
+            client = self._hub.client
+            assert client.token_manager is not None
+            token = await client.token_manager.async_get_access_token()
+            babies = await client.rest_client.async_get_babies(token)
+        except NanitAuthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        except NanitConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cloud_fetch_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+        for baby in babies:
+            if baby.camera_uid == self.baby.camera_uid:
+                return baby.network
+        return None
 
 
 _SL_STORE_VERSION = 1

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -6,7 +6,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
+from .coordinator import (
+    NanitCloudCoordinator,
+    NanitNetworkCoordinator,
+    NanitPushCoordinator,
+    NanitSoundLightCoordinator,
+)
 from .sanitize import sanitize_name
 
 
@@ -79,3 +84,18 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
         separately by the S&L connectivity binary sensor.
         """
         return self.coordinator.last_update_success and self.coordinator.data is not None
+
+
+class NanitNetworkEntity(CoordinatorEntity[NanitNetworkCoordinator]):
+    """Base entity for network diagnostic sensors — backed by the network coordinator."""
+
+    _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.baby.camera_uid)},
+            name=sanitize_name(self.coordinator.baby.name),
+            manufacturer="Nanit",
+        )

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -28,7 +28,12 @@ from aionanit.models import Baby
 
 from .aionanit_sl.sound_light import NanitSoundLight
 from .const import CONF_CAMERA_IPS, CONF_REFRESH_TOKEN, CONF_SPEAKER_IPS, DOMAIN
-from .coordinator import NanitCloudCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
+from .coordinator import (
+    NanitCloudCoordinator,
+    NanitNetworkCoordinator,
+    NanitPushCoordinator,
+    NanitSoundLightCoordinator,
+)
 from .sanitize import sanitize_name
 
 if TYPE_CHECKING:
@@ -46,6 +51,7 @@ class CameraData:
     push_coordinator: NanitPushCoordinator
     cloud_coordinator: NanitCloudCoordinator | None
     sound_light_coordinator: NanitSoundLightCoordinator | None = None
+    network_coordinator: NanitNetworkCoordinator | None = None
 
 
 class NanitHub:
@@ -252,12 +258,27 @@ class NanitHub:
 
         ir.async_delete_issue(self._hass, DOMAIN, f"camera_connection_failed_{baby.camera_uid}")
 
+        # Network diagnostics coordinator (optional — polls GET /babies for WiFi info)
+        network_coordinator: NanitNetworkCoordinator | None = None
+        try:
+            network_coordinator = NanitNetworkCoordinator(self._hass, self._entry, self, baby)
+            await network_coordinator.async_config_entry_first_refresh()
+        except NanitAuthError:
+            raise
+        except NanitConnectionError:
+            _LOGGER.debug(
+                "Network coordinator for %s failed to start; network sensors disabled",
+                baby.name,
+            )
+            network_coordinator = None
+
         self._camera_data[baby.camera_uid] = CameraData(
             camera=camera,
             baby=baby,
             push_coordinator=push_coordinator,
             cloud_coordinator=cloud_coordinator,
             sound_light_coordinator=sound_light_coordinator,
+            network_coordinator=network_coordinator,
         )
 
     @callback

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -11,16 +11,23 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfTemperature
+from homeassistant.const import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfFrequency,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from aionanit.models import CameraState
+from aionanit.models import CameraState, NetworkInfo
 
 from . import NanitConfigEntry
 from .aionanit_sl.models import SoundLightFullState
-from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
-from .entity import NanitEntity, NanitSoundLightEntity
+from .coordinator import NanitNetworkCoordinator, NanitPushCoordinator, NanitSoundLightCoordinator
+from .entity import NanitEntity, NanitNetworkEntity, NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
@@ -95,6 +102,44 @@ SL_SENSORS: tuple[NanitSLSensorEntityDescription, ...] = (
 )
 
 
+@dataclass(frozen=True, kw_only=True)
+class NanitNetworkSensorDescription(SensorEntityDescription):
+    """Description for network diagnostic sensors."""
+
+    value_fn: Callable[[NetworkInfo], str | int | None]
+
+
+NETWORK_SENSORS: tuple[NanitNetworkSensorDescription, ...] = (
+    NanitNetworkSensorDescription(
+        key="wifi_ssid",
+        translation_key="wifi_ssid",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda net: net.ssid,
+    ),
+    NanitNetworkSensorDescription(
+        key="wifi_signal",
+        translation_key="wifi_signal",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda net: net.signal_dbm,
+    ),
+    NanitNetworkSensorDescription(
+        key="wifi_frequency",
+        translation_key="wifi_frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda net: net.frequency_mhz,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: NanitConfigEntry,
@@ -112,6 +157,12 @@ async def async_setup_entry(
             for sl_description in SL_SENSORS:
                 entities.append(NanitSLSensor(sl_coordinator, sl_description))
             entities.append(NanitSLConnectionModeSensor(sl_coordinator))
+
+        # Network diagnostic sensors (optional)
+        net_coordinator = cam_data.network_coordinator
+        if net_coordinator is not None:
+            for net_description in NETWORK_SENSORS:
+                entities.append(NanitNetworkSensor(net_coordinator, net_description))
 
     async_add_entities(entities)
 
@@ -190,3 +241,26 @@ class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
         """Return the current connection mode."""
         result: str = self.coordinator.sound_light.connection_mode
         return result
+
+
+class NanitNetworkSensor(NanitNetworkEntity, SensorEntity):
+    """Diagnostic sensor for camera WiFi network information."""
+
+    entity_description: NanitNetworkSensorDescription
+
+    def __init__(
+        self,
+        coordinator: NanitNetworkCoordinator,
+        description: NanitNetworkSensorDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.baby.camera_uid}_{description.key}"
+
+    @property
+    def native_value(self) -> str | int | None:
+        """Return the sensor value."""
+        if self.coordinator.data is None:
+            return None
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -100,7 +100,10 @@
           "cloud": "Cloud",
           "unavailable": "Unavailable"
         }
-      }
+      },
+      "wifi_ssid": { "name": "WiFi SSID" },
+      "wifi_signal": { "name": "WiFi Signal Strength" },
+      "wifi_frequency": { "name": "WiFi Frequency" }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -100,7 +100,10 @@
           "cloud": "Cloud",
           "unavailable": "Unavailable"
         }
-      }
+      },
+      "wifi_ssid": { "name": "WiFi SSID" },
+      "wifi_signal": { "name": "WiFi Signal Strength" },
+      "wifi_frequency": { "name": "WiFi Frequency" }
     },
     "binary_sensor": {
       "motion": { "name": "Motion" },

--- a/packages/aionanit/aionanit/__init__.py
+++ b/packages/aionanit/aionanit/__init__.py
@@ -22,6 +22,7 @@ from .models import (
     ConnectionInfo,
     ConnectionState,
     ControlState,
+    NetworkInfo,
     NightLightState,
     SensorReading,
     SensorState,
@@ -57,6 +58,7 @@ __all__ = [
     # rest
     "NanitRestClient",
     "NanitTransportError",
+    "NetworkInfo",
     "NightLightState",
     "SensorReading",
     "SensorState",

--- a/packages/aionanit/aionanit/models.py
+++ b/packages/aionanit/aionanit/models.py
@@ -115,11 +115,21 @@ class CameraEvent:
 
 
 @dataclass(frozen=True)
+class NetworkInfo:
+    """WiFi network information reported by the camera."""
+
+    ssid: str | None = None
+    frequency_mhz: int | None = None  # e.g. 5240
+    signal_dbm: int | None = None  # e.g. -60
+
+
+@dataclass(frozen=True)
 class Baby:
     uid: str
     name: str
     camera_uid: str
     speaker_uid: str | None = None
+    network: NetworkInfo | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -13,7 +13,7 @@ from .exceptions import (
     NanitConnectionError,
     NanitMfaRequiredError,
 )
-from .models import Baby, CloudEvent
+from .models import Baby, CloudEvent, NetworkInfo
 
 DEFAULT_BASE_URL = "https://api.nanit.com"
 _DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=15)
@@ -24,6 +24,22 @@ _HTML_TAG_RE = re.compile(r"<[^>]+>")
 def _sanitize_name(raw: str) -> str:
     stripped = _HTML_TAG_RE.sub("", raw)
     return "".join(ch for ch in stripped if unicodedata.category(ch)[0] != "C").strip()
+
+
+def _parse_network(baby_json: dict[str, Any]) -> NetworkInfo | None:
+    net = (baby_json.get("camera") or {}).get("network")
+    if not isinstance(net, dict):
+        return None
+    ssid = net.get("ssid")
+    freq = net.get("freq")
+    level = net.get("level")
+    if ssid is None and freq is None and level is None:
+        return None
+    return NetworkInfo(
+        ssid=str(ssid) if ssid is not None else None,
+        frequency_mhz=int(freq) if isinstance(freq, int | float) else None,
+        signal_dbm=int(level) if isinstance(level, int | float) else None,
+    )
 
 
 # Headers required by the Nanit API. The API rejects requests without
@@ -166,6 +182,7 @@ class NanitRestClient:
                 name=_sanitize_name(baby["name"]),
                 camera_uid=baby["camera_uid"],
                 speaker_uid=((baby.get("speaker") or {}).get("speaker") or {}).get("uid"),
+                network=_parse_network(baby),
             )
             for baby in body.get("babies", [])
         ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -68,6 +68,7 @@ def mock_nanit_client():
     with (
         patch("custom_components.nanit.hub.NanitClient", autospec=True) as mock_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as mock_cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as mock_net_cls,
     ):
         client = mock_cls.return_value
 
@@ -94,6 +95,7 @@ def mock_nanit_client():
         client.rest_client.async_get_events = AsyncMock(return_value=[])
 
         mock_cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        mock_net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
 
         yield client
 

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -55,9 +55,11 @@ async def test_setup_single_baby(hass: HomeAssistant, mock_nanit_client) -> None
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     assert len(hub.camera_data) == 1
@@ -74,9 +76,11 @@ async def test_setup_multiple_babies(hass: HomeAssistant, mock_nanit_client) -> 
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     assert len(hub.camera_data) == 3
@@ -114,6 +118,7 @@ async def test_setup_partial_failure(hass: HomeAssistant, mock_nanit_client) -> 
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
 
         def push_factory(_hass, _entry, camera, _baby):
@@ -126,6 +131,7 @@ async def test_setup_partial_failure(hass: HomeAssistant, mock_nanit_client) -> 
 
         push_cls.side_effect = push_factory
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     assert len(hub.camera_data) == 1
@@ -157,9 +163,11 @@ async def test_setup_reads_camera_ips_from_options(hass: HomeAssistant, mock_nan
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     mock_nanit_client.camera.assert_called_once_with(
@@ -210,10 +218,12 @@ async def test_successful_camera_setup_deletes_repair_issue(
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
         patch("custom_components.nanit.hub.ir.async_delete_issue") as mock_delete_issue,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     mock_delete_issue.assert_called_once_with(
@@ -228,9 +238,11 @@ async def test_async_close(hass: HomeAssistant, mock_nanit_client) -> None:
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     assert hub.camera_data
@@ -246,9 +258,11 @@ async def test_token_refresh_callback(hass: HomeAssistant, mock_nanit_client) ->
     with (
         patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
         patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
     ):
         push_cls.return_value = MagicMock(async_setup=AsyncMock())
         cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
         await hub.async_setup()
 
     callback = mock_nanit_client.token_manager.on_tokens_refreshed.call_args.args[0]

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -914,6 +914,7 @@ async def test_sensor_async_setup_entry_creates_sl_sensors() -> None:
     cam_data = MagicMock(
         push_coordinator=_push_coordinator(_camera_state()),
         sound_light_coordinator=sl_coordinator,
+        network_coordinator=None,
     )
     entry = MagicMock(runtime_data=MagicMock(cameras={"cam_1": cam_data}))
     async_add_entities = MagicMock()


### PR DESCRIPTION
## Summary

- Add three WiFi diagnostic sensors (SSID, signal strength, frequency) for Nanit cameras, sourced from the `GET /babies` API endpoint's `camera.network` data
- Introduce `NanitNetworkCoordinator` that polls every 5 minutes, following the same pattern as `NanitCloudCoordinator`
- All sensors are `EntityCategory.DIAGNOSTIC` and disabled by default — users opt in via the HA entity registry

## Changes

### aionanit library
- **models.py**: New `NetworkInfo` frozen dataclass (`ssid`, `frequency_mhz`, `signal_dbm`)
- **rest.py**: `_parse_network()` helper extracts `camera.network` from `/babies` JSON; `async_get_babies()` populates `Baby.network`
- **__init__.py**: Export `NetworkInfo`

### HA integration
- **const.py**: `NETWORK_POLL_INTERVAL = 300` (5 min)
- **coordinator.py**: `NanitNetworkCoordinator` — per-camera polling coordinator
- **entity.py**: `NanitNetworkEntity` base class
- **hub.py**: Creates and starts `NanitNetworkCoordinator` per camera in `_setup_camera()`
- **sensor.py**: Three new sensor descriptions (`wifi_ssid`, `wifi_signal`, `wifi_frequency`) + `NanitNetworkSensor` entity class
- **strings.json / translations/en.json**: Translations for new sensors

### Tests
- Updated `conftest.py`, `test_hub.py`, `test_sl_entities.py` to mock `NanitNetworkCoordinator`

Closes #38