### PR TITLE
fix: power Sound & Light before child controls

### DIFF
--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -86,7 +86,11 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
         return self.coordinator.last_update_success and self.coordinator.data is not None
 
     async def _async_power_on_sound_light(self) -> None:
-        """Power on the Sound & Light Machine before enabling child features."""
+        """Power on the Sound & Light Machine before enabling child features.
+
+        Always send the command before child controls because coordinator
+        state can be stale after the device is toggled outside Home Assistant.
+        """
         await self.coordinator.sound_light.async_set_power(True)
 
 

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -85,6 +85,10 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
         """
         return self.coordinator.last_update_success and self.coordinator.data is not None
 
+    async def _async_power_on_sound_light(self) -> None:
+        """Power on the Sound & Light Machine before enabling child features."""
+        await self.coordinator.sound_light.async_set_power(True)
+
 
 class NanitNetworkEntity(CoordinatorEntity[NanitNetworkCoordinator]):
     """Base entity for network diagnostic sensors — backed by the network coordinator."""

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -224,10 +224,12 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return True if the light is on."""
+        """Return True if the light is effectively on."""
         if self.coordinator.data is None:
             return None
         state = self.coordinator.data
+        if state.power_on is False:
+            return False
         if state.light_enabled is not None:
             result: bool = state.light_enabled
             return result
@@ -265,6 +267,7 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light, optionally setting brightness and/or color."""
         try:
+            await self._async_power_on_sound_light()
             await self.coordinator.sound_light.async_set_light_enabled(True)
 
             if ATTR_HS_COLOR in kwargs:

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -248,15 +248,18 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return True if sound is on."""
+        """Return True if sound is effectively on."""
         if self.coordinator.data is None:
             return None
