### PR TITLE
fix: preserve available_tracks across playback poll cycles

### DIFF
--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -296,6 +296,11 @@ class NanitCamera:
         """GET_PLAYBACK request — query current sound machine state."""
         resp = await self._send_request(RequestType.GET_PLAYBACK)
         pb = _parse_playback(resp)
+        # Preserve available_tracks from existing state — GET_PLAYBACK does
+        # not include the track list; only GET_SOUNDTRACKS provides it.
+        current_tracks = self._state.playback.available_tracks
+        if current_tracks and not pb.available_tracks:
+            pb = dataclasses.replace(pb, available_tracks=current_tracks)
         self._update_state(playback=pb, kind=CameraEventKind.PLAYBACK_UPDATE)
         return pb
 
@@ -600,6 +605,9 @@ class NanitCamera:
         elif req_type == RequestType.PUT_PLAYBACK:
             if proto_request.HasField("playback"):
                 pb = _parse_playback_from_proto(proto_request.playback)
+                current_tracks = self._state.playback.available_tracks
+                if current_tracks and not pb.available_tracks:
+                    pb = dataclasses.replace(pb, available_tracks=current_tracks)
                 self._update_state(playback=pb, kind=CameraEventKind.PLAYBACK_UPDATE)
 
         else:


### PR DESCRIPTION
## Summary

- Fix: the 30s playback poll (`async_get_playback()`) replaced the entire `PlaybackState`, wiping `available_tracks` that was populated by `async_get_soundtracks()` during initial setup
- The source dropdown in the media player entity would appear on startup then vanish ~30 seconds later
- Same fix applied to the `PUT_PLAYBACK` push event handler

## Root Cause

`_parse_playback()` returns `PlaybackState(playing=..., current_track=..., available_tracks=())` — it doesn't know about tracks (that's a separate request type). But `async_get_playback()` was replacing the *entire* playback state with this result, overwriting the tracks that `async_get_soundtracks()` had stored.

## Fix

Preserve existing `available_tracks` when `async_get_playback()` or a `PUT_PLAYBACK` push event updates playback state, since neither of these sources provides track list data.