### PR TITLE
fix: fetch tags before promote to resolve remote beta tags

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,6 +92,8 @@ promote version="":
 
     target="{{ version }}"
 
+    git fetch origin --tags --quiet
+
     if [ -z "${target}" ]; then
         # List all pre-releases, let user pick a specific beta tag
         echo "Fetching pre-releases..."


### PR DESCRIPTION
Adds `git fetch origin --tags` at the start of `just promote` so beta tags created by CI are available locally.