+        if self.coordinator.data.power_on is False:
+            return False
         result: bool | None = self.coordinator.data.sound_on
         return result
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn sound on."""
         try:
+            await self._async_power_on_sound_light()
             await self.coordinator.sound_light.async_set_sound_on(True)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn on S&L sound: %s", err)

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -83,6 +83,20 @@ def test_light_is_on_returns_true_when_light_enabled_true() -> None:
     assert entity.is_on is True
 
 
+def test_light_is_on_returns_false_when_device_power_is_off_even_if_light_enabled() -> None:
+    state = SoundLightFullState(power_on=False, light_enabled=True, brightness=0.5)
+    entity = NanitSoundLightLight(_sl_coordinator(state))
+
+    assert entity.is_on is False
+
+
+def test_light_is_on_preserves_light_enabled_when_device_power_is_unknown() -> None:
+    state = SoundLightFullState(power_on=None, light_enabled=True, brightness=0.0)
+    entity = NanitSoundLightLight(_sl_coordinator(state))
+
+    assert entity.is_on is True
+
+
 def test_light_is_on_returns_false_when_light_enabled_false() -> None:
     state = SoundLightFullState(light_enabled=False, brightness=1.0)
     entity = NanitSoundLightLight(_sl_coordinator(state))
@@ -169,6 +183,44 @@ async def test_light_turn_on_calls_set_light_enabled_true() -> None:
 
     await entity.async_turn_on()
 
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
+
+
+async def test_light_turn_on_powers_device_before_enabling_light() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=False))
+    calls: list[str] = []
+    coordinator.sound_light.async_set_power.side_effect = lambda _on: calls.append("power")
+    coordinator.sound_light.async_set_light_enabled.side_effect = lambda _on: calls.append("light")
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    assert calls[:2] == ["power", "light"]
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
+
+
+async def test_light_turn_on_sends_power_command_even_when_state_already_powered() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=True))
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
+
+
+async def test_light_turn_on_sends_power_command_when_power_state_unknown() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=None))
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
     coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
 
 
@@ -179,6 +231,8 @@ async def test_light_turn_on_with_hs_color_calls_set_color() -> None:
 
     await entity.async_turn_on(**{ATTR_HS_COLOR: (180.0, 40.0)})
 
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
     coordinator.sound_light.async_set_color.assert_awaited_once_with(0.5, 0.4)
 
 
@@ -189,7 +243,26 @@ async def test_light_turn_on_with_brightness_calls_set_brightness() -> None:
 
     await entity.async_turn_on(**{ATTR_BRIGHTNESS: 128})
 
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(True)
     coordinator.sound_light.async_set_brightness.assert_awaited_once_with(128 / 255)
+
+
+async def test_light_turn_on_applies_power_enable_color_brightness_in_order() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=False))
+    calls: list[str] = []
+    coordinator.sound_light.async_set_power.side_effect = lambda _on: calls.append("power")
+    coordinator.sound_light.async_set_light_enabled.side_effect = lambda _on: calls.append("light")
+    coordinator.sound_light.async_set_color.side_effect = lambda *_args: calls.append("color")
+    coordinator.sound_light.async_set_brightness.side_effect = lambda _value: calls.append(
+        "brightness"
+    )
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on(**{ATTR_HS_COLOR: (180.0, 40.0), ATTR_BRIGHTNESS: 128})
+
+    assert calls == ["power", "light", "color", "brightness"]
 
 
 async def test_light_turn_off_calls_set_light_enabled_false() -> None:
@@ -200,6 +273,17 @@ async def test_light_turn_off_calls_set_light_enabled_false() -> None:
     await entity.async_turn_off()
 
     coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(False)
+
+
+async def test_light_turn_off_does_not_turn_off_device_power() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=True, light_enabled=True))
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_off()
+
+    coordinator.sound_light.async_set_light_enabled.assert_awaited_once_with(False)
+    coordinator.sound_light.async_set_power.assert_not_awaited()
 
 
 async def test_light_turn_on_handles_transport_error_gracefully(
@@ -213,6 +297,17 @@ async def test_light_turn_on_handles_transport_error_gracefully(
     await entity.async_turn_on()
 
     assert "Failed to control Sound & Light light" in caplog.text
+
+
+async def test_light_turn_on_does_not_enable_light_when_power_on_fails() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=False))
+    coordinator.sound_light.async_set_power.side_effect = NanitTransportError("power boom")
+    entity = NanitSoundLightLight(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_light_enabled.assert_not_awaited()
 
 
 async def test_light_turn_off_handles_transport_error_gracefully(
@@ -330,6 +425,20 @@ def test_sl_sound_switch_is_on_returns_sound_on_from_state() -> None:
     assert entity.is_on is True
 
 
+def test_sl_sound_switch_is_on_returns_false_when_device_power_is_off() -> None:
+    state = SoundLightFullState(power_on=False, sound_on=True)
+    entity = NanitSLSoundSwitch(_sl_coordinator(state))
+
+    assert entity.is_on is False
+
+
+def test_sl_sound_switch_is_on_preserves_sound_on_when_device_power_is_unknown() -> None:
+    state = SoundLightFullState(power_on=None, sound_on=True)
+    entity = NanitSLSoundSwitch(_sl_coordinator(state))
+
+    assert entity.is_on is True
+
+
 async def test_sl_sound_switch_turn_on_calls_set_sound_on_true() -> None:
     coordinator = _sl_coordinator(SoundLightFullState())
     entity = NanitSLSoundSwitch(coordinator)
@@ -337,6 +446,46 @@ async def test_sl_sound_switch_turn_on_calls_set_sound_on_true() -> None:
 
     await entity.async_turn_on()
 
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(True)
+
+
+async def test_sl_sound_switch_turn_on_powers_device_before_enabling_sound() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=False))
+    calls: list[str] = []
+    coordinator.sound_light.async_set_power.side_effect = lambda _on: calls.append("power")
+    coordinator.sound_light.async_set_sound_on.side_effect = lambda _on: calls.append("sound")
+    entity = NanitSLSoundSwitch(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    assert calls[:2] == ["power", "sound"]
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(True)
+
+
+async def test_sl_sound_switch_turn_on_sends_power_command_even_when_state_already_powered() -> (
+    None
+):
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=True))
+    entity = NanitSLSoundSwitch(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
+    coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(True)
+
+
+async def test_sl_sound_switch_turn_on_sends_power_command_when_power_state_unknown() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=None))
+    entity = NanitSLSoundSwitch(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_power.assert_awaited_once_with(True)
     coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(True)
 
 
@@ -348,6 +497,17 @@ async def test_sl_sound_switch_turn_off_calls_set_sound_on_false() -> None:
     await entity.async_turn_off()
 
     coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(False)
+
+
+async def test_sl_sound_switch_turn_off_does_not_turn_off_device_power() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=True, sound_on=True))
+    entity = NanitSLSoundSwitch(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_off()
+
+    coordinator.sound_light.async_set_sound_on.assert_awaited_once_with(False)
+    coordinator.sound_light.async_set_power.assert_not_awaited()
 
 
 async def test_sl_sound_switch_handles_transport_error_gracefully(
@@ -363,6 +523,17 @@ async def test_sl_sound_switch_handles_transport_error_gracefully(
 
     assert "Failed to turn on S&L sound" in caplog.text
     assert "Failed to turn off S&L sound" in caplog.text
+
+
+async def test_sl_sound_switch_turn_on_does_not_enable_sound_when_power_on_fails() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState(power_on=False))
+    coordinator.sound_light.async_set_power.side_effect = NanitTransportError("power boom")
+    entity = NanitSLSoundSwitch(coordinator)
+    _disable_state_writes(entity)
+
+    await entity.async_turn_on()
+
+    coordinator.sound_light.async_set_sound_on.assert_not_awaited()
 
 
 async def test_light_async_setup_entry_adds_entities_for_sound_light_coordinators() -> None:

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -114,6 +114,22 @@ class TestSubscription:
         sl._fire_event(SoundLightEventKind.STATE_UPDATE)
 
 
+class TestCommands:
+    @pytest.mark.asyncio
+    async def test_async_set_power_updates_state_and_fires_state_update(self) -> None:
+        sl = _make_sound_light()
+        sl._async_send = AsyncMock()
+        events: list[SoundLightEvent] = []
+        sl.subscribe(events.append)
+
+        await sl.async_set_power(True)
+
+        sl._async_send.assert_awaited_once()
+        assert sl.state.power_on is True
+        assert events[-1].kind is SoundLightEventKind.STATE_UPDATE
+        assert events[-1].state.power_on is True
+
+
 class TestDualSslContext:
     """Verify that local and cloud connections use different TLS settings."""
 

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -14,6 +14,7 @@ from custom_components.nanit.aionanit_sl.models import (
     SoundLightEventKind,
     SoundLightFullState,
 )
+from custom_components.nanit.aionanit_sl.sl_protocol import build_power_cmd
 from custom_components.nanit.aionanit_sl.sound_light import NanitSoundLight
 
 
@@ -124,7 +125,7 @@ class TestCommands:
 
         await sl.async_set_power(True)
 
-        sl._async_send.assert_awaited_once()
+        sl._async_send.assert_awaited_once_with(build_power_cmd(True))
         assert sl.state.power_on is True
         assert events[-1].kind is SoundLightEventKind.STATE_UPDATE
         assert events[-1].state.power_on is True


### PR DESCRIPTION
## Summary

Fixes Sound & Light child controls when master power is off. Home Assistant now powers the Sound & Light Machine on before sending light or sound commands.

The light and sound entities show as off while master power is off, matching what is actually visible or audible.

## Testing

Tested on my real Home Assistant setup with a Nanit Sound & Light Machine. I installed the updated HACS custom component files, restarted HA Core, and verified Nanit loaded.

On the live device, enabling light or sound powered the machine on first, then enabled the requested feature. Unit coverage was added.
