### PR TITLE
fix: invalidate cached RTMPS stream on WebSocket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 
 ### Fixed
 - Volume entity no longer resets to 0 after unrelated settings pushes from the camera (partial `PUT_SETTINGS` messages now merge into existing state instead of replacing it)
+- Camera stream now survives token refresh — the cached RTMPS stream URL is invalidated after every WebSocket reconnection so HA re-fetches a fresh access token instead of retrying with an expired one indefinitely
 
 ## [1.1.0] – 2026-03-23
 

--- a/custom_components/nanit/camera.py
+++ b/custom_components/nanit/camera.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from datetime import datetime
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.core import HomeAssistant
@@ -55,6 +56,7 @@ class NanitCameraEntity(NanitEntity, Camera):
         Camera.__init__(self)
         self._camera = camera
         self._prev_is_on: bool | None = None
+        self._prev_last_seen: datetime | None = None
         self._attr_unique_id = f"{camera.uid}_camera"
         self._cached_snapshot: bytes | None = None
         self._cached_snapshot_at: float = 0.0
@@ -77,14 +79,27 @@ class NanitCameraEntity(NanitEntity, Camera):
 
         if prev_on is not None and prev_on != cur_on:
             # Camera power changed — invalidate cached stream.
-            self._invalidate_stream()
+            self._invalidate_stream("power state change")
+
+        # Invalidate stream after WebSocket reconnection so the RTMPS URL
+        # gets a fresh access token.  last_seen is updated only when the
+        # transport moves to CONNECTED, so this fires once per reconnect.
+        if self.coordinator.data is not None:
+            cur_last_seen = self.coordinator.data.connection.last_seen
+            if (
+                self._prev_last_seen is not None
+                and cur_last_seen != self._prev_last_seen
+                and self.stream is not None
+            ):
+                self._invalidate_stream("WebSocket reconnection (token refreshed)")
+            self._prev_last_seen = cur_last_seen
 
         super()._handle_coordinator_update()
 
-    def _invalidate_stream(self) -> None:
+    def _invalidate_stream(self, reason: str = "state change") -> None:
         """Discard HA's cached stream so a fresh one is created on next view."""
         if self.stream is not None:
-            _LOGGER.debug("Invalidating cached stream after power state change")
+            _LOGGER.debug("Invalidating cached stream after %s", reason)
             self.stream = None
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -85,6 +85,7 @@ def _camera_state(
     night_light_timeout: int | None = None,
     playback: PlaybackState | None = None,
     connection_state: ConnectionState = ConnectionState.CONNECTED,
+    last_seen: Any = None,
 ) -> CameraState:
     kwargs: dict[str, Any] = {
         "sensors": SensorState(
@@ -99,7 +100,7 @@ def _camera_state(
             night_light_brightness=night_light_brightness,
         ),
         "control": ControlState(night_light=night_light, night_light_timeout=night_light_timeout),
-        "connection": ConnectionInfo(state=connection_state),
+        "connection": ConnectionInfo(state=connection_state, last_seen=last_seen),
     }
     if "playback" in getattr(CameraState, "__dataclass_fields__", {}):
         kwargs["playback"] = playback or PlaybackState()
@@ -614,3 +615,82 @@ async def test_reconnect_within_grace_cancels_timer(hass: HomeAssistant) -> None
     timeout_callback(None)
     assert coordinator.connected is True
     assert coordinator.async_update_listeners.call_count == baseline_calls
+
+
+def test_camera_invalidates_stream_on_reconnection() -> None:
+    from datetime import UTC, datetime
+
+    t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    t2 = datetime(2026, 1, 1, 13, 0, 0, tzinfo=UTC)
+
+    coordinator = _push_coordinator(_camera_state(last_seen=t1))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitCameraEntity(coordinator, camera)
+    _disable_state_writes(entity)
+
+    entity._handle_coordinator_update()
+    assert entity._prev_last_seen == t1
+
+    entity.stream = MagicMock()
+    coordinator.data = _camera_state(last_seen=t2)
+    entity._handle_coordinator_update()
+
+    assert entity.stream is None
+    assert entity._prev_last_seen == t2
+
+
+def test_camera_does_not_invalidate_stream_when_last_seen_unchanged() -> None:
+    from datetime import UTC, datetime
+
+    t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    coordinator = _push_coordinator(_camera_state(last_seen=t1))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitCameraEntity(coordinator, camera)
+    _disable_state_writes(entity)
+
+    entity._handle_coordinator_update()
+
+    mock_stream = MagicMock()
+    entity.stream = mock_stream
+    coordinator.data = _camera_state(last_seen=t1)
+    entity._handle_coordinator_update()
+
+    assert entity.stream is mock_stream
+
+
+def test_camera_does_not_invalidate_stream_on_first_update() -> None:
+    from datetime import UTC, datetime
+
+    t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    coordinator = _push_coordinator(_camera_state(last_seen=t1))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitCameraEntity(coordinator, camera)
+    _disable_state_writes(entity)
+
+    mock_stream = MagicMock()
+    entity.stream = mock_stream
+    entity._handle_coordinator_update()
+
+    assert entity.stream is mock_stream
+    assert entity._prev_last_seen == t1
+
+
+def test_camera_does_not_invalidate_when_no_stream_cached() -> None:
+    from datetime import UTC, datetime
+
+    t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    t2 = datetime(2026, 1, 1, 13, 0, 0, tzinfo=UTC)
+
+    coordinator = _push_coordinator(_camera_state(last_seen=t1))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitCameraEntity(coordinator, camera)
+    _disable_state_writes(entity)
+
+    entity._handle_coordinator_update()
+    coordinator.data = _camera_state(last_seen=t2)
+    entity._handle_coordinator_update()
+
+    assert entity.stream is None
+    assert entity._prev_last_seen == t2


### PR DESCRIPTION
## Problem

HA's stream component caches the RTMPS URL returned by `stream_source()`. The Nanit access token embedded in that URL expires after 3 hours (10800s), but HA's ffmpeg stream worker retries with the same cached URL indefinitely — never calling `stream_source()` again to get a fresh token. This causes the camera stream to fail permanently after the first token expiry, only recovering on camera power toggle or HA restart.

Logs showed the same expired JWT tokens (days old) being retried every 15–30 minutes.

## Fix

Track `ConnectionInfo.last_seen` in the camera entity. When the WebSocket reconnects (which happens on pre-emptive token refresh every ~55 minutes), `last_seen` changes — triggering `_invalidate_stream()` which sets `self.stream = None`. This forces HA to call `stream_source()` on the next view, which builds a fresh RTMPS URL with a current access token.

## Changes

- `custom_components/nanit/camera.py`: Track `_prev_last_seen` and invalidate stream when it changes. Parameterize `_invalidate_stream(reason)` for clearer debug logs.
- `tests/unit/test_entities.py`: 4 new tests covering stream invalidation on reconnection, no-op on unchanged `last_seen`, no-op on first update, and no-op when no stream is cached.
- `CHANGELOG.md`: Document the fix.