### PR TITLE
fix: attach versioned zip artifact for all releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,8 @@ jobs:
       - name: Run aionanit tests
         run: python -m pytest packages/aionanit/tests/ -v --tb=short
 
-  publish-beta:
-    name: Publish Beta to PyPI
+  publish-pypi:
+    name: Publish to PyPI
     needs: resolve
     if: needs.resolve.outputs.is_stable == 'false'
     runs-on: ubuntu-latest
@@ -133,7 +133,7 @@ jobs:
           pip install build
           python -m build packages/aionanit
 
-      - name: Publish beta to PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/aionanit/dist/
@@ -180,8 +180,7 @@ jobs:
 
   attach-artifact:
     name: Attach Release Artifact
-    needs: [resolve, ci-gate]
-    if: needs.resolve.outputs.is_stable == 'true'
+    needs: [resolve]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -190,7 +189,7 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.tag }}
 
-      - name: Inject version from tag
+      - name: Inject version into manifest
         env:
           SEMVER: ${{ needs.resolve.outputs.semver }}
           PEP440: ${{ needs.resolve.outputs.pep440 }}

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL
@@ -66,8 +68,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> boo
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Reload entry when options change (e.g. camera IPs updated)
-    entry.async_on_unload(entry.add_update_listener(_async_options_update_listener))
+    # update_listener fires for ANY entry mutation (data OR options).
+    # Token refresh persists tokens via async_update_entry(data=...) which
+    # must not trigger a reload — only genuine options changes should.
+    entry.async_on_unload(
+        entry.add_update_listener(_make_options_update_listener(dict(entry.options)))
+    )
 
     return True
 
@@ -180,6 +186,22 @@ def _async_remove_deprecated_entities(hass: HomeAssistant, hub: NanitHub) -> Non
                 ent_reg.async_remove(entity_id)
 
 
-async def _async_options_update_listener(hass: HomeAssistant, entry: NanitConfigEntry) -> None:
-    """Reload entry when options change (e.g. camera IPs updated)."""
-    await hass.config_entries.async_reload(entry.entry_id)
+def _make_options_update_listener(
+    previous_options: dict[str, Any],
+) -> Callable[[HomeAssistant, NanitConfigEntry], Coroutine[Any, Any, None]]:
+    """Create an update listener that only reloads when options actually change.
+
+    HA fires update_listener for any entry mutation (data or options). Token
+    refresh persists new tokens via async_update_entry(data=...) — this must
+    not cause a reload. By comparing against a snapshot of the previous options,
+    we ensure only genuine options changes (e.g. camera IP updates) reload.
+    """
+
+    async def _listener(hass: HomeAssistant, entry: NanitConfigEntry) -> None:
+        nonlocal previous_options
+        current_options = dict(entry.options)
+        if current_options != previous_options:
+            previous_options = current_options
+            await hass.config_entries.async_reload(entry.entry_id)
+
+    return _listener

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - TZ=Europe/Oslo
     command: >
-      bash -c "cp -r /opt/aionanit /tmp/aionanit && pip install --no-deps /tmp/aionanit && exec python -m homeassistant -c /config"
+      bash -c "cp -r /opt/aionanit /tmp/aionanit && pip install --no-deps --force-reinstall /tmp/aionanit && exec python -m homeassistant -c /config"
 
 volumes:
   ha-config:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -7,8 +7,11 @@ services:
     volumes:
       - ha-config:/config
       - ../custom_components:/config/custom_components:ro
+      - ../packages/aionanit:/opt/aionanit:ro
     environment:
       - TZ=Europe/Oslo
+    command: >
+      bash -c "cp -r /opt/aionanit /tmp/aionanit && pip install --no-deps /tmp/aionanit && exec python -m homeassistant -c /config"
 
 volumes:
   ha-config:

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -408,14 +408,24 @@ class NanitCamera:
         self._update_state(control=new_control, kind=CameraEventKind.CONTROL_UPDATE)
         return new_control
 
-    async def async_start_playback(self, track: str | None = None) -> PlaybackState:
+    _DEFAULT_PLAYBACK_DURATION: int = 28800  # 8 hours
+
+    async def async_start_playback(
+        self,
+        track: str | None = None,
+        duration: int | None = None,
+    ) -> PlaybackState:
         """PUT_PLAYBACK with status=STARTED and optional track selection.
 
         Args:
             track: Filename of the track to play (e.g. "Birds.wav").
                    If None, starts/resumes the last-used track.
+            duration: Playback duration in seconds. Defaults to 8 hours.
         """
-        proto_playback = Playback(status=Playback.STARTED)
+        proto_playback = Playback(
+            status=Playback.STARTED,
+            duration=duration if duration is not None else self._DEFAULT_PLAYBACK_DURATION,
+        )
         if track is not None:
             proto_playback.track.type = 0
             proto_playback.track.filename = track

--- a/packages/aionanit/aionanit/proto/nanit_pb2.py
+++ b/packages/aionanit/aionanit/proto/nanit_pb2.py
@@ -4,88 +4,91 @@
 # source: nanit.proto
 # Protobuf Python Version: 6.31.1
 """Generated protocol buffer code."""
