### PR TITLE
fix: handle null baby name from Nanit API

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,6 +240,7 @@ jobs:
           branch="chore/bump-version-v${SEMVER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push origin --delete "$branch" 2>/dev/null || true
           git checkout -b "$branch"
           git add custom_components/nanit/manifest.json packages/aionanit/pyproject.toml
           git commit -m "chore: bump version to v${SEMVER} [skip ci]"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,9 +218,7 @@ All dev and test dependency versions are exact-pinned to prevent surprise breaka
 - `dev/requirements.txt` — integration dev/test/CI tooling (exact `==` pins)
 - `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (exact `==` pins)
 
-**Exceptions** (unpinned because they must match the CI Python version):
-- `homeassistant` — requires `>=3.14.2` on newer versions; CI runs 3.13
-- `pytest-homeassistant-custom-component` — must match the `homeassistant` version
+**CI Python version**: CI runs Python 3.13. `homeassistant` and `pytest-homeassistant-custom-component` must stay pinned to versions compatible with 3.13 (HA 2026.3.0+ requires Python 3.14.2+).
 
 **Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,10 @@ All dev and test dependency versions are exact-pinned to prevent surprise breaka
 - `dev/requirements.txt` — integration dev/test/CI tooling (exact `==` pins)
 - `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (exact `==` pins)
 
