### PR TITLE
fix: update release pipeline to Python 3.14 and bump version to 1.8.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
@@ -94,7 +94,7 @@ jobs:
         run: mypy packages/aionanit/aionanit --strict --ignore-missing-imports
 
       - name: Run mypy on integration
-        run: mypy custom_components/nanit --config-file pyproject.toml --python-version 3.13
+        run: mypy custom_components/nanit --config-file pyproject.toml --python-version 3.14
 
       - name: Install aionanit test dependencies
         run: pip install -e "packages/aionanit[dev]"
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Build aionanit package
         run: |
@@ -163,7 +163,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install build
         run: pip install build

--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nanit",
   "name": "Nanit",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "homeassistant": "2026.5.0",
   "documentation": "https://github.com/wealthystudent/ha-nanit",
   "issue_tracker": "https://github.com/wealthystudent/ha-nanit/issues",
@@ -10,6 +10,6 @@
   "dependencies": ["http", "lovelace"],
   "iot_class": "cloud_push",
   "integration_type": "hub",
-  "requirements": ["aionanit>=1.8.2"],
+  "requirements": ["aionanit>=1.8.3"],
   "loggers": ["custom_components.nanit", "aionanit"]
 }

--- a/packages/aionanit/pyproject.toml
+++ b/packages/aionanit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aionanit"
-version = "1.8.2"
+version = "1.8.3"
 description = "Async Python client for Nanit baby cameras"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
- Release workflow CI Gate, publish-beta, and publish-stable jobs now use Python 3.14 (matching ci.yaml and HA 2026.5 requirement)
- Bump version files to 1.8.3 (replaces closed PR #71)

Fixes release pipeline failure for v1.8.3.