### PR TITLE
fix: prevent volume entity reset on partial settings push

### DIFF
--- a/custom_components/nanit/frontend/nanit-card.js
+++ b/custom_components/nanit/frontend/nanit-card.js
@@ -361,14 +361,6 @@ function t(t,e,i,r){var s,n=arguments.length,a=n<3?e:null===r?r=Object.getOwnPro
     color: var(--nanit-teal);
   }
 
-  .pill-light {
-    color: var(--nanit-amber);
-  }
-
-  .pill-light ha-icon {
-    color: var(--nanit-amber);
-  }
-
   /* -- Motion / Sound Overlays -- */
 
   .overlay-bottom {
@@ -641,15 +633,6 @@ function t(t,e,i,r){var s,n=arguments.length,a=n<3?e:null===r?r=Object.getOwnPro
                 0 2px 6px rgba(0, 0, 0, 0.3);
   }
 
-  .slider-value {
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--secondary-text-color);
-    min-width: 32px;
-    text-align: right;
-    font-variant-numeric: tabular-nums;
-  }
-
   /* -- Sound Machine -- */
 
   .track-name {
@@ -850,11 +833,6 @@ function t(t,e,i,r){var s,n=arguments.length,a=n<3?e:null===r?r=Object.getOwnPro
           <ha-icon icon="mdi:water-percent"></ha-icon>
           <span>${r}%</span>
         </div>
-      `)}if(gt(this.hass,t.light)){const i=parseFloat(this.hass.states[t.light].state),r=isNaN(i)?this.hass.states[t.light].state:Math.round(i).toString();e.push(q`
-        <div class="pill pill-light" @click=${()=>this._fireMoreInfo(t.light)}>
-          <ha-icon icon="mdi:brightness-5"></ha-icon>
-          <span>${r} lx</span>
-        </div>
       `)}return 0===e.length?q``:q`<div class="overlay-top">${e}</div>`}_renderDetectionOverlays(t){const e=gt(this.hass,t.motion),i=gt(this.hass,t.sound);if(!e&&!i)return q``;const r=e&&"on"===this.hass.states[t.motion].state,s=i&&"on"===this.hass.states[t.sound].state;return q`
       <div class="overlay-bottom">
         ${e?q`
@@ -902,7 +880,6 @@ function t(t,e,i,r){var s,n=arguments.length,a=n<3?e:null===r?r=Object.getOwnPro
                 @change=${e=>{const i=Number(e.target.value);0===i?this.hass.callService("light","turn_off",{entity_id:t}):this.hass.callService("light","turn_on",{entity_id:t,brightness:Math.round(i/100*255)})}}
               />
             </div>
-            <span class="slider-value">${i?`${s}%`:"Off"}</span>
           </div>
         </div>
       </div>
@@ -943,7 +920,6 @@ function t(t,e,i,r){var s,n=arguments.length,a=n<3?e:null===r?r=Object.getOwnPro
                 @change=${e=>{const i=Number(e.target.value);this.hass.callService("media_player","volume_set",{entity_id:t,volume_level:i/100})}}
               />
             </div>
-            <span class="slider-value">${a}%</span>
           </div>
         </div>
       </div>

--- a/frontend/src/nanit-card.ts
+++ b/frontend/src/nanit-card.ts
@@ -298,17 +298,6 @@ export class NanitCard extends LitElement {
       `);
     }
 
-    if (isEntityAvailable(this.hass, entities.light)) {
-      const val = parseFloat(this.hass.states[entities.light!].state);
-      const display = isNaN(val) ? this.hass.states[entities.light!].state : Math.round(val).toString();
-      pills.push(html`
-        <div class="pill pill-light" @click=${() => this._fireMoreInfo(entities.light!)}>
-          <ha-icon icon="mdi:brightness-5"></ha-icon>
-          <span>${display} lx</span>
-        </div>
-      `);
-    }
-
     if (pills.length === 0) return html``;
     return html`<div class="overlay-top">${pills}</div>`;
   }
@@ -404,7 +393,6 @@ export class NanitCard extends LitElement {
                 }}
               />
             </div>
