### PR TITLE
fix: fetch initial settings when camera power state is unknown

### DIFF
--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -14,11 +14,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from aionanit import NanitCamera
+from aionanit import NanitCamera, NanitRequestTimeout, NanitTransportError
 from aionanit.models import CameraState
 
 from . import NanitConfigEntry
-from .aionanit_sl.exceptions import NanitTransportError
+from .aionanit_sl.exceptions import NanitTransportError as NanitSLTransportError
 from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
 from .entity import NanitEntity, NanitSoundLightEntity
 
@@ -108,6 +108,19 @@ class NanitSwitch(NanitEntity, RestoreEntity, SwitchEntity):
             and (last_state := await self.async_get_last_state()) is not None
         ):
             self._attr_is_on = last_state.state == STATE_ON
+
+        if self._attr_is_on is None:
+            await self._async_fetch_initial_settings()
+
+    async def _async_fetch_initial_settings(self) -> None:
+        """Fetch settings from camera when no live or restored state is available."""
+        try:
+            await self._camera.async_get_settings()
+        except (NanitTransportError, NanitRequestTimeout):
+            _LOGGER.debug(
+                "Could not fetch initial settings for %s; state will update when camera pushes",
+                self.entity_description.key,
+            )
 
     @property
     def is_on(self) -> bool | None:
@@ -219,14 +232,14 @@ class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
         """Turn the device on."""
         try:
             await self.coordinator.sound_light.async_set_power(True)
-        except NanitTransportError as err:
+        except NanitSLTransportError as err:
             _LOGGER.error("Failed to turn on S&L device: %s", err)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         try:
             await self.coordinator.sound_light.async_set_power(False)
-        except NanitTransportError as err:
+        except NanitSLTransportError as err:
             _LOGGER.error("Failed to turn off S&L device: %s", err)
 
 
@@ -258,12 +271,12 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
         """Turn sound on."""
         try:
             await self.coordinator.sound_light.async_set_sound_on(True)
-        except NanitTransportError as err:
+        except NanitSLTransportError as err:
             _LOGGER.error("Failed to turn on S&L sound: %s", err)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn sound off."""
         try:
             await self.coordinator.sound_light.async_set_sound_on(False)
-        except NanitTransportError as err:
+        except NanitSLTransportError as err:
             _LOGGER.error("Failed to turn off S&L sound: %s", err)

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -280,7 +280,68 @@ async def test_switch_camera_power_turn_off_calls_sleep_mode() -> None:
     assert entity.is_on is False
 
 
-def test_media_player_state_playing_when_playback_playing_true() -> None:
+def test_switch_camera_power_is_none_when_sleep_mode_unknown() -> None:
+    coordinator = _push_coordinator(_camera_state(sleep_mode=None))
+    camera = MagicMock(uid="cam_1")
+    entity = NanitSwitch(coordinator, camera, _switch_description("camera_power"))
+
+    assert entity.is_on is None
+
+
+async def test_switch_camera_power_fetches_settings_when_state_unknown() -> None:
+    coordinator = _push_coordinator(_camera_state(sleep_mode=None))
+    camera = MagicMock(uid="cam_1")
+    camera.async_get_settings = AsyncMock()
+    entity = NanitSwitch(coordinator, camera, _switch_description("camera_power"))
+    _disable_state_writes(entity)
+
+    assert entity.is_on is None
+
+    await entity._async_fetch_initial_settings()
+
+    camera.async_get_settings.assert_awaited_once()
+
+
+async def test_switch_camera_power_fetch_handles_transport_error() -> None:
+    from aionanit import NanitTransportError
+
+    coordinator = _push_coordinator(_camera_state(sleep_mode=None))
+    camera = MagicMock(uid="cam_1")
+    camera.async_get_settings = AsyncMock(side_effect=NanitTransportError("ws closed"))
+    entity = NanitSwitch(coordinator, camera, _switch_description("camera_power"))
+    _disable_state_writes(entity)
+
+    await entity._async_fetch_initial_settings()
+
+    camera.async_get_settings.assert_awaited_once()
+    assert entity.is_on is None
+
+
+async def test_switch_camera_power_no_fetch_when_state_known() -> None:
+    coordinator = _push_coordinator(_camera_state(sleep_mode=False))
+    camera = MagicMock(uid="cam_1")
+    camera.async_get_settings = AsyncMock()
+    entity = NanitSwitch(coordinator, camera, _switch_description("camera_power"))
+    _disable_state_writes(entity)
+
+    assert entity.is_on is True
+
+    with patch.object(entity, "_async_fetch_initial_settings", new=AsyncMock()) as mock_fetch:
+        with (
+            patch.object(entity, "async_get_last_state", new=AsyncMock(return_value=None)),
+            patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ),
+            patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ),
+        ):
+            await entity.async_added_to_hass()
+
+    mock_fetch.assert_not_awaited()
+
     coordinator = _push_coordinator(
         _camera_state(playback=PlaybackState(playing=True, current_track="White Noise.wav"))
     )


### PR DESCRIPTION
Fixes #74

## Problem

On fresh install, the Camera Power switch defaults to "off" even when the camera is on. 

**Root cause**: The camera uses a proto2 `optional bool sleep_mode` field. When the camera is on (`sleep_mode = false`), some firmware versions don't explicitly set this field in the `GET_SETTINGS` response since it's the default value. `HasField("sleep_mode")` returns `False`, the parser sets `sleep_mode = None`, and the switch's `value_fn` returns `None`. On a fresh install there is no previously-stored state to restore from, so `_attr_is_on` stays `None` and the toggle renders as off.

## Fix

Add `_async_fetch_initial_settings()` to `NanitSwitch`, called from `async_added_to_hass()` when neither live coordinator data nor a restored last-known state supplied an initial value. It calls `camera.async_get_settings()`, whose result flows back through the normal coordinator update chain — `_update_state()` → `_notify_subscribers()` → `_on_camera_event()` → `async_set_updated_data()` → `_handle_coordinator_update()` — updating `_attr_is_on` synchronously before the method returns. Transport errors are logged at DEBUG level and treated as non-fatal (state will arrive via the next push event).

## Tests

- `test_switch_camera_power_is_none_when_sleep_mode_unknown` — `is_on` is `None` when `sleep_mode = None`
- `test_switch_camera_power_fetches_settings_when_state_unknown` — `_async_fetch_initial_settings` calls `async_get_settings`
- `test_switch_camera_power_fetch_handles_transport_error` — transport errors are handled gracefully
- `test_switch_camera_power_no_fetch_when_state_known` — no fetch triggered when state is already known