### PR TITLE
remove night light timer select entity

### DIFF
--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -1,4 +1,4 @@
-"""Select platform for Nanit — night light timer and Sound & Light Machine sound."""
+"""Select platform for Nanit — Sound & Light Machine sound."""
 
 from __future__ import annotations
 
@@ -6,32 +6,17 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from aionanit import NanitCamera
 
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
-from .const import DEFAULT_SOUND_MACHINE_SOUNDS, DOMAIN
-from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
-from .entity import NanitEntity, NanitSoundLightEntity
+from .const import DEFAULT_SOUND_MACHINE_SOUNDS
+from .coordinator import NanitSoundLightCoordinator
+from .entity import NanitSoundLightEntity
 
 PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
-
-_OPTION_TO_SECONDS: dict[str, int] = {
-    "off": 0,
-    "15_minutes": 900,
-    "30_minutes": 1800,
-    "1_hour": 3600,
-    "2_hours": 7200,
-    "4_hours": 14400,
-}
-_SECONDS_TO_OPTION: dict[int, str] = {v: k for k, v in _OPTION_TO_SECONDS.items()}
-
-_OPTIONS: list[str] = list(_OPTION_TO_SECONDS)
 
 
 async def async_setup_entry(
@@ -42,51 +27,10 @@ async def async_setup_entry(
     """Set up Nanit select entities for all cameras on the account."""
     entities: list[SelectEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
-        entities.append(NanitNightLightTimer(cam_data.push_coordinator, cam_data.camera))
         sl_coordinator = cam_data.sound_light_coordinator
         if sl_coordinator is not None:
             entities.append(NanitSoundSelect(sl_coordinator))
     async_add_entities(entities)
-
-
-class NanitNightLightTimer(NanitEntity, SelectEntity):
-    """Night light auto-off timer."""
-
-    _attr_translation_key = "night_light_timer"
-    _attr_options = _OPTIONS
-
-    def __init__(
-        self,
-        coordinator: NanitPushCoordinator,
-        camera: NanitCamera,
-    ) -> None:
-        """Initialize."""
-        super().__init__(coordinator)
-        self._camera = camera
-        self._attr_unique_id = f"{camera.uid}_night_light_timer"
-
-    @property
-    def current_option(self) -> str | None:
-        """Return the currently selected timer option."""
-        if self.coordinator.data is None:
-            return None
-        timeout = self.coordinator.data.control.night_light_timeout
-        if timeout is None:
-            return "off"
-        return _SECONDS_TO_OPTION.get(timeout, "off")
-
-    async def async_select_option(self, option: str) -> None:
-        """Set the night light timer."""
-        if option not in _OPTION_TO_SECONDS:
-            raise ServiceValidationError(
-                f"Invalid option '{option}'",
-                translation_domain=DOMAIN,
-                translation_key="invalid_option",
-                translation_placeholders={"option": option},
-            )
-        seconds = _OPTION_TO_SECONDS[option]
-        await self._camera.async_set_control(night_light_timeout=seconds)
-        self.async_write_ha_state()
 
 
 class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -75,9 +75,6 @@
     },
     "cloud_fetch_failed": {
       "message": "Failed to fetch cloud events: {error}"
-    },
-    "invalid_option": {
-      "message": "Invalid option: {option}"
     }
   },
   "issues": {
@@ -124,17 +121,6 @@
       "sound_light_light": { "name": "Light" }
     },
     "select": {
-      "night_light_timer": {
-        "name": "Night Light Timer",
-        "state": {
-          "off": "Off",
-          "15_minutes": "15 minutes",
-          "30_minutes": "30 minutes",
-          "1_hour": "1 hour",
-          "2_hours": "2 hours",
-          "4_hours": "4 hours"
-        }
-      },
       "sound_machine_sound": { "name": "Sound Track" }
     },
     "media_player": {

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -75,9 +75,6 @@
     },
     "cloud_fetch_failed": {
       "message": "Failed to fetch cloud events: {error}"
-    },
-    "invalid_option": {
-      "message": "Invalid option: {option}"
     }
   },
   "issues": {
@@ -124,17 +121,6 @@
       "sound_light_light": { "name": "Light" }
     },
     "select": {
-      "night_light_timer": {
-        "name": "Night Light Timer",
-        "state": {
-          "off": "Off",
-          "15_minutes": "15 minutes",
-          "30_minutes": "30 minutes",
-          "1_hour": "1 hour",
-          "2_hours": "2 hours",
-          "4_hours": "4 hours"
-        }
-      },
       "sound_machine_sound": { "name": "Sound Track" }
     },
     "media_player": {

--- a/tests/unit/snapshots/test_entity_registration.ambr
+++ b/tests/unit/snapshots/test_entity_registration.ambr
@@ -226,36 +226,10 @@
 # ---
 # name: TestEntityRegistration.test_select[baseline]
   list([
-    dict({
-      'class': 'NanitNightLightTimer',
-      'device_class': None,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'night_light_timer',
-      'unique_id': 'cam_1_night_light_timer',
-    }),
   ])
 # ---
 # name: TestEntityRegistration.test_select[full]
   list([
-    dict({
-      'class': 'NanitNightLightTimer',
-      'device_class': None,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'night_light_timer',
-      'unique_id': 'cam_1_night_light_timer',
-    }),
     dict({
       'class': 'NanitSoundSelect',
       'device_class': None,

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -26,7 +26,7 @@ from custom_components.nanit.light import (
 from custom_components.nanit.light import (
     _COMMAND_GRACE_PERIOD as _NL_GRACE,
 )
-from custom_components.nanit.select import NanitNightLightTimer, NanitSoundSelect
+from custom_components.nanit.select import NanitSoundSelect
 from custom_components.nanit.switch import NanitSLPowerSwitch, NanitSLSoundSwitch
 
 _MODELS = importlib.import_module("aionanit.models")
@@ -411,9 +411,7 @@ async def test_select_async_setup_entry_adds_entities_for_sound_light_coordinato
     await select_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
 
     entities = async_add_entities.call_args.args[0]
-    # 2 camera night light timers + 1 S&L sound select = 3
-    assert len(entities) == 3
-    assert sum(isinstance(e, NanitNightLightTimer) for e in entities) == 2
+    assert len(entities) == 1
     assert sum(isinstance(e, NanitSoundSelect) for e in entities) == 1
 
 
@@ -1446,93 +1444,3 @@ async def test_night_light_async_added_to_hass_skips_restore_when_data_present()
         await entity.async_added_to_hass()
 
     assert entity.is_on is True
-
-
-# ---------------------------------------------------------------------------
-# NanitNightLightTimer — camera night light timer entity
-# ---------------------------------------------------------------------------
-
-
-def _night_light_timer_entity(
-    *, night_light_timeout: int | None = None, data_is_none: bool = False
-) -> tuple[NanitNightLightTimer, MagicMock]:
-    control = ControlState(night_light_timeout=night_light_timeout)
-    state: CameraState | None = None
-    if not data_is_none:
-        state = CameraState(
-            sensors=SensorState(temperature=22.5, humidity=50.0, light=100),
-            settings=SettingsState(volume=50, sleep_mode=False, night_vision=True),
-            control=control,
-            connection=ConnectionInfo(state=ConnectionState.CONNECTED),
-        )
-    coordinator = _push_coordinator(state)
-    camera = MagicMock(uid="cam_1")
-    camera.async_set_control = AsyncMock()
-    entity = NanitNightLightTimer(coordinator, camera)
-    _disable_state_writes(entity)
-    return entity, camera
-
-
-def test_night_light_timer_unique_id() -> None:
-    entity, _ = _night_light_timer_entity()
-    assert entity.unique_id == "cam_1_night_light_timer"
-
-
-def test_night_light_timer_current_option_none_when_no_data() -> None:
-    entity, _ = _night_light_timer_entity(data_is_none=True)
-    assert entity.current_option is None
-
-
-def test_night_light_timer_current_option_off_when_timeout_none() -> None:
-    entity, _ = _night_light_timer_entity(night_light_timeout=None)
-    assert entity.current_option == "off"
-
-
-def test_night_light_timer_current_option_off_when_zero() -> None:
-    entity, _ = _night_light_timer_entity(night_light_timeout=0)
-    assert entity.current_option == "off"
-
-
-def test_night_light_timer_current_option_15_minutes() -> None:
-    entity, _ = _night_light_timer_entity(night_light_timeout=900)
-    assert entity.current_option == "15_minutes"
-
-
-def test_night_light_timer_current_option_1_hour() -> None:
-    entity, _ = _night_light_timer_entity(night_light_timeout=3600)
-    assert entity.current_option == "1_hour"
-
-
-def test_night_light_timer_current_option_unknown_defaults_off() -> None:
-    entity, _ = _night_light_timer_entity(night_light_timeout=9999)
-    assert entity.current_option == "off"
-
-
-async def test_night_light_timer_select_option_calls_camera() -> None:
-    entity, camera = _night_light_timer_entity()
-
-    await entity.async_select_option("30_minutes")
-
-    camera.async_set_control.assert_awaited_once_with(night_light_timeout=1800)
-
-
-async def test_night_light_timer_select_option_off() -> None:
-    entity, camera = _night_light_timer_entity(night_light_timeout=900)
-
-    await entity.async_select_option("off")
-
-    camera.async_set_control.assert_awaited_once_with(night_light_timeout=0)
-
-
-async def test_night_light_timer_select_invalid_option_raises() -> None:
-    from homeassistant.exceptions import ServiceValidationError
-
-    entity, _ = _night_light_timer_entity()
-
-    with pytest.raises(ServiceValidationError):
-        await entity.async_select_option("invalid_option")
-
-
-def test_night_light_timer_options_list() -> None:
-    entity, _ = _night_light_timer_entity()
-    assert entity.options == ["off", "15_minutes", "30_minutes", "1_hour", "2_hours", "4_hours"]


### PR DESCRIPTION
Users can replicate timer behavior with HA automations, which offer more flexibility than the fixed preset options.