### PR TITLE
fix: make release pipeline compatible with branch protection

### DIFF
--- a/.github/workflows/auto-beta.yaml
+++ b/.github/workflows/auto-beta.yaml
@@ -87,38 +87,17 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Computed: ${tag}"
 
-      - name: Inject version into manifest and pyproject
+      - name: Create and push tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          version="${TAG#v}"
-          base="${version%-beta.*}"
-          beta_num="${version##*-beta.}"
-          pep440="${base}b${beta_num}"
-
-          # Update manifest.json version + requirements
-          jq --arg v "$version" --arg r "aionanit>=$pep440" \
-            '.version = $v | .requirements = [$r]' \
-            custom_components/nanit/manifest.json > /tmp/manifest.json
-          mv /tmp/manifest.json custom_components/nanit/manifest.json
-
-          # Update pyproject.toml version
-          sed -i "s/^version = \".*\"/version = \"$pep440\"/" packages/aionanit/pyproject.toml
-
-      - name: Create version commit and tag
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
-          git commit -m "chore: bump version to ${TAG} [skip ci]"
           git tag "${TAG}"
-          git push origin HEAD:main "${TAG}"
+          git push origin "${TAG}"
 
       - name: Summary
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          echo "✅ Tagged ${TAG} and pushed."
-          echo "Run 'just beta' locally to create the GitHub pre-release and publish to PyPI."
+          echo "✅ Tagged ${TAG} on merge commit $(git rev-parse --short HEAD)."
+          echo "Version injection happens at build time in the release workflow."
+          echo "Run 'just release' → Release beta to publish the pre-release."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,6 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -231,12 +232,20 @@ jobs:
 
           sed -i "s/^version = \".*\"/version = \"$PEP440\"/" packages/aionanit/pyproject.toml
 
-      - name: Push version to main
+      - name: Create version bump PR
         env:
           SEMVER: ${{ needs.resolve.outputs.semver }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          branch="chore/bump-version-v${SEMVER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
           git commit -m "chore: bump version to v${SEMVER} [skip ci]"
-          git push origin HEAD:main
+          git push origin "$branch"
+          gh pr create \
+            --title "chore: bump version to v${SEMVER}" \
+            --body "Automated version bump after stable release v${SEMVER}." \
+            --base main \
+            --head "$branch"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v1.20.0
     hooks:
       - id: mypy
-        language_version: python3.13
+        language_version: python3.14
         additional_dependencies:
           - aiohttp>=3.9.0
           - homeassistant-stubs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,11 @@ Path B (skip beta):
 
 **Multiple concurrent betas** are supported. Different features can have independent beta tracks (e.g., `v1.4.0-beta.2` and `v1.5.0-beta.1` can coexist).
 
-**Version lives in two files** (kept in sync by auto-beta workflow and release CLI):
+**Version lives in two files** (kept in sync by release workflow and version-bump PRs):
 - `custom_components/nanit/manifest.json` → `"version"` (semver) + `"requirements"` (PEP 440)
 - `packages/aionanit/pyproject.toml` → `version` (PEP 440)
+
+Version files on `main` contain the **last stable release version** (not the current beta). The actual release version is always derived from the **git tag name** and injected at build time by the release workflow. After a stable release, the workflow opens a PR to bump version files on `main`.
 
 | Version mapping | manifest.json `version` | pyproject.toml `version` | manifest.json `requirements` |
 |-----------------|------------------------|--------------------------|------------------------------|
@@ -206,6 +208,8 @@ Path B (skip beta):
 **Rollback strategy**: Forward-fix via new PR. Merge the fix → auto-beta tags a new beta → `just release` → test → release stable.
 
 **Pipeline fix**: If the release workflow fails (e.g. action version issues, PyPI errors), fix the pipeline code, push to `main`, then use the "Retry pipeline" option in `just release`. This re-triggers the workflow using the updated YAML from `main` while building from the original tag. PyPI publish is idempotent (skips already-uploaded versions).
+
+**Branch protection compatibility**: The auto-beta workflow tags the merge commit directly (no version-injection commit) and pushes only the tag — no push to `main`. The release workflow opens a version-bump PR after stable releases instead of pushing directly to `main`. This ensures all commits on `main` go through the normal PR + signed-commit flow.
 
 ---
 

--- a/tests/unit/test_frontend.py
+++ b/tests/unit/test_frontend.py
@@ -125,7 +125,18 @@ async def test_register_card_yaml_mode_skips_resource(hass: HomeAssistant) -> No
 
 
 def test_manifest_version_is_loaded() -> None:
-    assert _MANIFEST_VERSION == "1.4.0"
+    import json
+    from pathlib import Path
+
+    manifest = json.loads(
+        (
+            Path(__file__).resolve().parent.parent.parent
+            / "custom_components"
+            / "nanit"
+            / "manifest.json"
+        ).read_text()
+    )
+    assert manifest["version"] == _MANIFEST_VERSION
 
 
 async def test_register_card_loads_resources_when_not_loaded(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Fixes two systemic release failures:

1. **CI Gate test failure** — `test_manifest_version_is_loaded` hardcoded `"1.4.0"`, breaking on every version change. Now reads manifest.json dynamically.

2. **Branch protection rejection** — Both `auto-beta.yaml` and `release.yaml` tried to push unsigned commits directly to `main`. Auto-beta now just tags the merge commit (no version-injection commit). Release stable now opens a version-bump PR instead of pushing directly.

Also updates AGENTS.md to document the new version strategy and bumps pre-commit mypy hook to python3.14.