### PR TITLE
fix: inject version into manifest.json and pyproject.toml in auto-beta workflow

### DIFF
--- a/.github/workflows/auto-beta.yaml
+++ b/.github/workflows/auto-beta.yaml
@@ -87,10 +87,32 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Computed: ${tag}"
 
-      - name: Create tag
+      - name: Inject version into manifest and pyproject
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
+          version="${TAG#v}"
+          base="${version%-beta.*}"
+          beta_num="${version##*-beta.}"
+          pep440="${base}b${beta_num}"
+
+          # Update manifest.json version + requirements
+          jq --arg v "$version" --arg r "aionanit>=$pep440" \
+            '.version = $v | .requirements = [$r]' \
+            custom_components/nanit/manifest.json > /tmp/manifest.json
+          mv /tmp/manifest.json custom_components/nanit/manifest.json
+
+          # Update pyproject.toml version
+          sed -i "s/^version = \".*\"/version = \"$pep440\"/" packages/aionanit/pyproject.toml
+
+      - name: Create version commit and tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
+          git commit -m "chore: bump version to ${TAG} [skip ci]"
           git tag "${TAG}"
           git push origin "${TAG}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ PR merged to main
   │
   ├─ Reads PR label to determine bump type
   ├─ Computes version + beta number from existing tags
-  ├─ Updates manifest.json + pyproject.toml on main
+  ├─ Updates manifest.json + pyproject.toml in the tagged commit
   ├─ Tags vX.Y.Z-beta.N, creates GitHub pre-release
   └─ Publishes aionanit beta to PyPI
   │


### PR DESCRIPTION
## Summary

- Fix `auto-beta.yaml` to inject version and requirements into `manifest.json` and `pyproject.toml` before creating the tag
- Without this, beta tags had stale `requirements: ["aionanit>=1.4.0"]`, so HA installed the old aionanit from PyPI — missing new exports like `NetworkInfo`
- The fix creates a version-bumped commit and tags it; only the tag is pushed (branch protection prevents direct commits to main)
- Update AGENTS.md to reflect that version files are updated in the tagged commit, not on main

## Root Cause

`auto-beta.yaml` created the tag directly from HEAD without updating version files. The `release.yaml` `publish-beta` job correctly published the new `aionanit` to PyPI, but `manifest.json` in the tag still required the old version (`>=1.4.0`). HA resolved that requirement from PyPI and got the old package.

## Testing

After merging with `release:patch`, auto-beta will create `v1.5.0-beta.2` with:
- `manifest.json`: `version: "1.5.0-beta.2"`, `requirements: ["aionanit>=1.5.0b2"]`
- `pyproject.toml`: `version = "1.5.0b2"`