-            <span class="slider-value">${isOn ? `${brightnessPercent}%` : "Off"}</span>
           </div>
         </div>
       </div>
@@ -480,7 +468,6 @@ export class NanitCard extends LitElement {
                 }}
               />
             </div>
-            <span class="slider-value">${volumePercent}%</span>
           </div>
         </div>
       </div>

--- a/frontend/src/styles.ts
+++ b/frontend/src/styles.ts
@@ -363,14 +363,6 @@ export const cardStyles = css`
     color: var(--nanit-teal);
   }
 
-  .pill-light {
-    color: var(--nanit-amber);
-  }
-
-  .pill-light ha-icon {
-    color: var(--nanit-amber);
-  }
-
   /* -- Motion / Sound Overlays -- */
 
   .overlay-bottom {
@@ -641,15 +633,6 @@ export const cardStyles = css`
   .control-section-sound .nanit-slider input[type="range"]::-moz-range-thumb:hover {
     box-shadow: 0 0 10px var(--nanit-teal-glow),
                 0 2px 6px rgba(0, 0, 0, 0.3);
-  }
-
-  .slider-value {
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--secondary-text-color);
-    min-width: 32px;
-    text-align: right;
-    font-variant-numeric: tabular-nums;
   }
 
   /* -- Sound Machine -- */

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -604,8 +604,13 @@ class NanitCamera:
 
         elif req_type == RequestType.PUT_SETTINGS:
             if proto_request.HasField("settings"):
-                settings = _parse_settings_from_proto(proto_request.settings)
-                self._update_state(settings=settings, kind=CameraEventKind.SETTINGS_UPDATE)
+                incoming = _parse_settings_from_proto(proto_request.settings)
+                # Merge — push may omit unchanged fields (e.g. volume).
+                merged = dataclasses.replace(
+                    self._state.settings,
+                    **{f: v for f, v in dataclasses.asdict(incoming).items() if v is not None},
+                )
+                self._update_state(settings=merged, kind=CameraEventKind.SETTINGS_UPDATE)
 
         elif req_type == RequestType.PUT_CONTROL:
             if proto_request.HasField("control"):

--- a/packages/aionanit/tests/test_camera.py
+++ b/packages/aionanit/tests/test_camera.py
@@ -573,6 +573,29 @@ class TestHandlePushEvent:
         assert cam.state.settings.night_light_brightness == 80
         assert events[0].kind == CameraEventKind.SETTINGS_UPDATE
 
+    def test_put_settings_preserves_fields_not_in_push(self) -> None:
+        """PUT_SETTINGS push with only some fields must not wipe existing values."""
+        cam, *_ = _make_camera()
+
+        # First push sets volume.
+        cam._handle_push_event(
+            Request(
+                type=RequestType.PUT_SETTINGS,
+                settings=Settings(volume=42),
+            )
+        )
+        assert cam.state.settings.volume == 42
+
+        # Second push only sets night_vision — volume must survive.
+        cam._handle_push_event(
+            Request(
+                type=RequestType.PUT_SETTINGS,
+                settings=Settings(night_vision=True),
+            )
+        )
+        assert cam.state.settings.night_vision is True
+        assert cam.state.settings.volume == 42
+
 
 # ---------------------------------------------------------------------------
 # WebSocket message dispatch


### PR DESCRIPTION
## Summary

- **Fix volume reset bug**: `PUT_SETTINGS` push messages from the camera may contain only a subset of fields (e.g. just `night_vision`). The handler now merges incoming fields into existing `SettingsState` instead of replacing it wholesale, preventing volume from being wiped to `None`.
- **Card cleanup**: Remove illuminance sensor overlay, slider value labels (`<span class="slider-value">`), and dead CSS (`.pill-light`, `.slider-value`).

## Root Cause

`camera.py` `_handle_push_event` for `PUT_SETTINGS` was doing a full replacement of `SettingsState`. Protobuf push messages from the camera only include changed fields — absent fields parsed as `None` would overwrite the previously known volume.

## Test

Added `test_put_settings_preserves_fields_not_in_push` — sets volume via push, then sends a second push with only `night_vision`, and verifies volume is preserved.