### PR TITLE
fix: enable network diagnostic sensors by default to start polling

### DIFF
--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -114,7 +114,6 @@ NETWORK_SENSORS: tuple[NanitNetworkSensorDescription, ...] = (
         key="wifi_ssid",
         translation_key="wifi_ssid",
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
         value_fn=lambda net: net.ssid,
     ),
     NanitNetworkSensorDescription(
@@ -124,7 +123,6 @@ NETWORK_SENSORS: tuple[NanitNetworkSensorDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
         value_fn=lambda net: net.signal_dbm,
     ),
     NanitNetworkSensorDescription(
@@ -134,7 +132,6 @@ NETWORK_SENSORS: tuple[NanitNetworkSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfFrequency.MEGAHERTZ,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
         value_fn=lambda net: net.frequency_mhz,
     ),
 )

--- a/justfile
+++ b/justfile
@@ -77,6 +77,10 @@ events *args:
 probe *args:
     {{ python }} tools/nanit-probe.py {{ args }}
 
+# Fetch camera network diagnostics (use --watch N to repeat)
+network *args:
+    {{ python }} tools/nanit-network.py {{ args }}
+
 # ─── Releases (Owner Only) ────────────────────────────────────────────
 
 # Release flow:

--- a/tools/nanit-network.py
+++ b/tools/nanit-network.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fetch camera network diagnostics from the Nanit cloud API.
+
+Reads session from .nanit-session (created by nanit-login.py).
+Calls: GET https://api.nanit.com/babies and extracts camera.network info.
+
+Usage:
+    just network              # single fetch
+    just network --watch 60   # repeat every 60s
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import aiohttp
+
+from aionanit.rest import NANIT_API_HEADERS
+
+SESSION_FILE = Path(__file__).resolve().parents[1] / ".nanit-session"
+
+
+def _print_network(babies: list[dict], *, request_num: int = 0) -> None:
+    """Print network info for each baby/camera."""
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    header = f"[{timestamp}]"
+    if request_num:
+        header += f" Request #{request_num}"
+    print(f"\n{header}")
+    print("-" * 50)
+
+    for baby in babies:
+        name = baby.get("name", "?")
+        camera = baby.get("camera") or {}
+        network = camera.get("network")
+
+        if network is None:
+            print(f"  {name}: no network data")
+            continue
+
+        ssid = network.get("ssid", "?")
+        freq = network.get("freq")
+        level = network.get("level")
+        print(f"  {name}:")
+        print(f"    SSID:      {ssid}")
+        print(f"    Signal:    {level} dBm" if level is not None else "    Signal:    n/a")
+        print(f"    Frequency: {freq} MHz" if freq is not None else "    Frequency: n/a")
+
+        # Show any extra fields in camera.network we might not know about
+        known = {"ssid", "freq", "level"}
+        extra = {k: v for k, v in network.items() if k not in known}
+        if extra:
+            print(f"    Extra:     {extra}")
+
+
+async def _fetch_babies(
+    session: aiohttp.ClientSession,
+    token: str,
+) -> list[dict] | None:
+    """Fetch /babies and return the raw list, or None on auth failure."""
+    async with session.get(
+        "https://api.nanit.com/babies",
+        headers={**NANIT_API_HEADERS, "Authorization": token},
+    ) as resp:
+        if resp.status == 401:
+            print("Token expired. Run: just login", file=sys.stderr)
+            return None
+        if resp.status != 200:
+            text = await resp.text()
+            print(f"Error: HTTP {resp.status}\n{text}", file=sys.stderr)
+            return None
+        body = await resp.json()
+        return body.get("babies", [])
+
+
+async def async_main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch Nanit camera network info.")
+    parser.add_argument(
+        "--watch",
+        type=int,
+        metavar="SECONDS",
+        help="Repeat every N seconds (e.g. --watch 60)",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print full raw JSON response",
+    )
+    args = parser.parse_args()
+
+    if not SESSION_FILE.exists():
+        print("No session found. Run: just login", file=sys.stderr)
+        return 1
+
+    data = json.loads(SESSION_FILE.read_text())
+    token = data["access_token"]
+
+    async with aiohttp.ClientSession() as session:
+        request_num = 0
+        while True:
+            request_num += 1
+            babies = await _fetch_babies(session, token)
+            if babies is None:
+                return 1
+
+            if args.raw:
+                for baby in babies:
+                    network = (baby.get("camera") or {}).get("network")
+                    print(json.dumps({"name": baby.get("name"), "network": network}, indent=2))
+            else:
+                _print_network(babies, request_num=request_num)
+
+            if not args.watch:
+                break
+
+            try:
+                print(f"\nNext request in {args.watch}s (Ctrl+C to stop)")
+                await asyncio.sleep(args.watch)
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                print("\nStopped.")
+                break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(async_main()))


### PR DESCRIPTION
## Summary

- **Fix:** Network diagnostic sensors (WiFi SSID, signal strength, frequency) were registered with `entity_registry_enabled_default=False`, which prevented HA's `DataUpdateCoordinator` polling loop from ever starting. Removed the flag so sensors are enabled by default and the coordinator polls every 5 minutes as intended.
- **Tool:** Added `just network` CLI tool (`tools/nanit-network.py`) to fetch camera network info directly from the Nanit REST API. Supports `--watch N` for repeated polling and `--raw` for JSON output.

### Root cause

When all entities backed by a coordinator are disabled in the entity registry, `async_added_to_hass()` is never called, so no listener is registered via `coordinator.async_add_listener()`. Without listeners, `DataUpdateCoordinator._schedule_refresh()` is never invoked, and the polling timer never starts. The only data available was the one-shot fetch from `async_config_entry_first_refresh()` during setup.

### Note for existing installs

The entity registry already has these entities stored as disabled. After upgrading, users need to manually enable them in HA (Settings → Devices → camera → enable wifi entities) and restart for polling to begin.