-
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
-
 _runtime_version.ValidateProtobufRuntimeVersion(
-    _runtime_version.Domain.PUBLIC, 6, 31, 1, "", "nanit.proto"
+    _runtime_version.Domain.PUBLIC,
+    6,
+    31,
+    1,
+    '',
+    'nanit.proto'
 )
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0bnanit.proto\x12\x05nanit"}\n\nSensorData\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\r\n\x05value\x18\x03 \x01(\x05\x12\x10\n\x08is_alert\x18\x04 \x01(\x08\x12\x11\n\ttimestamp\x18\x05 \x01(\x05\x12\x13\n\x0bvalue_milli\x18\x06 \x01(\x05"a\n\rGetSensorData\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\x12\x13\n\x0btemperature\x18\x04 \x01(\x08\x12\x10\n\x08humidity\x18\x05 \x01(\x08\x12\r\n\x05light\x18\x06 \x01(\x08\x12\r\n\x05night\x18\x07 \x01(\x08"l\n\nGetControl\x12\x0b\n\x03ptz\x18\x01 \x01(\x08\x12\x13\n\x0bnight_light\x18\x02 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x03 \x01(\x08\x12\x1f\n\x17sensor_data_transfer_en\x18\x04 \x01(\x08"\xdd\x02\n\x07\x43ontrol\x12.\n\x0bnight_light\x18\x03 \x01(\x0e\x32\x19.nanit.Control.NightLight\x12?\n\x14sensor_data_transfer\x18\x04 \x01(\x0b\x32!.nanit.Control.SensorDataTransfer\x12\x1f\n\x17\x66orce_connect_to_server\x18\x05 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x06 \x01(\x05\x1ax\n\x12SensorDataTransfer\x12\r\n\x05sound\x18\x01 \x01(\x08\x12\x0e\n\x06motion\x18\x02 \x01(\x08\x12\x13\n\x0btemperature\x18\x03 \x01(\x08\x12\x10\n\x08humidity\x18\x04 \x01(\x08\x12\r\n\x05light\x18\x05 \x01(\x08\x12\r\n\x05night\x18\x06 \x01(\x08")\n\nNightLight\x12\r\n\tLIGHT_OFF\x10\x00\x12\x0c\n\x08LIGHT_ON\x10\x01"\xe0\x06\n\x08Settings\x12\x14\n\x0cnight_vision\x18\x02 \x01(\x08\x12/\n\x07sensors\x18\x07 \x03(\x0b\x32\x1e.nanit.Settings.SensorSettings\x12/\n\x07streams\x18\x08 \x03(\x0b\x32\x1e.nanit.Settings.StreamSettings\x12\x0e\n\x06volume\x18\t \x01(\x05\x12\x31\n\x0c\x61nti_flicker\x18\n \x01(\x0e\x32\x1b.nanit.Settings.AntiFlicker\x12\x12\n\nsleep_mode\x18\x0b \x01(\x08\x12\x17\n\x0fstatus_light_on\x18\x0c \x01(\x08\x12\x15\n\rmounting_mode\x18\x0f \x01(\x05\x12+\n\twifi_band\x18\x12 \x01(\x0e\x32\x18.nanit.Settings.WifiBand\x12\x13\n\x0bmic_mute_on\x18\x14 \x01(\x08\x12\x1e\n\x16night_light_brightness\x18\x18 \x01(\x05\x1a\xfb\x01\n\x0eSensorSettings\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\x19\n\x11use_low_threshold\x18\x02 \x01(\x08\x12\x1a\n\x12use_high_threshold\x18\x03 \x01(\x08\x12\x15\n\rlow_threshold\x18\x04 \x01(\x05\x12\x16\n\x0ehigh_threshold\x18\x05 \x01(\x05\x12\x1b\n\x13sample_interval_sec\x18\x06 \x01(\x05\x12\x1c\n\x14trigger_interval_sec\x18\x07 \x01(\x05\x12 \n\x18use_milli_for_thresholds\x18\x08 \x01(\x08\x1a\x9c\x01\n\x0eStreamSettings\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\x05\x12\x17\n\x0f\x65\x63onomy_bitrate\x18\x03 \x01(\x05\x12\x13\n\x0b\x65\x63onomy_fps\x18\x04 \x01(\x05\x12\x14\n\x0c\x62\x65st_bitrate\x18\x05 \x01(\x05\x12\x10\n\x08\x62\x65st_fps\x18\x06 \x01(\x05"%\n\x0b\x41ntiFlicker\x12\n\n\x06\x46R50HZ\x10\x00\x12\n\n\x06\x46R60HZ\x10\x01"/\n\x08WifiBand\x12\x07\n\x03\x41NY\x10\x00\x12\x0c\n\x08\x46R2_4GHZ\x10\x01\x12\x0c\n\x08\x46R5_0GHZ\x10\x02"\xaa\x02\n\x06Status\x12\x1a\n\x12upgrade_downloaded\x18\x01 \x01(\x08\x12>\n\x14\x63onnection_to_server\x18\x02 \x01(\x0e\x32 .nanit.Status.ConnectionToServer\x12\x17\n\x0f\x63urrent_version\x18\x03 \x01(\t\x12!\n\x04mode\x18\x04 \x01(\x0e\x32\x13.nanit.MountingMode\x12\x1b\n\x13is_security_upgrade\x18\x05 \x01(\x08\x12\x1a\n\x12\x64ownloaded_version\x18\x06 \x01(\t\x12\x18\n\x10hardware_version\x18\x07 \x01(\t"5\n\x12\x43onnectionToServer\x12\x10\n\x0c\x44ISCONNECTED\x10\x00\x12\r\n\tCONNECTED\x10\x01",\n\nSoundtrack\x12\x0c\n\x04type\x18\x01 \x01(\x05\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t"\x9c\x01\n\x08Playback\x12&\n\x06status\x18\x01 \x02(\x0e\x32\x16.nanit.Playback.Status\x12 \n\x05track\x18\x03 \x01(\x0b\x32\x11.nanit.Soundtrack\x12"\n\x07\x63urrent\x18\x04 \x01(\x0b\x32\x11.nanit.Soundtrack""\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01"v\n\x06Stream\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.nanit.Stream.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x0b\n\x03\x62ps\x18\x03 \x01(\x05"0\n\x04Type\x12\t\n\x05LOCAL\x10\x00\x12\n\n\x06REMOTE\x10\x01\x12\x08\n\x04RTSP\x10\x02\x12\x07\n\x03P2P\x10\x03"\xad\x01\n\tStreaming\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\'\n\x06status\x18\x02 \x02(\x0e\x32\x17.nanit.Streaming.Status\x12\x10\n\x08rtmp_url\x18\x03 \x02(\t\x12\x10\n\x08\x61ttempts\x18\x04 \x01(\x05".\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\x12\n\n\x06PAUSED\x10\x02"\x16\n\x07GetLogs\x12\x0b\n\x03url\x18\x01 \x02(\t"\x18\n\tGetStatus\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08"\xa9\x03\n\x07Request\x12\n\n\x02id\x18\x01 \x02(\x05\x12 \n\x04type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12#\n\tstreaming\x18\x04 \x01(\x0b\x32\x10.nanit.Streaming\x12!\n\x08settings\x18\x05 \x01(\x0b\x32\x0f.nanit.Settings\x12\x1d\n\x06status\x18\x07 \x01(\x0b\x32\r.nanit.Status\x12$\n\nget_status\x18\x08 \x01(\x0b\x32\x10.nanit.GetStatus\x12-\n\x0fget_sensor_data\x18\x0c \x01(\x0b\x32\x14.nanit.GetSensorData\x12&\n\x0bsensor_data\x18\r \x03(\x0b\x32\x11.nanit.SensorData\x12\x1f\n\x07\x63ontrol\x18\x0f \x01(\x0b\x32\x0e.nanit.Control\x12!\n\x08playback\x18\x10 \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bget_control\x18\x11 \x01(\x0b\x32\x11.nanit.GetControl\x12 \n\x08get_logs\x18\x12 \x01(\x0b\x32\x0e.nanit.GetLogs"\xcb\x02\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x02(\x05\x12(\n\x0crequest_type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12\x13\n\x0bstatus_code\x18\x03 \x02(\x05\x12\x16\n\x0estatus_message\x18\x04 \x01(\t\x12\x1d\n\x06status\x18\x05 \x01(\x0b\x32\r.nanit.Status\x12!\n\x08settings\x18\x06 \x01(\x0b\x32\x0f.nanit.Settings\x12&\n\x0bsensor_data\x18\t \x03(\x0b\x32\x11.nanit.SensorData\x12!\n\x08playback\x18\x0b \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bsoundtracks\x18\x0c \x03(\x0b\x32\x11.nanit.Soundtrack\x12\x1f\n\x07\x63ontrol\x18\r \x01(\x0b\x32\x0e.nanit.Control"\xa2\x01\n\x07Message\x12!\n\x04type\x18\x01 \x02(\x0e\x32\x13.nanit.Message.Type\x12\x1f\n\x07request\x18\x02 \x01(\x0b\x32\x0e.nanit.Request\x12!\n\x08response\x18\x03 \x01(\x0b\x32\x0f.nanit.Response"0\n\x04Type\x12\r\n\tKEEPALIVE\x10\x00\x12\x0b\n\x07REQUEST\x10\x01\x12\x0c\n\x08RESPONSE\x10\x02*\xe0\x06\n\x0bRequestType\x12\x11\n\rPUT_STREAMING\x10\x02\x12\x11\n\rGET_STREAMING\x10\x03\x12\x10\n\x0cGET_SETTINGS\x10\x04\x12\x10\n\x0cPUT_SETTINGS\x10\x05\x12\x0f\n\x0bGET_CONTROL\x10\x06\x12\x0f\n\x0bPUT_CONTROL\x10\x07\x12\x0e\n\nGET_STATUS\x10\x08\x12\x0e\n\nPUT_STATUS\x10\t\x12\x13\n\x0fPUT_SENSOR_DATA\x10\x0b\x12\x13\n\x0fGET_SENSOR_DATA\x10\x0c\x12\x10\n\x0cGET_UCTOKENS\x10\r\x12\x10\n\x0cPUT_UCTOKENS\x10\x0e\x12\x15\n\x11PUT_SETUP_NETWORK\x10\x0f\x12\x14\n\x10PUT_SETUP_SERVER\x10\x10\x12\x10\n\x0cGET_FIRMWARE\x10\x11\x12\x10\n\x0cPUT_FIRMWARE\x10\x12\x12\x10\n\x0cGET_PLAYBACK\x10\x13\x12\x10\n\x0cPUT_PLAYBACK\x10\x14\x12\x13\n\x0fGET_SOUNDTRACKS\x10\x15\x12\x16\n\x12GET_STATUS_NETWORK\x10\x16\x12\x15\n\x11GET_LIST_NETWORKS\x10\x17\x12\x0c\n\x08GET_LOGS\x10\x18\x12\x11\n\rGET_BANDWIDTH\x10\x19\x12\x17\n\x13GET_AUDIO_STREAMING\x10\x1a\x12\x17\n\x13PUT_AUDIO_STREAMING\x10\x1b\x12\x12\n\x0eGET_WIFI_SETUP\x10\x1c\x12\x12\n\x0ePUT_WIFI_SETUP\x10\x1d\x12\x13\n\x0fPUT_STING_START\x10\x1e\x12\x12\n\x0ePUT_STING_STOP\x10\x1f\x12\x14\n\x10PUT_STING_STATUS\x10 \x12\x13\n\x0fPUT_STING_ALERT\x10"\x12\x12\n\x0ePUT_KEEP_ALIVE\x10#\x12\x14\n\x10GET_STING_STATUS\x10$\x12\x12\n\x0ePUT_STING_TEST\x10%\x12\x16\n\x12PUT_RTSP_STREAMING\x10&\x12\x0f\n\x0bGET_UOM_URI\x10\'\x12\x0b\n\x07GET_UOM\x10(\x12\x0b\n\x07PUT_UOM\x10)\x12\x10\n\x0cGET_AUTH_KEY\x10*\x12\x10\n\x0cPUT_AUTH_KEY\x10+\x12\x0e\n\nPUT_HEALTH\x10,\x12\x13\n\x0fPUT_TCP_REQUEST\x10-\x12\x13\n\x0fGET_STING_START\x10.\x12\x10\n\x0cGET_LOGS_URI\x10/*X\n\nSensorType\x12\t\n\x05SOUND\x10\x00\x12\n\n\x06MOTION\x10\x01\x12\x0f\n\x0bTEMPERATURE\x10\x02\x12\x0c\n\x08HUMIDITY\x10\x03\x12\t\n\x05LIGHT\x10\x04\x12\t\n\x05NIGHT\x10\x05*6\n\x10StreamIdentifier\x12\x07\n\x03\x44VR\x10\x00\x12\r\n\tANALYTICS\x10\x01\x12\n\n\x06MOBILE\x10\x02*1\n\x0cMountingMode\x12\t\n\x05STAND\x10\x00\x12\n\n\x06TRAVEL\x10\x01\x12\n\n\x06SWITCH\x10\x02'
-)
+
+
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0bnanit.proto\x12\x05nanit\"}\n\nSensorData\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\r\n\x05value\x18\x03 \x01(\x05\x12\x10\n\x08is_alert\x18\x04 \x01(\x08\x12\x11\n\ttimestamp\x18\x05 \x01(\x05\x12\x13\n\x0bvalue_milli\x18\x06 \x01(\x05\"a\n\rGetSensorData\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\x12\x13\n\x0btemperature\x18\x04 \x01(\x08\x12\x10\n\x08humidity\x18\x05 \x01(\x08\x12\r\n\x05light\x18\x06 \x01(\x08\x12\r\n\x05night\x18\x07 \x01(\x08\"l\n\nGetControl\x12\x0b\n\x03ptz\x18\x01 \x01(\x08\x12\x13\n\x0bnight_light\x18\x02 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x03 \x01(\x08\x12\x1f\n\x17sensor_data_transfer_en\x18\x04 \x01(\x08\"\xdd\x02\n\x07\x43ontrol\x12.\n\x0bnight_light\x18\x03 \x01(\x0e\x32\x19.nanit.Control.NightLight\x12?\n\x14sensor_data_transfer\x18\x04 \x01(\x0b\x32!.nanit.Control.SensorDataTransfer\x12\x1f\n\x17\x66orce_connect_to_server\x18\x05 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x06 \x01(\x05\x1ax\n\x12SensorDataTransfer\x12\r\n\x05sound\x18\x01 \x01(\x08\x12\x0e\n\x06motion\x18\x02 \x01(\x08\x12\x13\n\x0btemperature\x18\x03 \x01(\x08\x12\x10\n\x08humidity\x18\x04 \x01(\x08\x12\r\n\x05light\x18\x05 \x01(\x08\x12\r\n\x05night\x18\x06 \x01(\x08\")\n\nNightLight\x12\r\n\tLIGHT_OFF\x10\x00\x12\x0c\n\x08LIGHT_ON\x10\x01\"\xe0\x06\n\x08Settings\x12\x14\n\x0cnight_vision\x18\x02 \x01(\x08\x12/\n\x07sensors\x18\x07 \x03(\x0b\x32\x1e.nanit.Settings.SensorSettings\x12/\n\x07streams\x18\x08 \x03(\x0b\x32\x1e.nanit.Settings.StreamSettings\x12\x0e\n\x06volume\x18\t \x01(\x05\x12\x31\n\x0c\x61nti_flicker\x18\n \x01(\x0e\x32\x1b.nanit.Settings.AntiFlicker\x12\x12\n\nsleep_mode\x18\x0b \x01(\x08\x12\x17\n\x0fstatus_light_on\x18\x0c \x01(\x08\x12\x15\n\rmounting_mode\x18\x0f \x01(\x05\x12+\n\twifi_band\x18\x12 \x01(\x0e\x32\x18.nanit.Settings.WifiBand\x12\x13\n\x0bmic_mute_on\x18\x14 \x01(\x08\x12\x1e\n\x16night_light_brightness\x18\x18 \x01(\x05\x1a\xfb\x01\n\x0eSensorSettings\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\x19\n\x11use_low_threshold\x18\x02 \x01(\x08\x12\x1a\n\x12use_high_threshold\x18\x03 \x01(\x08\x12\x15\n\rlow_threshold\x18\x04 \x01(\x05\x12\x16\n\x0ehigh_threshold\x18\x05 \x01(\x05\x12\x1b\n\x13sample_interval_sec\x18\x06 \x01(\x05\x12\x1c\n\x14trigger_interval_sec\x18\x07 \x01(\x05\x12 \n\x18use_milli_for_thresholds\x18\x08 \x01(\x08\x1a\x9c\x01\n\x0eStreamSettings\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\x05\x12\x17\n\x0f\x65\x63onomy_bitrate\x18\x03 \x01(\x05\x12\x13\n\x0b\x65\x63onomy_fps\x18\x04 \x01(\x05\x12\x14\n\x0c\x62\x65st_bitrate\x18\x05 \x01(\x05\x12\x10\n\x08\x62\x65st_fps\x18\x06 \x01(\x05\"%\n\x0b\x41ntiFlicker\x12\n\n\x06\x46R50HZ\x10\x00\x12\n\n\x06\x46R60HZ\x10\x01\"/\n\x08WifiBand\x12\x07\n\x03\x41NY\x10\x00\x12\x0c\n\x08\x46R2_4GHZ\x10\x01\x12\x0c\n\x08\x46R5_0GHZ\x10\x02\"\xaa\x02\n\x06Status\x12\x1a\n\x12upgrade_downloaded\x18\x01 \x01(\x08\x12>\n\x14\x63onnection_to_server\x18\x02 \x01(\x0e\x32 .nanit.Status.ConnectionToServer\x12\x17\n\x0f\x63urrent_version\x18\x03 \x01(\t\x12!\n\x04mode\x18\x04 \x01(\x0e\x32\x13.nanit.MountingMode\x12\x1b\n\x13is_security_upgrade\x18\x05 \x01(\x08\x12\x1a\n\x12\x64ownloaded_version\x18\x06 \x01(\t\x12\x18\n\x10hardware_version\x18\x07 \x01(\t\"5\n\x12\x43onnectionToServer\x12\x10\n\x0c\x44ISCONNECTED\x10\x00\x12\r\n\tCONNECTED\x10\x01\",\n\nSoundtrack\x12\x0c\n\x04type\x18\x01 \x01(\x05\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\"\xae\x01\n\x08Playback\x12&\n\x06status\x18\x01 \x02(\x0e\x32\x16.nanit.Playback.Status\x12\x10\n\x08\x64uration\x18\x02 \x01(\x05\x12 \n\x05track\x18\x03 \x01(\x0b\x32\x11.nanit.Soundtrack\x12\"\n\x07\x63urrent\x18\x04 \x01(\x0b\x32\x11.nanit.Soundtrack\"\"\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\"v\n\x06Stream\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.nanit.Stream.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x0b\n\x03\x62ps\x18\x03 \x01(\x05\"0\n\x04Type\x12\t\n\x05LOCAL\x10\x00\x12\n\n\x06REMOTE\x10\x01\x12\x08\n\x04RTSP\x10\x02\x12\x07\n\x03P2P\x10\x03\"\xad\x01\n\tStreaming\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\'\n\x06status\x18\x02 \x02(\x0e\x32\x17.nanit.Streaming.Status\x12\x10\n\x08rtmp_url\x18\x03 \x02(\t\x12\x10\n\x08\x61ttempts\x18\x04 \x01(\x05\".\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\x12\n\n\x06PAUSED\x10\x02\"\x16\n\x07GetLogs\x12\x0b\n\x03url\x18\x01 \x02(\t\"\x18\n\tGetStatus\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\"\xa9\x03\n\x07Request\x12\n\n\x02id\x18\x01 \x02(\x05\x12 \n\x04type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12#\n\tstreaming\x18\x04 \x01(\x0b\x32\x10.nanit.Streaming\x12!\n\x08settings\x18\x05 \x01(\x0b\x32\x0f.nanit.Settings\x12\x1d\n\x06status\x18\x07 \x01(\x0b\x32\r.nanit.Status\x12$\n\nget_status\x18\x08 \x01(\x0b\x32\x10.nanit.GetStatus\x12-\n\x0fget_sensor_data\x18\x0c \x01(\x0b\x32\x14.nanit.GetSensorData\x12&\n\x0bsensor_data\x18\r \x03(\x0b\x32\x11.nanit.SensorData\x12\x1f\n\x07\x63ontrol\x18\x0f \x01(\x0b\x32\x0e.nanit.Control\x12!\n\x08playback\x18\x10 \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bget_control\x18\x11 \x01(\x0b\x32\x11.nanit.GetControl\x12 \n\x08get_logs\x18\x12 \x01(\x0b\x32\x0e.nanit.GetLogs\"\xcb\x02\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x02(\x05\x12(\n\x0crequest_type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12\x13\n\x0bstatus_code\x18\x03 \x02(\x05\x12\x16\n\x0estatus_message\x18\x04 \x01(\t\x12\x1d\n\x06status\x18\x05 \x01(\x0b\x32\r.nanit.Status\x12!\n\x08settings\x18\x06 \x01(\x0b\x32\x0f.nanit.Settings\x12&\n\x0bsensor_data\x18\t \x03(\x0b\x32\x11.nanit.SensorData\x12!\n\x08playback\x18\x0b \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bsoundtracks\x18\x0c \x03(\x0b\x32\x11.nanit.Soundtrack\x12\x1f\n\x07\x63ontrol\x18\r \x01(\x0b\x32\x0e.nanit.Control\"\xa2\x01\n\x07Message\x12!\n\x04type\x18\x01 \x02(\x0e\x32\x13.nanit.Message.Type\x12\x1f\n\x07request\x18\x02 \x01(\x0b\x32\x0e.nanit.Request\x12!\n\x08response\x18\x03 \x01(\x0b\x32\x0f.nanit.Response\"0\n\x04Type\x12\r\n\tKEEPALIVE\x10\x00\x12\x0b\n\x07REQUEST\x10\x01\x12\x0c\n\x08RESPONSE\x10\x02*\xe0\x06\n\x0bRequestType\x12\x11\n\rPUT_STREAMING\x10\x02\x12\x11\n\rGET_STREAMING\x10\x03\x12\x10\n\x0cGET_SETTINGS\x10\x04\x12\x10\n\x0cPUT_SETTINGS\x10\x05\x12\x0f\n\x0bGET_CONTROL\x10\x06\x12\x0f\n\x0bPUT_CONTROL\x10\x07\x12\x0e\n\nGET_STATUS\x10\x08\x12\x0e\n\nPUT_STATUS\x10\t\x12\x13\n\x0fPUT_SENSOR_DATA\x10\x0b\x12\x13\n\x0fGET_SENSOR_DATA\x10\x0c\x12\x10\n\x0cGET_UCTOKENS\x10\r\x12\x10\n\x0cPUT_UCTOKENS\x10\x0e\x12\x15\n\x11PUT_SETUP_NETWORK\x10\x0f\x12\x14\n\x10PUT_SETUP_SERVER\x10\x10\x12\x10\n\x0cGET_FIRMWARE\x10\x11\x12\x10\n\x0cPUT_FIRMWARE\x10\x12\x12\x10\n\x0cGET_PLAYBACK\x10\x13\x12\x10\n\x0cPUT_PLAYBACK\x10\x14\x12\x13\n\x0fGET_SOUNDTRACKS\x10\x15\x12\x16\n\x12GET_STATUS_NETWORK\x10\x16\x12\x15\n\x11GET_LIST_NETWORKS\x10\x17\x12\x0c\n\x08GET_LOGS\x10\x18\x12\x11\n\rGET_BANDWIDTH\x10\x19\x12\x17\n\x13GET_AUDIO_STREAMING\x10\x1a\x12\x17\n\x13PUT_AUDIO_STREAMING\x10\x1b\x12\x12\n\x0eGET_WIFI_SETUP\x10\x1c\x12\x12\n\x0ePUT_WIFI_SETUP\x10\x1d\x12\x13\n\x0fPUT_STING_START\x10\x1e\x12\x12\n\x0ePUT_STING_STOP\x10\x1f\x12\x14\n\x10PUT_STING_STATUS\x10 \x12\x13\n\x0fPUT_STING_ALERT\x10\"\x12\x12\n\x0ePUT_KEEP_ALIVE\x10#\x12\x14\n\x10GET_STING_STATUS\x10$\x12\x12\n\x0ePUT_STING_TEST\x10%\x12\x16\n\x12PUT_RTSP_STREAMING\x10&\x12\x0f\n\x0bGET_UOM_URI\x10\'\x12\x0b\n\x07GET_UOM\x10(\x12\x0b\n\x07PUT_UOM\x10)\x12\x10\n\x0cGET_AUTH_KEY\x10*\x12\x10\n\x0cPUT_AUTH_KEY\x10+\x12\x0e\n\nPUT_HEALTH\x10,\x12\x13\n\x0fPUT_TCP_REQUEST\x10-\x12\x13\n\x0fGET_STING_START\x10.\x12\x10\n\x0cGET_LOGS_URI\x10/*X\n\nSensorType\x12\t\n\x05SOUND\x10\x00\x12\n\n\x06MOTION\x10\x01\x12\x0f\n\x0bTEMPERATURE\x10\x02\x12\x0c\n\x08HUMIDITY\x10\x03\x12\t\n\x05LIGHT\x10\x04\x12\t\n\x05NIGHT\x10\x05*6\n\x10StreamIdentifier\x12\x07\n\x03\x44VR\x10\x00\x12\r\n\tANALYTICS\x10\x01\x12\n\n\x06MOBILE\x10\x02*1\n\x0cMountingMode\x12\t\n\x05STAND\x10\x00\x12\n\n\x06TRAVEL\x10\x01\x12\n\n\x06SWITCH\x10\x02')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "nanit_pb2", _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'nanit_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
-    DESCRIPTOR._loaded_options = None
-    _globals["_REQUESTTYPE"]._serialized_start = 3357
-    _globals["_REQUESTTYPE"]._serialized_end = 4221
-    _globals["_SENSORTYPE"]._serialized_start = 4223
-    _globals["_SENSORTYPE"]._serialized_end = 4311
-    _globals["_STREAMIDENTIFIER"]._serialized_start = 4313
-    _globals["_STREAMIDENTIFIER"]._serialized_end = 4367
-    _globals["_MOUNTINGMODE"]._serialized_start = 4369
-    _globals["_MOUNTINGMODE"]._serialized_end = 4418
-    _globals["_SENSORDATA"]._serialized_start = 22
-    _globals["_SENSORDATA"]._serialized_end = 147
-    _globals["_GETSENSORDATA"]._serialized_start = 149
-    _globals["_GETSENSORDATA"]._serialized_end = 246
-    _globals["_GETCONTROL"]._serialized_start = 248
-    _globals["_GETCONTROL"]._serialized_end = 356
-    _globals["_CONTROL"]._serialized_start = 359
-    _globals["_CONTROL"]._serialized_end = 708
-    _globals["_CONTROL_SENSORDATATRANSFER"]._serialized_start = 545
-    _globals["_CONTROL_SENSORDATATRANSFER"]._serialized_end = 665
-    _globals["_CONTROL_NIGHTLIGHT"]._serialized_start = 667
-    _globals["_CONTROL_NIGHTLIGHT"]._serialized_end = 708
-    _globals["_SETTINGS"]._serialized_start = 711
-    _globals["_SETTINGS"]._serialized_end = 1575
-    _globals["_SETTINGS_SENSORSETTINGS"]._serialized_start = 1077
-    _globals["_SETTINGS_SENSORSETTINGS"]._serialized_end = 1328
-    _globals["_SETTINGS_STREAMSETTINGS"]._serialized_start = 1331
-    _globals["_SETTINGS_STREAMSETTINGS"]._serialized_end = 1487
-    _globals["_SETTINGS_ANTIFLICKER"]._serialized_start = 1489
-    _globals["_SETTINGS_ANTIFLICKER"]._serialized_end = 1526
-    _globals["_SETTINGS_WIFIBAND"]._serialized_start = 1528
-    _globals["_SETTINGS_WIFIBAND"]._serialized_end = 1575
-    _globals["_STATUS"]._serialized_start = 1578
-    _globals["_STATUS"]._serialized_end = 1876
-    _globals["_STATUS_CONNECTIONTOSERVER"]._serialized_start = 1823
-    _globals["_STATUS_CONNECTIONTOSERVER"]._serialized_end = 1876
-    _globals["_SOUNDTRACK"]._serialized_start = 1878
-    _globals["_SOUNDTRACK"]._serialized_end = 1922
-    _globals["_PLAYBACK"]._serialized_start = 1925
-    _globals["_PLAYBACK"]._serialized_end = 2081
-    _globals["_PLAYBACK_STATUS"]._serialized_start = 2047
-    _globals["_PLAYBACK_STATUS"]._serialized_end = 2081
-    _globals["_STREAM"]._serialized_start = 2083
-    _globals["_STREAM"]._serialized_end = 2201
-    _globals["_STREAM_TYPE"]._serialized_start = 2153
-    _globals["_STREAM_TYPE"]._serialized_end = 2201
-    _globals["_STREAMING"]._serialized_start = 2204
-    _globals["_STREAMING"]._serialized_end = 2377
-    _globals["_STREAMING_STATUS"]._serialized_start = 2331
-    _globals["_STREAMING_STATUS"]._serialized_end = 2377
-    _globals["_GETLOGS"]._serialized_start = 2379
-    _globals["_GETLOGS"]._serialized_end = 2401
-    _globals["_GETSTATUS"]._serialized_start = 2403
-    _globals["_GETSTATUS"]._serialized_end = 2427
-    _globals["_REQUEST"]._serialized_start = 2430
-    _globals["_REQUEST"]._serialized_end = 2855
-    _globals["_RESPONSE"]._serialized_start = 2858
-    _globals["_RESPONSE"]._serialized_end = 3189
-    _globals["_MESSAGE"]._serialized_start = 3192
-    _globals["_MESSAGE"]._serialized_end = 3354
-    _globals["_MESSAGE_TYPE"]._serialized_start = 3306
-    _globals["_MESSAGE_TYPE"]._serialized_end = 3354
+  DESCRIPTOR._loaded_options = None
+  _globals['_REQUESTTYPE']._serialized_start=3375
+  _globals['_REQUESTTYPE']._serialized_end=4239
+  _globals['_SENSORTYPE']._serialized_start=4241
+  _globals['_SENSORTYPE']._serialized_end=4329
+  _globals['_STREAMIDENTIFIER']._serialized_start=4331
+  _globals['_STREAMIDENTIFIER']._serialized_end=4385
+  _globals['_MOUNTINGMODE']._serialized_start=4387
+  _globals['_MOUNTINGMODE']._serialized_end=4436
+  _globals['_SENSORDATA']._serialized_start=22
+  _globals['_SENSORDATA']._serialized_end=147
+  _globals['_GETSENSORDATA']._serialized_start=149
+  _globals['_GETSENSORDATA']._serialized_end=246
+  _globals['_GETCONTROL']._serialized_start=248
+  _globals['_GETCONTROL']._serialized_end=356
+  _globals['_CONTROL']._serialized_start=359
+  _globals['_CONTROL']._serialized_end=708
+  _globals['_CONTROL_SENSORDATATRANSFER']._serialized_start=545
+  _globals['_CONTROL_SENSORDATATRANSFER']._serialized_end=665
+  _globals['_CONTROL_NIGHTLIGHT']._serialized_start=667
+  _globals['_CONTROL_NIGHTLIGHT']._serialized_end=708
+  _globals['_SETTINGS']._serialized_start=711
+  _globals['_SETTINGS']._serialized_end=1575
+  _globals['_SETTINGS_SENSORSETTINGS']._serialized_start=1077
+  _globals['_SETTINGS_SENSORSETTINGS']._serialized_end=1328
+  _globals['_SETTINGS_STREAMSETTINGS']._serialized_start=1331
+  _globals['_SETTINGS_STREAMSETTINGS']._serialized_end=1487
+  _globals['_SETTINGS_ANTIFLICKER']._serialized_start=1489
+  _globals['_SETTINGS_ANTIFLICKER']._serialized_end=1526
+  _globals['_SETTINGS_WIFIBAND']._serialized_start=1528
+  _globals['_SETTINGS_WIFIBAND']._serialized_end=1575
+  _globals['_STATUS']._serialized_start=1578
+  _globals['_STATUS']._serialized_end=1876
+  _globals['_STATUS_CONNECTIONTOSERVER']._serialized_start=1823
+  _globals['_STATUS_CONNECTIONTOSERVER']._serialized_end=1876
+  _globals['_SOUNDTRACK']._serialized_start=1878
+  _globals['_SOUNDTRACK']._serialized_end=1922
+  _globals['_PLAYBACK']._serialized_start=1925
+  _globals['_PLAYBACK']._serialized_end=2099
+  _globals['_PLAYBACK_STATUS']._serialized_start=2065
+  _globals['_PLAYBACK_STATUS']._serialized_end=2099
+  _globals['_STREAM']._serialized_start=2101
+  _globals['_STREAM']._serialized_end=2219
+  _globals['_STREAM_TYPE']._serialized_start=2171
+  _globals['_STREAM_TYPE']._serialized_end=2219
+  _globals['_STREAMING']._serialized_start=2222
+  _globals['_STREAMING']._serialized_end=2395
+  _globals['_STREAMING_STATUS']._serialized_start=2349
+  _globals['_STREAMING_STATUS']._serialized_end=2395
+  _globals['_GETLOGS']._serialized_start=2397
+  _globals['_GETLOGS']._serialized_end=2419
+  _globals['_GETSTATUS']._serialized_start=2421
+  _globals['_GETSTATUS']._serialized_end=2445
+  _globals['_REQUEST']._serialized_start=2448
+  _globals['_REQUEST']._serialized_end=2873
+  _globals['_RESPONSE']._serialized_start=2876
+  _globals['_RESPONSE']._serialized_end=3207
+  _globals['_MESSAGE']._serialized_start=3210
+  _globals['_MESSAGE']._serialized_end=3372
+  _globals['_MESSAGE_TYPE']._serialized_start=3324
+  _globals['_MESSAGE_TYPE']._serialized_end=3372
 # @@protoc_insertion_point(module_scope)

--- a/packages/aionanit/aionanit/proto/nanit_pb2.py
+++ b/packages/aionanit/aionanit/proto/nanit_pb2.py
@@ -4,91 +4,88 @@
 # source: nanit.proto
 # Protobuf Python Version: 6.31.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
+
 _runtime_version.ValidateProtobufRuntimeVersion(
-    _runtime_version.Domain.PUBLIC,
-    6,
-    31,
-    1,
-    '',
-    'nanit.proto'
+    _runtime_version.Domain.PUBLIC, 6, 31, 1, "", "nanit.proto"
 )
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0bnanit.proto\x12\x05nanit\"}\n\nSensorData\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\r\n\x05value\x18\x03 \x01(\x05\x12\x10\n\x08is_alert\x18\x04 \x01(\x08\x12\x11\n\ttimestamp\x18\x05 \x01(\x05\x12\x13\n\x0bvalue_milli\x18\x06 \x01(\x05\"a\n\rGetSensorData\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\x12\x13\n\x0btemperature\x18\x04 \x01(\x08\x12\x10\n\x08humidity\x18\x05 \x01(\x08\x12\r\n\x05light\x18\x06 \x01(\x08\x12\r\n\x05night\x18\x07 \x01(\x08\"l\n\nGetControl\x12\x0b\n\x03ptz\x18\x01 \x01(\x08\x12\x13\n\x0bnight_light\x18\x02 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x03 \x01(\x08\x12\x1f\n\x17sensor_data_transfer_en\x18\x04 \x01(\x08\"\xdd\x02\n\x07\x43ontrol\x12.\n\x0bnight_light\x18\x03 \x01(\x0e\x32\x19.nanit.Control.NightLight\x12?\n\x14sensor_data_transfer\x18\x04 \x01(\x0b\x32!.nanit.Control.SensorDataTransfer\x12\x1f\n\x17\x66orce_connect_to_server\x18\x05 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x06 \x01(\x05\x1ax\n\x12SensorDataTransfer\x12\r\n\x05sound\x18\x01 \x01(\x08\x12\x0e\n\x06motion\x18\x02 \x01(\x08\x12\x13\n\x0btemperature\x18\x03 \x01(\x08\x12\x10\n\x08humidity\x18\x04 \x01(\x08\x12\r\n\x05light\x18\x05 \x01(\x08\x12\r\n\x05night\x18\x06 \x01(\x08\")\n\nNightLight\x12\r\n\tLIGHT_OFF\x10\x00\x12\x0c\n\x08LIGHT_ON\x10\x01\"\xe0\x06\n\x08Settings\x12\x14\n\x0cnight_vision\x18\x02 \x01(\x08\x12/\n\x07sensors\x18\x07 \x03(\x0b\x32\x1e.nanit.Settings.SensorSettings\x12/\n\x07streams\x18\x08 \x03(\x0b\x32\x1e.nanit.Settings.StreamSettings\x12\x0e\n\x06volume\x18\t \x01(\x05\x12\x31\n\x0c\x61nti_flicker\x18\n \x01(\x0e\x32\x1b.nanit.Settings.AntiFlicker\x12\x12\n\nsleep_mode\x18\x0b \x01(\x08\x12\x17\n\x0fstatus_light_on\x18\x0c \x01(\x08\x12\x15\n\rmounting_mode\x18\x0f \x01(\x05\x12+\n\twifi_band\x18\x12 \x01(\x0e\x32\x18.nanit.Settings.WifiBand\x12\x13\n\x0bmic_mute_on\x18\x14 \x01(\x08\x12\x1e\n\x16night_light_brightness\x18\x18 \x01(\x05\x1a\xfb\x01\n\x0eSensorSettings\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\x19\n\x11use_low_threshold\x18\x02 \x01(\x08\x12\x1a\n\x12use_high_threshold\x18\x03 \x01(\x08\x12\x15\n\rlow_threshold\x18\x04 \x01(\x05\x12\x16\n\x0ehigh_threshold\x18\x05 \x01(\x05\x12\x1b\n\x13sample_interval_sec\x18\x06 \x01(\x05\x12\x1c\n\x14trigger_interval_sec\x18\x07 \x01(\x05\x12 \n\x18use_milli_for_thresholds\x18\x08 \x01(\x08\x1a\x9c\x01\n\x0eStreamSettings\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\x05\x12\x17\n\x0f\x65\x63onomy_bitrate\x18\x03 \x01(\x05\x12\x13\n\x0b\x65\x63onomy_fps\x18\x04 \x01(\x05\x12\x14\n\x0c\x62\x65st_bitrate\x18\x05 \x01(\x05\x12\x10\n\x08\x62\x65st_fps\x18\x06 \x01(\x05\"%\n\x0b\x41ntiFlicker\x12\n\n\x06\x46R50HZ\x10\x00\x12\n\n\x06\x46R60HZ\x10\x01\"/\n\x08WifiBand\x12\x07\n\x03\x41NY\x10\x00\x12\x0c\n\x08\x46R2_4GHZ\x10\x01\x12\x0c\n\x08\x46R5_0GHZ\x10\x02\"\xaa\x02\n\x06Status\x12\x1a\n\x12upgrade_downloaded\x18\x01 \x01(\x08\x12>\n\x14\x63onnection_to_server\x18\x02 \x01(\x0e\x32 .nanit.Status.ConnectionToServer\x12\x17\n\x0f\x63urrent_version\x18\x03 \x01(\t\x12!\n\x04mode\x18\x04 \x01(\x0e\x32\x13.nanit.MountingMode\x12\x1b\n\x13is_security_upgrade\x18\x05 \x01(\x08\x12\x1a\n\x12\x64ownloaded_version\x18\x06 \x01(\t\x12\x18\n\x10hardware_version\x18\x07 \x01(\t\"5\n\x12\x43onnectionToServer\x12\x10\n\x0c\x44ISCONNECTED\x10\x00\x12\r\n\tCONNECTED\x10\x01\",\n\nSoundtrack\x12\x0c\n\x04type\x18\x01 \x01(\x05\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\"\xae\x01\n\x08Playback\x12&\n\x06status\x18\x01 \x02(\x0e\x32\x16.nanit.Playback.Status\x12\x10\n\x08\x64uration\x18\x02 \x01(\x05\x12 \n\x05track\x18\x03 \x01(\x0b\x32\x11.nanit.Soundtrack\x12\"\n\x07\x63urrent\x18\x04 \x01(\x0b\x32\x11.nanit.Soundtrack\"\"\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\"v\n\x06Stream\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.nanit.Stream.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x0b\n\x03\x62ps\x18\x03 \x01(\x05\"0\n\x04Type\x12\t\n\x05LOCAL\x10\x00\x12\n\n\x06REMOTE\x10\x01\x12\x08\n\x04RTSP\x10\x02\x12\x07\n\x03P2P\x10\x03\"\xad\x01\n\tStreaming\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\'\n\x06status\x18\x02 \x02(\x0e\x32\x17.nanit.Streaming.Status\x12\x10\n\x08rtmp_url\x18\x03 \x02(\t\x12\x10\n\x08\x61ttempts\x18\x04 \x01(\x05\".\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\x12\n\n\x06PAUSED\x10\x02\"\x16\n\x07GetLogs\x12\x0b\n\x03url\x18\x01 \x02(\t\"\x18\n\tGetStatus\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\"\xa9\x03\n\x07Request\x12\n\n\x02id\x18\x01 \x02(\x05\x12 \n\x04type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12#\n\tstreaming\x18\x04 \x01(\x0b\x32\x10.nanit.Streaming\x12!\n\x08settings\x18\x05 \x01(\x0b\x32\x0f.nanit.Settings\x12\x1d\n\x06status\x18\x07 \x01(\x0b\x32\r.nanit.Status\x12$\n\nget_status\x18\x08 \x01(\x0b\x32\x10.nanit.GetStatus\x12-\n\x0fget_sensor_data\x18\x0c \x01(\x0b\x32\x14.nanit.GetSensorData\x12&\n\x0bsensor_data\x18\r \x03(\x0b\x32\x11.nanit.SensorData\x12\x1f\n\x07\x63ontrol\x18\x0f \x01(\x0b\x32\x0e.nanit.Control\x12!\n\x08playback\x18\x10 \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bget_control\x18\x11 \x01(\x0b\x32\x11.nanit.GetControl\x12 \n\x08get_logs\x18\x12 \x01(\x0b\x32\x0e.nanit.GetLogs\"\xcb\x02\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x02(\x05\x12(\n\x0crequest_type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12\x13\n\x0bstatus_code\x18\x03 \x02(\x05\x12\x16\n\x0estatus_message\x18\x04 \x01(\t\x12\x1d\n\x06status\x18\x05 \x01(\x0b\x32\r.nanit.Status\x12!\n\x08settings\x18\x06 \x01(\x0b\x32\x0f.nanit.Settings\x12&\n\x0bsensor_data\x18\t \x03(\x0b\x32\x11.nanit.SensorData\x12!\n\x08playback\x18\x0b \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bsoundtracks\x18\x0c \x03(\x0b\x32\x11.nanit.Soundtrack\x12\x1f\n\x07\x63ontrol\x18\r \x01(\x0b\x32\x0e.nanit.Control\"\xa2\x01\n\x07Message\x12!\n\x04type\x18\x01 \x02(\x0e\x32\x13.nanit.Message.Type\x12\x1f\n\x07request\x18\x02 \x01(\x0b\x32\x0e.nanit.Request\x12!\n\x08response\x18\x03 \x01(\x0b\x32\x0f.nanit.Response\"0\n\x04Type\x12\r\n\tKEEPALIVE\x10\x00\x12\x0b\n\x07REQUEST\x10\x01\x12\x0c\n\x08RESPONSE\x10\x02*\xe0\x06\n\x0bRequestType\x12\x11\n\rPUT_STREAMING\x10\x02\x12\x11\n\rGET_STREAMING\x10\x03\x12\x10\n\x0cGET_SETTINGS\x10\x04\x12\x10\n\x0cPUT_SETTINGS\x10\x05\x12\x0f\n\x0bGET_CONTROL\x10\x06\x12\x0f\n\x0bPUT_CONTROL\x10\x07\x12\x0e\n\nGET_STATUS\x10\x08\x12\x0e\n\nPUT_STATUS\x10\t\x12\x13\n\x0fPUT_SENSOR_DATA\x10\x0b\x12\x13\n\x0fGET_SENSOR_DATA\x10\x0c\x12\x10\n\x0cGET_UCTOKENS\x10\r\x12\x10\n\x0cPUT_UCTOKENS\x10\x0e\x12\x15\n\x11PUT_SETUP_NETWORK\x10\x0f\x12\x14\n\x10PUT_SETUP_SERVER\x10\x10\x12\x10\n\x0cGET_FIRMWARE\x10\x11\x12\x10\n\x0cPUT_FIRMWARE\x10\x12\x12\x10\n\x0cGET_PLAYBACK\x10\x13\x12\x10\n\x0cPUT_PLAYBACK\x10\x14\x12\x13\n\x0fGET_SOUNDTRACKS\x10\x15\x12\x16\n\x12GET_STATUS_NETWORK\x10\x16\x12\x15\n\x11GET_LIST_NETWORKS\x10\x17\x12\x0c\n\x08GET_LOGS\x10\x18\x12\x11\n\rGET_BANDWIDTH\x10\x19\x12\x17\n\x13GET_AUDIO_STREAMING\x10\x1a\x12\x17\n\x13PUT_AUDIO_STREAMING\x10\x1b\x12\x12\n\x0eGET_WIFI_SETUP\x10\x1c\x12\x12\n\x0ePUT_WIFI_SETUP\x10\x1d\x12\x13\n\x0fPUT_STING_START\x10\x1e\x12\x12\n\x0ePUT_STING_STOP\x10\x1f\x12\x14\n\x10PUT_STING_STATUS\x10 \x12\x13\n\x0fPUT_STING_ALERT\x10\"\x12\x12\n\x0ePUT_KEEP_ALIVE\x10#\x12\x14\n\x10GET_STING_STATUS\x10$\x12\x12\n\x0ePUT_STING_TEST\x10%\x12\x16\n\x12PUT_RTSP_STREAMING\x10&\x12\x0f\n\x0bGET_UOM_URI\x10\'\x12\x0b\n\x07GET_UOM\x10(\x12\x0b\n\x07PUT_UOM\x10)\x12\x10\n\x0cGET_AUTH_KEY\x10*\x12\x10\n\x0cPUT_AUTH_KEY\x10+\x12\x0e\n\nPUT_HEALTH\x10,\x12\x13\n\x0fPUT_TCP_REQUEST\x10-\x12\x13\n\x0fGET_STING_START\x10.\x12\x10\n\x0cGET_LOGS_URI\x10/*X\n\nSensorType\x12\t\n\x05SOUND\x10\x00\x12\n\n\x06MOTION\x10\x01\x12\x0f\n\x0bTEMPERATURE\x10\x02\x12\x0c\n\x08HUMIDITY\x10\x03\x12\t\n\x05LIGHT\x10\x04\x12\t\n\x05NIGHT\x10\x05*6\n\x10StreamIdentifier\x12\x07\n\x03\x44VR\x10\x00\x12\r\n\tANALYTICS\x10\x01\x12\n\n\x06MOBILE\x10\x02*1\n\x0cMountingMode\x12\t\n\x05STAND\x10\x00\x12\n\n\x06TRAVEL\x10\x01\x12\n\n\x06SWITCH\x10\x02')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x0bnanit.proto\x12\x05nanit"}\n\nSensorData\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\r\n\x05value\x18\x03 \x01(\x05\x12\x10\n\x08is_alert\x18\x04 \x01(\x08\x12\x11\n\ttimestamp\x18\x05 \x01(\x05\x12\x13\n\x0bvalue_milli\x18\x06 \x01(\x05"a\n\rGetSensorData\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08\x12\x13\n\x0btemperature\x18\x04 \x01(\x08\x12\x10\n\x08humidity\x18\x05 \x01(\x08\x12\r\n\x05light\x18\x06 \x01(\x08\x12\r\n\x05night\x18\x07 \x01(\x08"l\n\nGetControl\x12\x0b\n\x03ptz\x18\x01 \x01(\x08\x12\x13\n\x0bnight_light\x18\x02 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x03 \x01(\x08\x12\x1f\n\x17sensor_data_transfer_en\x18\x04 \x01(\x08"\xdd\x02\n\x07\x43ontrol\x12.\n\x0bnight_light\x18\x03 \x01(\x0e\x32\x19.nanit.Control.NightLight\x12?\n\x14sensor_data_transfer\x18\x04 \x01(\x0b\x32!.nanit.Control.SensorDataTransfer\x12\x1f\n\x17\x66orce_connect_to_server\x18\x05 \x01(\x08\x12\x1b\n\x13night_light_timeout\x18\x06 \x01(\x05\x1ax\n\x12SensorDataTransfer\x12\r\n\x05sound\x18\x01 \x01(\x08\x12\x0e\n\x06motion\x18\x02 \x01(\x08\x12\x13\n\x0btemperature\x18\x03 \x01(\x08\x12\x10\n\x08humidity\x18\x04 \x01(\x08\x12\r\n\x05light\x18\x05 \x01(\x08\x12\r\n\x05night\x18\x06 \x01(\x08")\n\nNightLight\x12\r\n\tLIGHT_OFF\x10\x00\x12\x0c\n\x08LIGHT_ON\x10\x01"\xe0\x06\n\x08Settings\x12\x14\n\x0cnight_vision\x18\x02 \x01(\x08\x12/\n\x07sensors\x18\x07 \x03(\x0b\x32\x1e.nanit.Settings.SensorSettings\x12/\n\x07streams\x18\x08 \x03(\x0b\x32\x1e.nanit.Settings.StreamSettings\x12\x0e\n\x06volume\x18\t \x01(\x05\x12\x31\n\x0c\x61nti_flicker\x18\n \x01(\x0e\x32\x1b.nanit.Settings.AntiFlicker\x12\x12\n\nsleep_mode\x18\x0b \x01(\x08\x12\x17\n\x0fstatus_light_on\x18\x0c \x01(\x08\x12\x15\n\rmounting_mode\x18\x0f \x01(\x05\x12+\n\twifi_band\x18\x12 \x01(\x0e\x32\x18.nanit.Settings.WifiBand\x12\x13\n\x0bmic_mute_on\x18\x14 \x01(\x08\x12\x1e\n\x16night_light_brightness\x18\x18 \x01(\x05\x1a\xfb\x01\n\x0eSensorSettings\x12&\n\x0bsensor_type\x18\x01 \x02(\x0e\x32\x11.nanit.SensorType\x12\x19\n\x11use_low_threshold\x18\x02 \x01(\x08\x12\x1a\n\x12use_high_threshold\x18\x03 \x01(\x08\x12\x15\n\rlow_threshold\x18\x04 \x01(\x05\x12\x16\n\x0ehigh_threshold\x18\x05 \x01(\x05\x12\x1b\n\x13sample_interval_sec\x18\x06 \x01(\x05\x12\x1c\n\x14trigger_interval_sec\x18\x07 \x01(\x05\x12 \n\x18use_milli_for_thresholds\x18\x08 \x01(\x08\x1a\x9c\x01\n\x0eStreamSettings\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\x0f\n\x07\x62itrate\x18\x02 \x01(\x05\x12\x17\n\x0f\x65\x63onomy_bitrate\x18\x03 \x01(\x05\x12\x13\n\x0b\x65\x63onomy_fps\x18\x04 \x01(\x05\x12\x14\n\x0c\x62\x65st_bitrate\x18\x05 \x01(\x05\x12\x10\n\x08\x62\x65st_fps\x18\x06 \x01(\x05"%\n\x0b\x41ntiFlicker\x12\n\n\x06\x46R50HZ\x10\x00\x12\n\n\x06\x46R60HZ\x10\x01"/\n\x08WifiBand\x12\x07\n\x03\x41NY\x10\x00\x12\x0c\n\x08\x46R2_4GHZ\x10\x01\x12\x0c\n\x08\x46R5_0GHZ\x10\x02"\xaa\x02\n\x06Status\x12\x1a\n\x12upgrade_downloaded\x18\x01 \x01(\x08\x12>\n\x14\x63onnection_to_server\x18\x02 \x01(\x0e\x32 .nanit.Status.ConnectionToServer\x12\x17\n\x0f\x63urrent_version\x18\x03 \x01(\t\x12!\n\x04mode\x18\x04 \x01(\x0e\x32\x13.nanit.MountingMode\x12\x1b\n\x13is_security_upgrade\x18\x05 \x01(\x08\x12\x1a\n\x12\x64ownloaded_version\x18\x06 \x01(\t\x12\x18\n\x10hardware_version\x18\x07 \x01(\t"5\n\x12\x43onnectionToServer\x12\x10\n\x0c\x44ISCONNECTED\x10\x00\x12\r\n\tCONNECTED\x10\x01",\n\nSoundtrack\x12\x0c\n\x04type\x18\x01 \x01(\x05\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t"\xae\x01\n\x08Playback\x12&\n\x06status\x18\x01 \x02(\x0e\x32\x16.nanit.Playback.Status\x12\x10\n\x08\x64uration\x18\x02 \x01(\x05\x12 \n\x05track\x18\x03 \x01(\x0b\x32\x11.nanit.Soundtrack\x12"\n\x07\x63urrent\x18\x04 \x01(\x0b\x32\x11.nanit.Soundtrack""\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01"v\n\x06Stream\x12 \n\x04type\x18\x01 \x02(\x0e\x32\x12.nanit.Stream.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x0b\n\x03\x62ps\x18\x03 \x01(\x05"0\n\x04Type\x12\t\n\x05LOCAL\x10\x00\x12\n\n\x06REMOTE\x10\x01\x12\x08\n\x04RTSP\x10\x02\x12\x07\n\x03P2P\x10\x03"\xad\x01\n\tStreaming\x12#\n\x02id\x18\x01 \x02(\x0e\x32\x17.nanit.StreamIdentifier\x12\'\n\x06status\x18\x02 \x02(\x0e\x32\x17.nanit.Streaming.Status\x12\x10\n\x08rtmp_url\x18\x03 \x02(\t\x12\x10\n\x08\x61ttempts\x18\x04 \x01(\x05".\n\x06Status\x12\x0b\n\x07STARTED\x10\x00\x12\x0b\n\x07STOPPED\x10\x01\x12\n\n\x06PAUSED\x10\x02"\x16\n\x07GetLogs\x12\x0b\n\x03url\x18\x01 \x02(\t"\x18\n\tGetStatus\x12\x0b\n\x03\x61ll\x18\x01 \x01(\x08"\xa9\x03\n\x07Request\x12\n\n\x02id\x18\x01 \x02(\x05\x12 \n\x04type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12#\n\tstreaming\x18\x04 \x01(\x0b\x32\x10.nanit.Streaming\x12!\n\x08settings\x18\x05 \x01(\x0b\x32\x0f.nanit.Settings\x12\x1d\n\x06status\x18\x07 \x01(\x0b\x32\r.nanit.Status\x12$\n\nget_status\x18\x08 \x01(\x0b\x32\x10.nanit.GetStatus\x12-\n\x0fget_sensor_data\x18\x0c \x01(\x0b\x32\x14.nanit.GetSensorData\x12&\n\x0bsensor_data\x18\r \x03(\x0b\x32\x11.nanit.SensorData\x12\x1f\n\x07\x63ontrol\x18\x0f \x01(\x0b\x32\x0e.nanit.Control\x12!\n\x08playback\x18\x10 \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bget_control\x18\x11 \x01(\x0b\x32\x11.nanit.GetControl\x12 \n\x08get_logs\x18\x12 \x01(\x0b\x32\x0e.nanit.GetLogs"\xcb\x02\n\x08Response\x12\x12\n\nrequest_id\x18\x01 \x02(\x05\x12(\n\x0crequest_type\x18\x02 \x02(\x0e\x32\x12.nanit.RequestType\x12\x13\n\x0bstatus_code\x18\x03 \x02(\x05\x12\x16\n\x0estatus_message\x18\x04 \x01(\t\x12\x1d\n\x06status\x18\x05 \x01(\x0b\x32\r.nanit.Status\x12!\n\x08settings\x18\x06 \x01(\x0b\x32\x0f.nanit.Settings\x12&\n\x0bsensor_data\x18\t \x03(\x0b\x32\x11.nanit.SensorData\x12!\n\x08playback\x18\x0b \x01(\x0b\x32\x0f.nanit.Playback\x12&\n\x0bsoundtracks\x18\x0c \x03(\x0b\x32\x11.nanit.Soundtrack\x12\x1f\n\x07\x63ontrol\x18\r \x01(\x0b\x32\x0e.nanit.Control"\xa2\x01\n\x07Message\x12!\n\x04type\x18\x01 \x02(\x0e\x32\x13.nanit.Message.Type\x12\x1f\n\x07request\x18\x02 \x01(\x0b\x32\x0e.nanit.Request\x12!\n\x08response\x18\x03 \x01(\x0b\x32\x0f.nanit.Response"0\n\x04Type\x12\r\n\tKEEPALIVE\x10\x00\x12\x0b\n\x07REQUEST\x10\x01\x12\x0c\n\x08RESPONSE\x10\x02*\xe0\x06\n\x0bRequestType\x12\x11\n\rPUT_STREAMING\x10\x02\x12\x11\n\rGET_STREAMING\x10\x03\x12\x10\n\x0cGET_SETTINGS\x10\x04\x12\x10\n\x0cPUT_SETTINGS\x10\x05\x12\x0f\n\x0bGET_CONTROL\x10\x06\x12\x0f\n\x0bPUT_CONTROL\x10\x07\x12\x0e\n\nGET_STATUS\x10\x08\x12\x0e\n\nPUT_STATUS\x10\t\x12\x13\n\x0fPUT_SENSOR_DATA\x10\x0b\x12\x13\n\x0fGET_SENSOR_DATA\x10\x0c\x12\x10\n\x0cGET_UCTOKENS\x10\r\x12\x10\n\x0cPUT_UCTOKENS\x10\x0e\x12\x15\n\x11PUT_SETUP_NETWORK\x10\x0f\x12\x14\n\x10PUT_SETUP_SERVER\x10\x10\x12\x10\n\x0cGET_FIRMWARE\x10\x11\x12\x10\n\x0cPUT_FIRMWARE\x10\x12\x12\x10\n\x0cGET_PLAYBACK\x10\x13\x12\x10\n\x0cPUT_PLAYBACK\x10\x14\x12\x13\n\x0fGET_SOUNDTRACKS\x10\x15\x12\x16\n\x12GET_STATUS_NETWORK\x10\x16\x12\x15\n\x11GET_LIST_NETWORKS\x10\x17\x12\x0c\n\x08GET_LOGS\x10\x18\x12\x11\n\rGET_BANDWIDTH\x10\x19\x12\x17\n\x13GET_AUDIO_STREAMING\x10\x1a\x12\x17\n\x13PUT_AUDIO_STREAMING\x10\x1b\x12\x12\n\x0eGET_WIFI_SETUP\x10\x1c\x12\x12\n\x0ePUT_WIFI_SETUP\x10\x1d\x12\x13\n\x0fPUT_STING_START\x10\x1e\x12\x12\n\x0ePUT_STING_STOP\x10\x1f\x12\x14\n\x10PUT_STING_STATUS\x10 \x12\x13\n\x0fPUT_STING_ALERT\x10"\x12\x12\n\x0ePUT_KEEP_ALIVE\x10#\x12\x14\n\x10GET_STING_STATUS\x10$\x12\x12\n\x0ePUT_STING_TEST\x10%\x12\x16\n\x12PUT_RTSP_STREAMING\x10&\x12\x0f\n\x0bGET_UOM_URI\x10\'\x12\x0b\n\x07GET_UOM\x10(\x12\x0b\n\x07PUT_UOM\x10)\x12\x10\n\x0cGET_AUTH_KEY\x10*\x12\x10\n\x0cPUT_AUTH_KEY\x10+\x12\x0e\n\nPUT_HEALTH\x10,\x12\x13\n\x0fPUT_TCP_REQUEST\x10-\x12\x13\n\x0fGET_STING_START\x10.\x12\x10\n\x0cGET_LOGS_URI\x10/*X\n\nSensorType\x12\t\n\x05SOUND\x10\x00\x12\n\n\x06MOTION\x10\x01\x12\x0f\n\x0bTEMPERATURE\x10\x02\x12\x0c\n\x08HUMIDITY\x10\x03\x12\t\n\x05LIGHT\x10\x04\x12\t\n\x05NIGHT\x10\x05*6\n\x10StreamIdentifier\x12\x07\n\x03\x44VR\x10\x00\x12\r\n\tANALYTICS\x10\x01\x12\n\n\x06MOBILE\x10\x02*1\n\x0cMountingMode\x12\t\n\x05STAND\x10\x00\x12\n\n\x06TRAVEL\x10\x01\x12\n\n\x06SWITCH\x10\x02'
+)
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'nanit_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "nanit_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
-  DESCRIPTOR._loaded_options = None
-  _globals['_REQUESTTYPE']._serialized_start=3375
-  _globals['_REQUESTTYPE']._serialized_end=4239
-  _globals['_SENSORTYPE']._serialized_start=4241
-  _globals['_SENSORTYPE']._serialized_end=4329
-  _globals['_STREAMIDENTIFIER']._serialized_start=4331
-  _globals['_STREAMIDENTIFIER']._serialized_end=4385
-  _globals['_MOUNTINGMODE']._serialized_start=4387
-  _globals['_MOUNTINGMODE']._serialized_end=4436
-  _globals['_SENSORDATA']._serialized_start=22
-  _globals['_SENSORDATA']._serialized_end=147
-  _globals['_GETSENSORDATA']._serialized_start=149
-  _globals['_GETSENSORDATA']._serialized_end=246
-  _globals['_GETCONTROL']._serialized_start=248
-  _globals['_GETCONTROL']._serialized_end=356
-  _globals['_CONTROL']._serialized_start=359
-  _globals['_CONTROL']._serialized_end=708
-  _globals['_CONTROL_SENSORDATATRANSFER']._serialized_start=545
-  _globals['_CONTROL_SENSORDATATRANSFER']._serialized_end=665
-  _globals['_CONTROL_NIGHTLIGHT']._serialized_start=667
-  _globals['_CONTROL_NIGHTLIGHT']._serialized_end=708
-  _globals['_SETTINGS']._serialized_start=711
-  _globals['_SETTINGS']._serialized_end=1575
-  _globals['_SETTINGS_SENSORSETTINGS']._serialized_start=1077
-  _globals['_SETTINGS_SENSORSETTINGS']._serialized_end=1328
-  _globals['_SETTINGS_STREAMSETTINGS']._serialized_start=1331
-  _globals['_SETTINGS_STREAMSETTINGS']._serialized_end=1487
-  _globals['_SETTINGS_ANTIFLICKER']._serialized_start=1489
-  _globals['_SETTINGS_ANTIFLICKER']._serialized_end=1526
-  _globals['_SETTINGS_WIFIBAND']._serialized_start=1528
-  _globals['_SETTINGS_WIFIBAND']._serialized_end=1575
-  _globals['_STATUS']._serialized_start=1578
-  _globals['_STATUS']._serialized_end=1876
-  _globals['_STATUS_CONNECTIONTOSERVER']._serialized_start=1823
-  _globals['_STATUS_CONNECTIONTOSERVER']._serialized_end=1876
-  _globals['_SOUNDTRACK']._serialized_start=1878
-  _globals['_SOUNDTRACK']._serialized_end=1922
-  _globals['_PLAYBACK']._serialized_start=1925
-  _globals['_PLAYBACK']._serialized_end=2099
-  _globals['_PLAYBACK_STATUS']._serialized_start=2065
-  _globals['_PLAYBACK_STATUS']._serialized_end=2099
-  _globals['_STREAM']._serialized_start=2101
-  _globals['_STREAM']._serialized_end=2219
-  _globals['_STREAM_TYPE']._serialized_start=2171
-  _globals['_STREAM_TYPE']._serialized_end=2219
-  _globals['_STREAMING']._serialized_start=2222
-  _globals['_STREAMING']._serialized_end=2395
-  _globals['_STREAMING_STATUS']._serialized_start=2349
-  _globals['_STREAMING_STATUS']._serialized_end=2395
-  _globals['_GETLOGS']._serialized_start=2397
-  _globals['_GETLOGS']._serialized_end=2419
-  _globals['_GETSTATUS']._serialized_start=2421
-  _globals['_GETSTATUS']._serialized_end=2445
-  _globals['_REQUEST']._serialized_start=2448
-  _globals['_REQUEST']._serialized_end=2873
-  _globals['_RESPONSE']._serialized_start=2876
-  _globals['_RESPONSE']._serialized_end=3207
-  _globals['_MESSAGE']._serialized_start=3210
-  _globals['_MESSAGE']._serialized_end=3372
-  _globals['_MESSAGE_TYPE']._serialized_start=3324
-  _globals['_MESSAGE_TYPE']._serialized_end=3372
+    DESCRIPTOR._loaded_options = None
+    _globals["_REQUESTTYPE"]._serialized_start = 3375
+    _globals["_REQUESTTYPE"]._serialized_end = 4239
+    _globals["_SENSORTYPE"]._serialized_start = 4241
+    _globals["_SENSORTYPE"]._serialized_end = 4329
+    _globals["_STREAMIDENTIFIER"]._serialized_start = 4331
+    _globals["_STREAMIDENTIFIER"]._serialized_end = 4385
+    _globals["_MOUNTINGMODE"]._serialized_start = 4387
+    _globals["_MOUNTINGMODE"]._serialized_end = 4436
+    _globals["_SENSORDATA"]._serialized_start = 22
+    _globals["_SENSORDATA"]._serialized_end = 147
+    _globals["_GETSENSORDATA"]._serialized_start = 149
+    _globals["_GETSENSORDATA"]._serialized_end = 246
+    _globals["_GETCONTROL"]._serialized_start = 248
+    _globals["_GETCONTROL"]._serialized_end = 356
+    _globals["_CONTROL"]._serialized_start = 359
+    _globals["_CONTROL"]._serialized_end = 708
+    _globals["_CONTROL_SENSORDATATRANSFER"]._serialized_start = 545
+    _globals["_CONTROL_SENSORDATATRANSFER"]._serialized_end = 665
+    _globals["_CONTROL_NIGHTLIGHT"]._serialized_start = 667
+    _globals["_CONTROL_NIGHTLIGHT"]._serialized_end = 708
+    _globals["_SETTINGS"]._serialized_start = 711
+    _globals["_SETTINGS"]._serialized_end = 1575
+    _globals["_SETTINGS_SENSORSETTINGS"]._serialized_start = 1077
+    _globals["_SETTINGS_SENSORSETTINGS"]._serialized_end = 1328
+    _globals["_SETTINGS_STREAMSETTINGS"]._serialized_start = 1331
+    _globals["_SETTINGS_STREAMSETTINGS"]._serialized_end = 1487
+    _globals["_SETTINGS_ANTIFLICKER"]._serialized_start = 1489
+    _globals["_SETTINGS_ANTIFLICKER"]._serialized_end = 1526
+    _globals["_SETTINGS_WIFIBAND"]._serialized_start = 1528
+    _globals["_SETTINGS_WIFIBAND"]._serialized_end = 1575
+    _globals["_STATUS"]._serialized_start = 1578
+    _globals["_STATUS"]._serialized_end = 1876
+    _globals["_STATUS_CONNECTIONTOSERVER"]._serialized_start = 1823
+    _globals["_STATUS_CONNECTIONTOSERVER"]._serialized_end = 1876
+    _globals["_SOUNDTRACK"]._serialized_start = 1878
+    _globals["_SOUNDTRACK"]._serialized_end = 1922
+    _globals["_PLAYBACK"]._serialized_start = 1925
+    _globals["_PLAYBACK"]._serialized_end = 2099
+    _globals["_PLAYBACK_STATUS"]._serialized_start = 2065
+    _globals["_PLAYBACK_STATUS"]._serialized_end = 2099
+    _globals["_STREAM"]._serialized_start = 2101
+    _globals["_STREAM"]._serialized_end = 2219
+    _globals["_STREAM_TYPE"]._serialized_start = 2171
+    _globals["_STREAM_TYPE"]._serialized_end = 2219
+    _globals["_STREAMING"]._serialized_start = 2222
+    _globals["_STREAMING"]._serialized_end = 2395
+    _globals["_STREAMING_STATUS"]._serialized_start = 2349
+    _globals["_STREAMING_STATUS"]._serialized_end = 2395
+    _globals["_GETLOGS"]._serialized_start = 2397
+    _globals["_GETLOGS"]._serialized_end = 2419
+    _globals["_GETSTATUS"]._serialized_start = 2421
+    _globals["_GETSTATUS"]._serialized_end = 2445
+    _globals["_REQUEST"]._serialized_start = 2448
+    _globals["_REQUEST"]._serialized_end = 2873
+    _globals["_RESPONSE"]._serialized_start = 2876
+    _globals["_RESPONSE"]._serialized_end = 3207
+    _globals["_MESSAGE"]._serialized_start = 3210
+    _globals["_MESSAGE"]._serialized_end = 3372
+    _globals["_MESSAGE_TYPE"]._serialized_start = 3324
+    _globals["_MESSAGE_TYPE"]._serialized_end = 3372
 # @@protoc_insertion_point(module_scope)

--- a/packages/aionanit/proto/nanit.proto
+++ b/packages/aionanit/proto/nanit.proto
@@ -191,6 +191,7 @@ message Playback {
   }
 
   required Status status = 1;
+  optional int32 duration = 2;
   optional Soundtrack track = 3;
   optional Soundtrack current = 4;
 }

--- a/packages/aionanit/tests/test_playback_wire_format.py
+++ b/packages/aionanit/tests/test_playback_wire_format.py
@@ -1,0 +1,459 @@
+"""Tests for playback wire format — investigating why tracks stop after ~1 minute.
+
+Field 2 in the Playback proto is a duration (int32, seconds), not a loop boolean.
+Setting duration=1 causes 1-second playback; omitting it plays the full track once.
+Still probing whether duration=0 means infinite or if looping requires a different field.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from aionanit.camera import NanitCamera
+from aionanit.models import CameraEventKind, PlaybackState
+from aionanit.proto import (
+    Message,
+    MessageType,
+    Playback,
+    Request,
+    RequestType,
+    Response,
+)
+from aionanit.ws.protocol import build_request, decode_message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_camera() -> NanitCamera:
+    """Create a NanitCamera with mocked transport for wire-format inspection."""
+    import time
+
+    import aiohttp
+
+    from aionanit.auth import TokenManager
+    from aionanit.rest import NanitRestClient
+
+    session = MagicMock(spec=aiohttp.ClientSession)
+    rest = MagicMock(spec=NanitRestClient)
+    tm = MagicMock(spec=TokenManager)
+    tm.async_get_access_token = AsyncMock(return_value="test_token")
+    tm._expires_at = time.monotonic() + 3600.0
+
+    cam = NanitCamera(
+        uid="cam_uid_1",
+        baby_uid="baby_uid_1",
+        token_manager=tm,
+        rest_client=rest,
+        session=session,
+    )
+    return cam
+
+
+def _setup_camera_transport(cam: NanitCamera) -> list[bytes]:
+    """Mock the transport and return a list that captures sent bytes."""
+    sent_bytes: list[bytes] = []
+    cam._transport = MagicMock()
+    cam._transport.connected = True
+    cam._transport.idle_seconds = 0.0
+
+    resp = Response(request_id=1, request_type=RequestType.PUT_PLAYBACK, status_code=200)
+
+    async def _fake_send(data: bytes) -> None:
+        sent_bytes.append(data)
+        cam._pending.resolve(1, resp)
+
+    cam._transport.async_send = AsyncMock(side_effect=_fake_send)
+    return sent_bytes
+
+
+def _decode_playback_from_sent(data: bytes) -> Playback:
+    """Decode the Playback message from raw bytes sent over WebSocket."""
+    msg = decode_message(data)
+    assert msg.type == MessageType.REQUEST
+    assert msg.request.type == RequestType.PUT_PLAYBACK
+    assert msg.request.HasField("playback")
+    return msg.request.playback
+
+
+# ---------------------------------------------------------------------------
+# Tests — Current behavior (what we send now)
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentPlaybackWireFormat:
+    """Verify exactly what PUT_PLAYBACK bytes we currently send."""
+
+    async def test_start_playback_sends_status_started(self) -> None:
+        """Basic start sends status=STARTED (0) with no extra fields."""
+        cam = _make_camera()
+        sent = _setup_camera_transport(cam)
+
+        await cam.async_start_playback()
+
+        assert len(sent) == 1
+        playback = _decode_playback_from_sent(sent[0])
+        assert playback.status == Playback.STARTED
+
+    async def test_start_playback_with_track_sends_track_submessage(self) -> None:
+        """Start with track sends Soundtrack sub-message on field 3."""
+        cam = _make_camera()
+        sent = _setup_camera_transport(cam)
+
+        await cam.async_start_playback(track="Birds.wav")
+
+        assert len(sent) == 1
+        playback = _decode_playback_from_sent(sent[0])
+        assert playback.status == Playback.STARTED
+        assert playback.HasField("track")
+        assert playback.track.filename == "Birds.wav"
+        assert playback.track.type == 0
+
+    async def test_start_playback_sends_default_duration(self) -> None:
+        cam = _make_camera()
+        sent = _setup_camera_transport(cam)
+
+        await cam.async_start_playback(track="White Noise.wav")
+
+        playback = _decode_playback_from_sent(sent[0])
+        assert playback.HasField("duration")
+        assert playback.duration == 28800
+
+        raw = playback.SerializeToString()
+        field_numbers = _extract_field_numbers(raw)
+        assert 2 in field_numbers
+
+    async def test_stop_playback_sends_status_stopped(self) -> None:
+        """Stop sends status=STOPPED (1)."""
+        cam = _make_camera()
+        sent = _setup_camera_transport(cam)
+
+        await cam.async_stop_playback()
+
+        assert len(sent) == 1
+        playback = _decode_playback_from_sent(sent[0])
+        assert playback.status == Playback.STOPPED
+
+
+# ---------------------------------------------------------------------------
+# Tests — Optimistic state update
+# ---------------------------------------------------------------------------
+
+
+class TestPlaybackStateUpdate:
+    """Verify state is updated optimistically after PUT_PLAYBACK."""
+
+    async def test_start_sets_playing_true(self) -> None:
+        cam = _make_camera()
+        _setup_camera_transport(cam)
+
+        result = await cam.async_start_playback()
+        assert result.playing is True
+        assert cam.state.playback.playing is True
+
+    async def test_start_with_track_updates_current_track(self) -> None:
+        cam = _make_camera()
+        _setup_camera_transport(cam)
+
+        result = await cam.async_start_playback(track="Waves.wav")
+        assert result.current_track == "Waves.wav"
+        assert cam.state.playback.current_track == "Waves.wav"
+
+    async def test_stop_sets_playing_false(self) -> None:
+        cam = _make_camera()
+        cam._transport = MagicMock()
+        cam._transport.connected = True
+        cam._transport.idle_seconds = 0.0
+
+        request_counter = 0
+
+        async def _fake_send(data: bytes) -> None:
+            nonlocal request_counter
+            request_counter += 1
+            resp = Response(
+                request_id=request_counter,
+                request_type=RequestType.PUT_PLAYBACK,
+                status_code=200,
+            )
+            cam._pending.resolve(request_counter, resp)
+
+        cam._transport.async_send = AsyncMock(side_effect=_fake_send)
+
+        await cam.async_start_playback(track="Wind.wav")
+        result = await cam.async_stop_playback()
+        assert result.playing is False
+        assert cam.state.playback.playing is False
+
+
+# ---------------------------------------------------------------------------
+# Tests — Probe field 2 (loop/repeat hypothesis)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaybackField2Duration:
+    """Field 2 is int32 duration (seconds). Verify wire format correctness."""
+
+    def test_raw_playback_with_field2_varint_1_serializes(self) -> None:
+        raw_playback = (
+            _encode_varint((1 << 3) | 0)  # field 1 (status), wire type 0
+            + _encode_varint(0)  # STARTED = 0
+            + _encode_varint((2 << 3) | 0)  # field 2 (duration), wire type 0
+            + _encode_varint(1)  # value = 1 second
+        )
+
+        pb = Playback()
+        pb.ParseFromString(raw_playback)
+        assert pb.status == Playback.STARTED
+        assert pb.duration == 1
+
+        reserialized = pb.SerializeToString()
+        field_numbers = _extract_field_numbers(reserialized)
+        assert 1 in field_numbers
+        assert 2 in field_numbers
+
+    def test_raw_playback_with_field2_and_track(self) -> None:
+        filename = b"Birds.wav"
+        soundtrack_bytes = (
+            _encode_varint((1 << 3) | 0)  # field 1 (type), varint
+            + _encode_varint(0)  # type = 0
+            + _encode_varint((2 << 3) | 2)  # field 2 (filename), length-delimited
+            + _encode_varint(len(filename))
+            + filename
+        )
+
+        raw_playback = (
+            _encode_varint((1 << 3) | 0)  # field 1 (status), varint
+            + _encode_varint(0)  # STARTED
+            + _encode_varint((2 << 3) | 0)  # field 2 (duration), varint
+            + _encode_varint(3600)  # 1 hour
+            + _encode_varint((3 << 3) | 2)  # field 3 (track), length-delimited
+            + _encode_varint(len(soundtrack_bytes))
+            + soundtrack_bytes
+        )
+
+        pb = Playback()
+        pb.ParseFromString(raw_playback)
+        assert pb.status == Playback.STARTED
+        assert pb.duration == 3600
+        assert pb.track.filename == "Birds.wav"
+        assert pb.track.type == 0
+
+        reserialized = pb.SerializeToString()
+        assert 2 in _extract_field_numbers(reserialized)
+
+    def test_build_request_with_duration_field_produces_valid_message(self) -> None:
+        playback = Playback(status=Playback.STARTED, duration=3600)
+        playback.track.type = 0
+        playback.track.filename = "White Noise.wav"
+
+        data = build_request(1, RequestType.PUT_PLAYBACK, playback=playback)
+        msg = decode_message(data)
+
+        assert msg.request.playback.status == Playback.STARTED
+        assert msg.request.playback.duration == 3600
+        assert msg.request.playback.track.filename == "White Noise.wav"
+
+        pb_raw = msg.request.playback.SerializeToString()
+        field_numbers = _extract_field_numbers(pb_raw)
+        assert 2 in field_numbers
+
+
+# ---------------------------------------------------------------------------
+# Tests — Push event: camera sends PUT_PLAYBACK with status=STOPPED
+# ---------------------------------------------------------------------------
+
+
+class TestCameraPushPlaybackStopped:
+    """Verify that when the camera pushes a PUT_PLAYBACK STOPPED event,
+    our state correctly reflects that playback has stopped.
+
+    This confirms the camera DOES send a stop event (rather than just going
+    silent), which means it's the camera actively stopping, not a connection
+    issue.
+    """
+
+    def test_push_put_playback_stopped_updates_state(self) -> None:
+        """Simulate camera pushing PUT_PLAYBACK { status: STOPPED }."""
+        cam = _make_camera()
+        events: list[object] = []
+        cam.subscribe(lambda e: events.append(e))
+
+        # Simulate push: camera says playback stopped
+        req = Request(
+            id=99,
+            type=RequestType.PUT_PLAYBACK,
+            playback=Playback(status=Playback.STOPPED),
+        )
+        msg = Message(type=MessageType.REQUEST, request=req)
+        cam._on_ws_message(msg.SerializeToString())
+
+        assert cam.state.playback.playing is False
+        assert any(e.kind == CameraEventKind.PLAYBACK_UPDATE for e in events)
+
+    def test_push_put_playback_started_updates_state(self) -> None:
+        """Simulate camera pushing PUT_PLAYBACK { status: STARTED }."""
+        cam = _make_camera()
+
+        req = Request(
+            id=100,
+            type=RequestType.PUT_PLAYBACK,
+            playback=Playback(status=Playback.STARTED),
+        )
+        msg = Message(type=MessageType.REQUEST, request=req)
+        cam._on_ws_message(msg.SerializeToString())
+
+        assert cam.state.playback.playing is True
+
+    def test_push_playback_stopped_with_current_track(self) -> None:
+        """Camera reports stop with current track info."""
+        cam = _make_camera()
+
+        pb = Playback(status=Playback.STOPPED)
+        pb.current.type = 0
+        pb.current.filename = "White Noise.wav"
+
+        req = Request(id=101, type=RequestType.PUT_PLAYBACK, playback=pb)
+        msg = Message(type=MessageType.REQUEST, request=req)
+        cam._on_ws_message(msg.SerializeToString())
+
+        assert cam.state.playback.playing is False
+        assert cam.state.playback.current_track == "White Noise.wav"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Playback poll detects external stop
+# ---------------------------------------------------------------------------
+
+
+class TestPlaybackPollDetectsStop:
+    """Verify that the 30s playback poll detects when the camera stopped."""
+
+    async def test_get_playback_updates_state_to_stopped(self) -> None:
+        """GET_PLAYBACK response with status=STOPPED updates state."""
+        cam = _make_camera()
+        cam._transport = MagicMock()
+        cam._transport.connected = True
+        cam._transport.idle_seconds = 0.0
+
+        # First set playing=True
+        cam._update_state(
+            playback=PlaybackState(playing=True, current_track="Birds.wav"),
+            kind=CameraEventKind.PLAYBACK_UPDATE,
+        )
+        assert cam.state.playback.playing is True
+
+        # Simulate GET_PLAYBACK response saying STOPPED
+        resp = Response(
+            request_id=1,
+            request_type=RequestType.GET_PLAYBACK,
+            status_code=200,
+            playback=Playback(status=Playback.STOPPED),
+        )
+
+        async def _fake_send(data: bytes) -> None:
+            cam._pending.resolve(1, resp)
+
+        cam._transport.async_send = AsyncMock(side_effect=_fake_send)
+
+        result = await cam.async_get_playback()
+        assert result.playing is False
+        assert cam.state.playback.playing is False
+
+    async def test_get_playback_preserves_available_tracks(self) -> None:
+        """GET_PLAYBACK response doesn't include tracks — preserved from state."""
+        cam = _make_camera()
+        cam._transport = MagicMock()
+        cam._transport.connected = True
+        cam._transport.idle_seconds = 0.0
+
+        # Set state with available tracks
+        cam._update_state(
+            playback=PlaybackState(
+                playing=True,
+                current_track="Waves.wav",
+                available_tracks=("Birds.wav", "Waves.wav", "White Noise.wav"),
+            ),
+            kind=CameraEventKind.PLAYBACK_UPDATE,
+        )
+
+        # GET_PLAYBACK response won't include available_tracks
+        resp = Response(
+            request_id=1,
+            request_type=RequestType.GET_PLAYBACK,
+            status_code=200,
+            playback=Playback(status=Playback.STARTED),
+        )
+
+        async def _fake_send(data: bytes) -> None:
+            cam._pending.resolve(1, resp)
+
+        cam._transport.async_send = AsyncMock(side_effect=_fake_send)
+
+        result = await cam.async_get_playback()
+        assert result.playing is True
+        assert result.available_tracks == ("Birds.wav", "Waves.wav", "White Noise.wav")
+
+
+# ---------------------------------------------------------------------------
+# Utility — wire format parsing
+# ---------------------------------------------------------------------------
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def _extract_field_numbers(data: bytes) -> set[int]:
+    """Extract all field numbers from serialized protobuf bytes.
+
+    This is a simple wire-format scanner — only extracts top-level field numbers.
+    """
+    field_numbers: set[int] = set()
+    pos = 0
+    while pos < len(data):
+        # Decode tag varint
+        tag = 0
+        shift = 0
+        while pos < len(data):
+            b = data[pos]
+            tag |= (b & 0x7F) << shift
+            shift += 7
+            pos += 1
+            if not (b & 0x80):
+                break
+
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        field_numbers.add(field_number)
+
+        # Skip value based on wire type
+        if wire_type == 0:  # varint
+            while pos < len(data) and data[pos] & 0x80:
+                pos += 1
+            pos += 1  # final byte
+        elif wire_type == 1:  # 64-bit fixed
+            pos += 8
+        elif wire_type == 2:  # length-delimited
+            length = 0
+            shift = 0
+            while pos < len(data):
+                b = data[pos]
+                length |= (b & 0x7F) << shift
+                shift += 7
+                pos += 1
+                if not (b & 0x80):
+                    break
+            pos += length
+        elif wire_type == 5:  # 32-bit fixed
+            pos += 4
+        else:
+            break  # unknown wire type
+
+    return field_numbers

--- a/tools/nanit-sound.py
+++ b/tools/nanit-sound.py
@@ -716,9 +716,9 @@ async def cmd_loop_track(session: SoundSession, arg: str | None = None) -> None:
         playback=playback,
     )
     print(f'\n  → Track "{arg}" started.')
-    print(f"  → Listen and see if it keeps playing past ~1 min.")
+    print("  → Listen and see if it keeps playing past ~1 min.")
     print()
-    print(f"  ⏳ Connection alive. Press Enter when done listening ...")
+    print("  ⏳ Connection alive. Press Enter when done listening ...")
     input()
 
 

--- a/tools/nanit-sound.py
+++ b/tools/nanit-sound.py
@@ -655,6 +655,73 @@ async def cmd_select_track(session: SoundSession, arg: str | None = None) -> Non
     print(f'\n  → Listen: is "{arg}" playing now?')
 
 
+# ── 9b. Select track with duration probe ────────────────────────────────
+
+
+@sound_command(
+    name="loop-track",
+    description="PUT_PLAYBACK with duration field probe",
+    hint=(
+        "Sends PUT_PLAYBACK { status: STARTED, duration: N, track: ... }.\n"
+        "  Field 2 is a duration (seconds), not a loop boolean.\n"
+        "  Try: 0 (infinite?), 3600 (1 hour), or omit entirely.\n"
+        "  Available tracks: White Noise.wav, Birds.wav, Waves.wav, Wind.wav"
+    ),
+    takes_arg="TRACK (filename, e.g. Birds.wav)",
+)
+async def cmd_loop_track(session: SoundSession, arg: str | None = None) -> None:
+    tracks = ["White Noise.wav", "Birds.wav", "Waves.wav", "Wind.wav"]
+
+    if arg is None:
+        print("  Available tracks:")
+        for i, t in enumerate(tracks):
+            print(f"    {i}: {t}")
+        choice = input("  Select track (number or filename): ").strip()
+        if choice.isdigit():
+            idx = int(choice)
+            if 0 <= idx < len(tracks):
+                arg = tracks[idx]
+            else:
+                print(f"  ✗ Invalid index: {choice}")
+                return
+        else:
+            arg = choice
+
+    if arg not in tracks:
+        print(f"  ⚠ Unknown track: {arg!r} (trying anyway)")
+
+    print()
+    print("  Duration options:")
+    print("    <empty> = omit field 2 entirely (original behavior, stops after ~1 min)")
+    print("    0       = maybe infinite?")
+    print("    3600    = 1 hour")
+    print("    86400   = 24 hours")
+    dur_input = input("  Duration value (or empty to omit): ").strip()
+
+    playback = Playback(status=PlaybackStatus.STARTED)
+    playback.track.type = 0
+    playback.track.filename = arg
+
+    if dur_input:
+        dur_val = int(dur_input)
+        playback.duration = dur_val
+        label = f'status: STARTED, duration: {dur_val}, track: "{arg}"'
+    else:
+        label = f'status: STARTED, track: "{arg}"'
+
+    print(f"\n  Sending: PUT_PLAYBACK {{ {label} }}")
+    await session.send_typed_and_dump(
+        RequestType.PUT_PLAYBACK,
+        f"PUT_PLAYBACK {{ {label} }}",
+        playback=playback,
+    )
+    print(f'\n  → Track "{arg}" started.')
+    print(f"  → Listen and see if it keeps playing past ~1 min.")
+    print()
+    print(f"  ⏳ Connection alive. Press Enter when done listening ...")
+    input()
+
+
 # ── 10. Custom playback probe ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Beta releases via HACS were broken: `attach-artifact` job only ran for stable releases
- HACS would download source from the tag → stale `manifest.json` with old version/requirements → HA wouldn't upgrade `aionanit`

## Fix

Removed the `if: is_stable` gate from `attach-artifact` so every release (beta + stable) gets a properly versioned `nanit.zip` with:
- `manifest.json.version` set to the release semver
- `manifest.json.requirements` pinned to the matching aionanit PEP440 version

## Root cause of the bug

PR #52 was merged without a `release:*` label, so `auto-beta.yaml` never ran. The tag was created manually without version injection. Even when auto-beta does run, it only injects into the commit — but HACS downloads the zip artifact from the GitHub release, which was only created for stable releases.

Now the zip is always attached regardless of release type.