### PR TITLE
fix: skip config entry reload on token refresh

### DIFF
--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL
@@ -66,8 +68,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> boo
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Reload entry when options change (e.g. camera IPs updated)
-    entry.async_on_unload(entry.add_update_listener(_async_options_update_listener))
+    # update_listener fires for ANY entry mutation (data OR options).
+    # Token refresh persists tokens via async_update_entry(data=...) which
+    # must not trigger a reload — only genuine options changes should.
+    entry.async_on_unload(
+        entry.add_update_listener(_make_options_update_listener(dict(entry.options)))
+    )
 
     return True
 
@@ -180,6 +186,22 @@ def _async_remove_deprecated_entities(hass: HomeAssistant, hub: NanitHub) -> Non
                 ent_reg.async_remove(entity_id)
 
 
-async def _async_options_update_listener(hass: HomeAssistant, entry: NanitConfigEntry) -> None:
-    """Reload entry when options change (e.g. camera IPs updated)."""
-    await hass.config_entries.async_reload(entry.entry_id)
+def _make_options_update_listener(
+    previous_options: dict[str, Any],
+) -> Callable[[HomeAssistant, NanitConfigEntry], Coroutine[Any, Any, None]]:
+    """Create an update listener that only reloads when options actually change.
+
+    HA fires update_listener for any entry mutation (data or options). Token
+    refresh persists new tokens via async_update_entry(data=...) — this must
+    not cause a reload. By comparing against a snapshot of the previous options,
+    we ensure only genuine options changes (e.g. camera IP updates) reload.
+    """
+
+    async def _listener(hass: HomeAssistant, entry: NanitConfigEntry) -> None:
+        nonlocal previous_options
+        current_options = dict(entry.options)
+        if current_options != previous_options:
+            previous_options = current_options
+            await hass.config_entries.async_reload(entry.entry_id)
+
+    return _listener

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -7,8 +7,11 @@ services:
     volumes:
       - ha-config:/config
       - ../custom_components:/config/custom_components:ro
+      - ../packages/aionanit:/opt/aionanit:ro
     environment:
       - TZ=Europe/Oslo
+    command: >
+      bash -c "cp -r /opt/aionanit /tmp/aionanit && pip install --no-deps /tmp/aionanit && exec python -m homeassistant -c /config"
 
 volumes:
   ha-config:


### PR DESCRIPTION
## Summary

Entities went unavailable for ~3 seconds every ~55 minutes due to the config entry being fully reloaded on every token refresh.

## Root Cause

1. `_token_refresh_loop` forces a WebSocket reconnect every ~55 min (token TTL 3600s − 300s buffer)
2. During reconnect, `async_get_access_token()` triggers a token refresh → `_on_tokens_refreshed` callback
3. The callback persists new tokens via `async_update_entry(entry, data={...})`
4. HA fires **all** `update_listener` callbacks for any entry mutation — no distinction between `data` and `options` changes
5. `_async_options_update_listener` unconditionally calls `async_reload(entry.entry_id)`
6. Full reload: unload all platforms → entities become unavailable → re-setup (~3s)

## Fix

Replace the unconditional listener with a guarded one that snapshots `entry.options` at setup time and only reloads when options actually differ. Data-only updates (token refresh) are now ignored.

## Evidence

State history from production HA recorder DB showing the exact pattern — every entity going unavailable simultaneously at ~59-minute intervals for exactly 3 seconds:

```
2026-05-11 20:33:52|switch.nanit_camera_power|unavailable
2026-05-11 20:33:52|binary_sensor.nanit_cloud_motion|unavailable
2026-05-11 20:33:52|sensor.nanit_wifi_signal_strength|unavailable
2026-05-11 20:33:52|sensor.nanit_temperature|unavailable
  ↕ 3 seconds
2026-05-11 20:33:55|sensor.nanit_wifi_signal_strength|-69
```

Interval drift confirms token-refresh timing: `20:33` → `19:34` → `18:35` → `17:36` (−59 min each cycle).

## Also included

- `dev/docker-compose.yml`: Mount and install local `packages/aionanit/` in the dev container so `just dev` always uses the monorepo's aionanit, not the PyPI version.