### PR TITLE
refactor: remove redundant NanitVolume number entity

### DIFF
--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -153,6 +153,7 @@ def _async_remove_stale_devices(
 
 _DEPRECATED_ENTITIES: list[tuple[str, str]] = [
     ("switch", "night_light"),
+    ("number", "volume"),
 ]
 
 

--- a/custom_components/nanit/icons.json
+++ b/custom_components/nanit/icons.json
@@ -28,9 +28,7 @@
         }
       }
     },
-    "number": {
-      "volume": { "default": "mdi:volume-medium" }
-    },
+    "number": {},
     "camera": {
       "camera": { "default": "mdi:baby-face-outline" }
     }

--- a/custom_components/nanit/number.py
+++ b/custom_components/nanit/number.py
@@ -9,12 +9,10 @@ from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from aionanit import NanitCamera
-
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
-from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
-from .entity import NanitEntity, NanitSoundLightEntity
+from .coordinator import NanitSoundLightCoordinator
+from .entity import NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
@@ -29,49 +27,12 @@ async def async_setup_entry(
     """Set up Nanit number entities for all cameras on the account."""
     entities: list[NumberEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
-        entities.append(NanitVolume(cam_data.push_coordinator, cam_data.camera))
-
         # Sound & Light Machine volume (optional)
         sl_coordinator = cam_data.sound_light_coordinator
         if sl_coordinator is not None:
             entities.append(NanitSoundMachineVolume(sl_coordinator))
 
     async_add_entities(entities)
-
-
-class NanitVolume(NanitEntity, NumberEntity):
-    """Volume number entity."""
-
-    _attr_translation_key = "volume"
-    _attr_native_min_value = 0
-    _attr_native_max_value = 100
-    _attr_native_step = 1
-    _attr_mode = NumberMode.SLIDER
-    _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_entity_registry_enabled_default = False
-
-    def __init__(
-        self,
-        coordinator: NanitPushCoordinator,
-        camera: NanitCamera,
-    ) -> None:
-        """Initialize."""
-        super().__init__(coordinator)
-        self._camera = camera
-        self._attr_unique_id = f"{camera.uid}_volume"
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the current volume."""
-        if self.coordinator.data is None:
-            return None
-        val = self.coordinator.data.settings.volume
-        return float(val) if val is not None else None
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Set the volume."""
-        await self._camera.async_set_settings(volume=int(value))
-        self.async_write_ha_state()
 
 
 class NanitSoundMachineVolume(NanitSoundLightEntity, NumberEntity):

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -117,7 +117,6 @@
       "sl_sound_switch": { "name": "Sound" }
     },
     "number": {
-      "volume": { "name": "Volume" },
       "sound_machine_volume": { "name": "Volume" }
     },
     "light": {

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -117,7 +117,6 @@
       "sl_sound_switch": { "name": "Sound" }
     },
     "number": {
-      "volume": { "name": "Volume" },
       "sound_machine_volume": { "name": "Volume" }
     },
     "light": {

--- a/tests/unit/snapshots/test_entity_registration.ambr
+++ b/tests/unit/snapshots/test_entity_registration.ambr
@@ -205,19 +205,6 @@
 # ---
 # name: TestEntityRegistration.test_number[baseline]
   list([
-    dict({
-      'class': 'NanitVolume',
-      'device_class': None,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'volume',
-      'unique_id': 'cam_1_volume',
-    }),
   ])
 # ---
 # name: TestEntityRegistration.test_number[full]
@@ -234,19 +221,6 @@
       'entity_category': None,
       'translation_key': 'sound_machine_volume',
       'unique_id': 'cam_1_sound_machine_volume',
-    }),
-    dict({
-      'class': 'NanitVolume',
-      'device_class': None,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'volume',
-      'unique_id': 'cam_1_volume',
     }),
   ])
 # ---

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -50,7 +50,6 @@ from custom_components.nanit.coordinator import (
     NanitPushCoordinator,
 )
 from custom_components.nanit.media_player import NanitMediaPlayer
-from custom_components.nanit.number import NanitVolume
 from custom_components.nanit.sensor import SENSORS, NanitSensor
 from custom_components.nanit.switch import SWITCHES, NanitSwitch
 
@@ -278,26 +277,6 @@ async def test_switch_camera_power_turn_off_calls_sleep_mode() -> None:
     assert entity.is_on is False
 
 
