### PR TITLE
fix: remove zip_release from hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Nanit",
   "homeassistant": "2025.12.0",
-  "render_readme": true,
-  "zip_release": true,
-  "filename": "nanit.zip"
+  "render_readme": true
 }


### PR DESCRIPTION
## Summary

- Removes `zip_release` and `filename` from `hacs.json` — reverts to default HACS git clone behavior which works correctly.

## Root Cause

`zip_release: true` caused HACS to switch from cloning the repo to downloading the release zip. The zip structure (`custom_components/nanit/...`) doesn't match what HACS expects during extraction, breaking the integration directory on update.