+**Exceptions** (unpinned because they must match the CI Python version):
+- `homeassistant` — requires `>=3.14.2` on newer versions; CI runs 3.13
+- `pytest-homeassistant-custom-component` — must match the `homeassistant` version
+
 **Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
 
 **Before every release**, review and update pinned versions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,21 @@ Version files on `main` contain the **last stable release version** (not the cur
 
 **Branch protection compatibility**: The auto-beta workflow tags the merge commit directly (no version-injection commit) and pushes only the tag — no push to `main`. The release workflow opens a version-bump PR after stable releases instead of pushing directly to `main`. This ensures all commits on `main` go through the normal PR + signed-commit flow.
 
+### Pinned dependencies
+
+All dev and test dependency versions are exact-pinned to prevent surprise breakage from upstream releases:
+
+- `dev/requirements.txt` — integration dev/test/CI tooling (exact `==` pins)
+- `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (exact `==` pins)
+
+**Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
+
+**Before every release**, review and update pinned versions:
+1. Run `pip install --upgrade` for each pinned package (or recreate venv with `just setup`).
+2. Run `just check` to verify compatibility.
+3. Update the pinned versions in both `dev/requirements.txt` and `packages/aionanit/pyproject.toml` to match.
+4. Commit version bumps as a separate `chore: update pinned dev dependencies` commit.
+
 ---
 
 ## Security

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,14 +213,14 @@ Version files on `main` contain the **last stable release version** (not the cur
 
 ### Pinned dependencies
 
-All dev and test dependency versions are exact-pinned to prevent surprise breakage from upstream releases:
+All dev and test dependency versions are pinned to minor-version ranges to prevent supply-chain attacks while allowing patch updates:
 
-- `dev/requirements.txt` — integration dev/test/CI tooling (exact `==` pins)
-- `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (exact `==` pins)
+- `dev/requirements.txt` — integration dev/test/CI tooling (`>=x.y,<x.(y+1)` ranges)
+- `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (`>=x.y,<x.(y+1)` ranges)
 
-**CI Python version**: CI runs Python 3.13. `homeassistant` and `pytest-homeassistant-custom-component` must stay pinned to versions compatible with 3.13 (HA 2026.3.0+ requires Python 3.14.2+).
+**CI Python version**: CI runs Python 3.13. `homeassistant` must stay below `2026.3` (HA 2026.3.0+ requires Python 3.14.2+). The `aiohttp` dev pin must stay below `3.14` (aioresponses 0.7.x incompatible with aiohttp 3.14+).
 
-**Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
+**Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use broader range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
 
 **Before every release**, review and update pinned versions:
 1. Run `pip install --upgrade` for each pinned package (or recreate venv with `just setup`).

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -30,7 +30,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .sanitize import sanitize_name
+from .sanitize import display_name
 
 
 class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -201,7 +201,7 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
             client.restore_tokens(self._access_token, self._refresh_token)
             babies = await client.async_get_babies()
             if len(babies) == 1:
-                title = babies[0].name
+                title = display_name(babies[0].name, babies[0].uid)
             elif len(babies) > 1:
                 title = f"Nanit ({len(babies)} cameras)"
         except Exception:
@@ -336,7 +336,7 @@ class NanitOptionsFlow(OptionsFlow):
             self._selected_camera_uid = user_input["camera"]
             return await self.async_step_camera_ip()
 
-        camera_options = {baby.camera_uid: sanitize_name(baby.name) for baby in babies}
+        camera_options = {baby.camera_uid: display_name(baby.name, baby.uid) for baby in babies}
 
         return self.async_show_form(
             step_id="init",
@@ -403,7 +403,7 @@ class NanitOptionsFlow(OptionsFlow):
         camera_name = self._selected_camera_uid
         for baby in self.config_entry.runtime_data.hub.babies:
             if baby.camera_uid == self._selected_camera_uid:
-                camera_name = sanitize_name(baby.name)
+                camera_name = display_name(baby.name, baby.uid)
                 break
 
         return self.async_show_form(

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -12,7 +12,7 @@ from .coordinator import (
     NanitPushCoordinator,
     NanitSoundLightCoordinator,
 )
-from .sanitize import sanitize_name
+from .sanitize import display_name
 
 
 class NanitEntity(CoordinatorEntity[NanitPushCoordinator]):
@@ -25,7 +25,7 @@ class NanitEntity(CoordinatorEntity[NanitPushCoordinator]):
         """Return device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.camera.uid)},
-            name=sanitize_name(self.coordinator.baby.name),
+            name=display_name(self.coordinator.baby.name, self.coordinator.baby.uid),
             manufacturer="Nanit",
         )
 
@@ -53,7 +53,7 @@ class NanitCloudEntity(CoordinatorEntity[NanitCloudCoordinator]):
         """Return device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.baby.camera_uid)},
-            name=sanitize_name(self.coordinator.baby.name),
+            name=display_name(self.coordinator.baby.name, self.coordinator.baby.uid),
             manufacturer="Nanit",
         )
 
@@ -69,7 +69,7 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
         baby = self.coordinator.baby
         return DeviceInfo(
             identifiers={(DOMAIN, f"{baby.camera_uid}_sound_light")},
-            name=f"{sanitize_name(baby.name)} Sound & Light",
+            name=f"{display_name(baby.name, baby.uid)} Sound & Light",
             manufacturer="Nanit",
             model="Sound & Light Machine",
             via_device=(DOMAIN, baby.camera_uid),
@@ -96,6 +96,6 @@ class NanitNetworkEntity(CoordinatorEntity[NanitNetworkCoordinator]):
         """Return device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.baby.camera_uid)},
-            name=sanitize_name(self.coordinator.baby.name),
+            name=display_name(self.coordinator.baby.name, self.coordinator.baby.uid),
             manufacturer="Nanit",
         )

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -34,7 +34,7 @@ from .coordinator import (
     NanitPushCoordinator,
     NanitSoundLightCoordinator,
 )
-from .sanitize import sanitize_name
+from .sanitize import display_name
 
 if TYPE_CHECKING:
     from . import NanitConfigEntry
@@ -168,7 +168,7 @@ class NanitHub:
                     baby.camera_uid,
                     result,
                 )
-                failed_cameras.append(sanitize_name(baby.name))
+                failed_cameras.append(display_name(baby.name, baby.uid))
                 ir.async_create_issue(
                     self._hass,
                     DOMAIN,
@@ -178,7 +178,7 @@ class NanitHub:
                     severity=ir.IssueSeverity.WARNING,
                     translation_key="camera_connection_failed",
                     translation_placeholders={
-                        "camera_name": sanitize_name(baby.name),
+                        "camera_name": display_name(baby.name, baby.uid),
                         "error": str(result),
                     },
                 )

--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nanit",
   "name": "Nanit",
-  "version": "1.4.0",
+  "version": "1.8.1",
   "documentation": "https://github.com/wealthystudent/ha-nanit",
   "issue_tracker": "https://github.com/wealthystudent/ha-nanit/issues",
   "codeowners": ["@wealthystudent"],
@@ -9,6 +9,6 @@
   "dependencies": ["http", "lovelace"],
   "iot_class": "cloud_push",
   "integration_type": "hub",
-  "requirements": ["aionanit>=1.4.0"],
+  "requirements": ["aionanit>=1.8.1"],
   "loggers": ["custom_components.nanit", "aionanit"]
 }

--- a/custom_components/nanit/sanitize.py
+++ b/custom_components/nanit/sanitize.py
@@ -11,12 +11,20 @@ import re
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
-def sanitize_name(value: str) -> str:
+def sanitize_name(value: str | None) -> str:
     """Strip HTML tags and escape entities from an API-provided name.
 
     Prevents stored XSS via baby/camera names controlled by the Nanit API.
     """
+    if not value:
+        return ""
     cleaned = _HTML_TAG_RE.sub("", value)
     # Unescape pre-encoded entities, then re-escape for safe display.
     cleaned = html.escape(html.unescape(cleaned))
     return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def display_name(value: str | None, uid: str) -> str:
+    """Return a sanitized display name with a UID-based fallback for unnamed babies."""
+    name = sanitize_name(value)
+    return name if name else f"Baby {uid[:8]}"

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
 aioresponses==0.7.8
-homeassistant
-pytest-homeassistant-custom-component
+homeassistant==2026.2.3
+pytest-homeassistant-custom-component==0.13.316
 pytest-cov==7.1.0
 aionanit @ file:packages/aionanit
 ruff==0.15.14

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
 aioresponses==0.7.8
-homeassistant==2026.5.4
-pytest-homeassistant-custom-component==0.13.333
+homeassistant
+pytest-homeassistant-custom-component
 pytest-cov==7.1.0
 aionanit @ file:packages/aionanit
 ruff==0.15.14

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,11 +1,11 @@
-aiohttp
-aioresponses
-homeassistant
-pytest-homeassistant-custom-component
-pytest-cov
+aiohttp==3.13.5
+aioresponses==0.7.8
+homeassistant==2026.5.4
+pytest-homeassistant-custom-component==0.13.333
+pytest-cov==7.1.0
 aionanit @ file:packages/aionanit
-ruff
-mypy
-pre-commit
-syrupy
-rich
+ruff==0.15.14
+mypy==2.1.0
+pre-commit==4.6.0
+syrupy==5.1.0
+rich==15.0.0

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,11 +1,11 @@
-aiohttp==3.13.5
-aioresponses==0.7.8
-homeassistant==2026.2.3
-pytest-homeassistant-custom-component==0.13.316
-pytest-cov==7.1.0
+aiohttp>=3.13,<3.14
+aioresponses>=0.7,<0.8
+homeassistant>=2026.2,<2026.3
+pytest-homeassistant-custom-component>=0.13.316,<0.14
+pytest-cov>=7,<8
 aionanit @ file:packages/aionanit
-ruff==0.15.14
-mypy==2.1.0
-pre-commit==4.6.0
-syrupy==5.1.0
-rich==15.0.0
+ruff>=0.15,<0.16
+mypy>=2.1,<3
+pre-commit>=4,<5
+syrupy>=5,<6
+rich>=15,<16

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -21,7 +21,9 @@ _DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=15)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
-def _sanitize_name(raw: str) -> str:
+def _sanitize_name(raw: str | None) -> str:
+    if not raw:
+        return ""
     stripped = _HTML_TAG_RE.sub("", raw)
     return "".join(ch for ch in stripped if unicodedata.category(ch)[0] != "C").strip()
 

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aionanit"
-version = "1.4.0"
+version = "1.8.1"
 description = "Async Python client for Nanit baby cameras"
 readme = "README.md"
 license = "MIT"

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "aioresponses",
+    "aiohttp<3.14",  # aioresponses 0.7.8 incompatible with aiohttp 3.14+
     "pytest-cov",
 ]
 

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -16,12 +16,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "grpcio-tools==1.80.0",
-    "pytest==9.0.3",
-    "pytest-asyncio==1.3.0",
-    "aioresponses==0.7.8",
-    "aiohttp==3.13.5",
-    "pytest-cov==7.1.0",
+    "grpcio-tools>=1.80,<2",
+    "pytest>=9,<10",
+    "pytest-asyncio>=1.3,<2",
+    "aioresponses>=0.7,<0.8",
+    "aiohttp>=3.13,<3.14",
+    "pytest-cov>=7,<8",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -10,18 +10,18 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.9.0,<4",
     "protobuf>=6,<8",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "grpcio-tools",
-    "pytest",
-    "pytest-asyncio",
-    "aioresponses",
-    "aiohttp<3.14",  # aioresponses 0.7.8 incompatible with aiohttp 3.14+
-    "pytest-cov",
+    "grpcio-tools==1.80.0",
+    "pytest==9.0.3",
+    "pytest-asyncio==1.3.0",
+    "aioresponses==0.7.8",
+    "aiohttp==3.13.5",
+    "pytest-cov==7.1.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -202,6 +202,25 @@ class TestGetBabies:
 
         assert babies == []
 
+    async def test_get_babies_null_name(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={
+                    "babies": [
+                        {
+                            "uid": "baby123",
+                            "name": None,
+                            "camera_uid": "cam456",
+                        },
+                    ]
+                },
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert len(babies) == 1
+        assert babies[0].name == ""
+
     async def test_get_babies_unauthorized(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
             m.get(BABIES_URL, status=401)

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.nanit.sanitize import sanitize_name
+from custom_components.nanit.sanitize import display_name, sanitize_name
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore::pytest.PytestRemovedIn9Warning"),
@@ -45,3 +45,23 @@ def test_empty_string() -> None:
 
 def test_unicode_preserved() -> None:
     assert sanitize_name("Bébé's Room 🍼") == "Bébé&#x27;s Room 🍼"
+
+
+def test_none_returns_empty() -> None:
+    assert sanitize_name(None) == ""
+
+
+def test_display_name_with_valid_name() -> None:
+    assert display_name("Nursery", "abc12345") == "Nursery"
+
+
+def test_display_name_with_none_falls_back_to_uid() -> None:
+    assert display_name(None, "abc12345-6789") == "Baby abc12345"
+
+
+def test_display_name_with_empty_falls_back_to_uid() -> None:
+    assert display_name("", "abc12345-6789") == "Baby abc12345"
+
+
+def test_display_name_with_html_only_falls_back_to_uid() -> None:
+    assert display_name("<script></script>", "abc12345") == "Baby abc12345"


### PR DESCRIPTION
## Problem

The Nanit API can return `null` for the baby `name` field when a user hasn't set a name yet. This causes a `TypeError` in `_sanitize_name()` during setup, preventing the integration from loading.

```
TypeError: expected string or bytes-like object, got 'NoneType'
```

## Fix

**aionanit library** (`rest.py`):
- `_sanitize_name` now accepts `str | None` and returns `""` for null input

**HA integration**:
- Added `display_name(value, uid)` helper in `sanitize.py` that provides a `"Baby {uid[:8]}"` fallback when name is empty
- Updated all call sites in `entity.py`, `hub.py`, and `config_flow.py` to use `display_name()`
- `sanitize_name()` also hardened to accept `None`

## Tests

- Added `test_get_babies_null_name` in aionanit REST tests
- Added 5 tests in `test_sanitize.py` covering None/empty handling and display_name fallback

Closes #67