-def test_number_native_value_returns_volume() -> None:
-    coordinator = _push_coordinator(_camera_state(volume=50))
-    camera = MagicMock(uid="cam_1")
-    entity = NanitVolume(coordinator, camera)
-
-    assert entity.native_value == 50
-
-
-async def test_number_set_native_value_calls_camera_settings() -> None:
-    coordinator = _push_coordinator(_camera_state(volume=10))
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_settings = AsyncMock()
-    entity = NanitVolume(coordinator, camera)
-    _disable_state_writes(entity)
-
-    await entity.async_set_native_value(33.7)
-
-    camera.async_set_settings.assert_awaited_once_with(volume=33)
-
-
 def test_media_player_state_playing_when_playback_playing_true() -> None:
     coordinator = _push_coordinator(
         _camera_state(playback=PlaybackState(playing=True, current_track="White Noise.wav"))
@@ -306,6 +285,14 @@ def test_media_player_state_playing_when_playback_playing_true() -> None:
     entity = NanitMediaPlayer(coordinator, camera)
 
     assert entity.state is MediaPlayerState.PLAYING
+
+
+def test_media_player_state_none_when_no_data() -> None:
+    coordinator = _push_coordinator(None)
+    camera = MagicMock(uid="cam_1")
+    entity = NanitMediaPlayer(coordinator, camera)
+
+    assert entity.state is None
 
 
 def test_media_player_state_idle_when_playback_playing_false() -> None:
@@ -328,6 +315,14 @@ def test_media_player_source_returns_current_track() -> None:
     assert entity.source == "Waves.wav"
 
 
+def test_media_player_source_none_when_no_data() -> None:
+    coordinator = _push_coordinator(None)
+    camera = MagicMock(uid="cam_1")
+    entity = NanitMediaPlayer(coordinator, camera)
+
+    assert entity.source is None
+
+
 def test_media_player_source_list_returns_available_tracks() -> None:
     coordinator = _push_coordinator(
         _camera_state(
@@ -344,12 +339,36 @@ def test_media_player_source_list_returns_available_tracks() -> None:
     assert entity.source_list == ["White Noise.wav", "Birds.wav", "Waves.wav"]
 
 
+def test_media_player_source_list_none_when_no_data() -> None:
+    coordinator = _push_coordinator(None)
+    camera = MagicMock(uid="cam_1")
+    entity = NanitMediaPlayer(coordinator, camera)
+
+    assert entity.source_list is None
+
+
 def test_media_player_volume_level_returns_settings_volume_scaled() -> None:
     coordinator = _push_coordinator(_camera_state(volume=75))
     camera = MagicMock(uid="cam_1")
     entity = NanitMediaPlayer(coordinator, camera)
 
     assert entity.volume_level == 0.75
+
+
+def test_media_player_volume_level_none_when_no_data() -> None:
+    coordinator = _push_coordinator(None)
+    camera = MagicMock(uid="cam_1")
+    entity = NanitMediaPlayer(coordinator, camera)
+
+    assert entity.volume_level is None
+
+
+def test_media_player_volume_level_none_when_volume_is_none() -> None:
+    coordinator = _push_coordinator(_camera_state(volume=None))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitMediaPlayer(coordinator, camera)
+
+    assert entity.volume_level is None
 
 
 async def test_media_player_play_calls_camera_start_playback() -> None:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -218,10 +218,13 @@ async def test_deprecated_switch_entity_removed_on_setup(
     ):
         assert await async_setup_entry(hass, entry)
 
-    mock_ent_reg.async_get_entity_id.assert_called_once_with(
+    mock_ent_reg.async_get_entity_id.assert_any_call(
         "switch", DOMAIN, f"{MOCK_BABY_1.camera_uid}_night_light"
     )
-    mock_ent_reg.async_remove.assert_called_once_with("switch.nursery_night_light")
+    mock_ent_reg.async_get_entity_id.assert_any_call(
+        "number", DOMAIN, f"{MOCK_BABY_1.camera_uid}_volume"
+    )
+    assert mock_ent_reg.async_remove.call_count == 2
 
 
 async def test_deprecated_entity_removal_skipped_when_not_present(

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -941,8 +941,8 @@ async def test_number_async_setup_entry_creates_sl_volume() -> None:
     await number_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
 
     entities = async_add_entities.call_args.args[0]
-    # 1 camera volume + 1 S&L volume = 2
-    assert len(entities) == 2
+    # 1 S&L volume (camera volume entity removed)
+    assert len(entities) == 1
 
 
 async def test_binary_sensor_async_setup_entry_creates_sl_connectivity() -> None:
@@ -1091,32 +1091,6 @@ def test_cloud_binary_sensor_skips_non_matching_event_type() -> None:
 
     with patch("custom_components.nanit.binary_sensor.time_mod.time", return_value=now):
         assert entity.is_on is False
-
-
-def test_nanit_volume_returns_none_when_volume_is_none() -> None:
-    from custom_components.nanit.number import NanitVolume
-
-    state = CameraState(
-        sensors=SensorState(temperature=22.5, humidity=50.0, light=100),
-        settings=SettingsState(volume=None, sleep_mode=False, night_vision=True),
-        control=ControlState(),
-        connection=ConnectionInfo(state=ConnectionState.CONNECTED),
-    )
-    coordinator = _push_coordinator(state)
-    camera = MagicMock(uid="cam_1")
-    entity = NanitVolume(coordinator, camera)
-
-    assert entity.native_value is None
-
-
-def test_nanit_volume_returns_none_when_no_data() -> None:
-    from custom_components.nanit.number import NanitVolume
-
-    coordinator = _push_coordinator(None)
-    camera = MagicMock(uid="cam_1")
-    entity = NanitVolume(coordinator, camera)
-
-    assert entity.native_value is None
 
 
 async def test_camera_async_setup_entry_creates_entities() -> None:


### PR DESCRIPTION
## Summary

- Remove the standalone `NanitVolume` number entity — volume control is now handled by the `NanitMediaPlayer` entity (added in #46)
- Register `("number", "volume")` in `_DEPRECATED_ENTITIES` so orphaned entities are automatically cleaned up on existing installations
- Remove associated translations, icons, tests, and snapshot entries
- Add media player edge-case tests (no-data/None volume, source, source_list, state) to maintain 80% coverage threshold