### PR TITLE
docs: document manual PyPI publish step for beta releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,10 @@ PR merged to main
   ├─ Computes version + beta number from existing tags
   ├─ Updates manifest.json + pyproject.toml in the tagged commit
   ├─ Tags vX.Y.Z-beta.N, creates GitHub pre-release
-  └─ Publishes aionanit beta to PyPI
+  └─ ⚠️  Does NOT auto-trigger release.yaml (GITHUB_TOKEN limitation)
+  │
+  Manually trigger PyPI publish:
+  just release-retry <tag>
   │
   You test on your HA via HACS beta channel
   │
@@ -207,6 +210,8 @@ just promote 1.4.0        # Direct — promotes latest v1.4.0-beta.N to v1.4.0
 **Rollback strategy**: Forward-fix via new PR. Merge the fix → auto-beta creates a new beta → test → promote.
 
 **Pipeline fix**: If the release workflow fails (e.g. action version issues, PyPI errors), fix the pipeline code, push to `main`, then run `just release-retry [tag]`. This re-triggers the workflow using the updated YAML from `main` while building from the original tag. PyPI publish is idempotent (skips already-uploaded versions).
+
+**Beta PyPI publish is manual**: `auto-beta.yaml` uses `GITHUB_TOKEN` to create the GitHub pre-release, which does not trigger `release.yaml` (GitHub Actions limitation — workflows using the default token cannot trigger other workflows). After every beta merge, run `just release-retry <tag>` to publish `aionanit` to PyPI. Without this step, HA cannot install the updated library.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -93,7 +93,7 @@ promote version="":
     target="{{ version }}"
 
     if [ -z "${target}" ]; then
-        # List all pre-releases grouped by base version, let user pick
+        # List all pre-releases, let user pick a specific beta tag
         echo "Fetching pre-releases..."
         releases=$(gh release list --limit 50 --json tagName,isPrerelease,isDraft,publishedAt \
             --jq '[.[] | select(.isPrerelease and (.isDraft | not))]')
@@ -103,44 +103,44 @@ promote version="":
             exit 1
         fi
 
-        # Extract unique base versions, sorted by version descending
-        versions=$(echo "$releases" | jq -r '
-            [.[] | .tagName | ltrimstr("v") | split("-beta.")[0]]
-            | unique
-            | sort_by(split(".") | map(tonumber))
+        # List individual beta tags sorted by version descending
+        tags=$(echo "$releases" | jq -r '
+            [.[] | {tag: .tagName, date: .publishedAt}]
+            | sort_by(.tag | ltrimstr("v") | split("-beta.") | [
+                (.[0] | split(".") | map(tonumber)),
+                (.[1] | tonumber)
+              ])
             | reverse
-            | .[]')
+            | .[]
+            | "\(.tag)\t\(.date)"')
 
         echo ""
-        echo "Available versions to promote:"
+        echo "Available betas to promote:"
         echo "─────────────────────────────"
         i=1
-        version_list=()
-        while IFS= read -r v; do
-            latest_beta=$(echo "$releases" | jq -r --arg v "$v" '
-                [.[] | select(.tagName | startswith("v" + $v + "-beta."))]
-                | sort_by(.tagName | split("-beta.")[1] | tonumber)
-                | last | .tagName')
-            beta_count=$(echo "$releases" | jq --arg v "$v" '
-                [.[] | select(.tagName | startswith("v" + $v + "-beta."))] | length')
-            echo "  ${i}) v${v}  (latest: ${latest_beta}, ${beta_count} beta(s))"
-            version_list+=("$v")
+        tag_list=()
+        while IFS=$'\t' read -r tag date; do
+            base=$(echo "$tag" | sed 's/^v//; s/-beta\..*//')
+            echo "  ${i}) ${tag}  →  v${base}   (published ${date%T*})"
+            tag_list+=("$tag")
             i=$((i + 1))
-        done <<< "$versions"
+        done <<< "$tags"
 
         echo ""
-        printf "Select version to promote [1-%d]: " "${#version_list[@]}"
+        printf "Select beta to promote [1-%d]: " "${#tag_list[@]}"
         read -r choice
 
-        if ! [[ "$choice" =~ ^[0-9]+$ ]] || [ "$choice" -lt 1 ] || [ "$choice" -gt "${#version_list[@]}" ]; then
+        if ! [[ "$choice" =~ ^[0-9]+$ ]] || [ "$choice" -lt 1 ] || [ "$choice" -gt "${#tag_list[@]}" ]; then
             echo "Error: Invalid selection."
             exit 1
         fi
-        target="${version_list[$((choice - 1))]}"
+        selected_tag="${tag_list[$((choice - 1))]}"
+        target=$(echo "$selected_tag" | sed 's/^v//; s/-beta\..*//')
+        beta_tag="$selected_tag"
+    else
+        # Direct version: find the latest beta tag for this version
+        beta_tag=$(git tag -l "v${target}-beta.*" | sort -V | tail -1)
     fi
-
-    # Find the latest beta tag for this version
-    beta_tag=$(git tag -l "v${target}-beta.*" | sort -V | tail -1)
 
     if [ -z "${beta_tag}" ]; then
         echo "Error: No beta tags found for version ${target}."


### PR DESCRIPTION
## Summary

- Document that `just release-retry <tag>` is required after every beta merge to publish aionanit to PyPI
- Update the release flow diagram to show the manual step
- Explain the `GITHUB_TOKEN` limitation that prevents auto-triggering

No code changes — docs only.