### PR TITLE
fix: surface OAuth2 error bodies in auth responses

### DIFF
--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -21,6 +21,24 @@ _DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=15)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
+def _extract_error_message(body: dict[str, Any]) -> str | None:
+    """Extract error message from an API error response.
+
+    Handles OAuth2-style errors (``error`` + ``error_description``) and
+    Nanit's simple error format (``message`` without ``access_token``).
+    Returns *None* for success responses.
+    """
+    # OAuth2-style: {"error": "...", "error_description": "..."}
+    if "error" in body:
+        error = str(body["error"])
+        desc = body.get("error_description")
+        return f"{error}: {desc}" if desc else error
+    # Nanit simple error: {"message": "..."} without tokens
+    if "message" in body and "access_token" not in body:
+        return str(body["message"])
+    return None
+
+
 def _sanitize_name(raw: str | None) -> str:
     if not raw:
         return ""
@@ -123,6 +141,10 @@ class NanitRestClient:
         if "mfa_token" in body:
             raise NanitMfaRequiredError(body["mfa_token"])
 
+        error_msg = _extract_error_message(body)
+        if error_msg:
+            raise NanitAuthError(error_msg)
+
         resp.raise_for_status()
 
         return {
@@ -151,8 +173,13 @@ class NanitRestClient:
         if resp.status == 401:
             raise NanitAuthError("Access token invalid during refresh")
 
-        resp.raise_for_status()
         body = await resp.json()
+
+        error_msg = _extract_error_message(body)
+        if error_msg:
+            raise NanitAuthError(error_msg)
+
+        resp.raise_for_status()
 
         return {
             "access_token": body["access_token"],

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -89,6 +89,45 @@ class TestLogin:
             with pytest.raises(NanitConnectionError):
                 await client.async_login("user@test.com", "pass123")
 
+    async def test_login_oauth2_error_with_description(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(
+                LOGIN_URL,
+                status=400,
+                payload={
+                    "error": "unauthorized_client",
+                    "error_description": "Grant type 'implicit' not allowed for the client.",
+                },
+            )
+
+            with pytest.raises(
+                NanitAuthError,
+                match=r"unauthorized_client: Grant type 'implicit' not allowed",
+            ):
+                await client.async_login("user@test.com", "pass123")
+
+    async def test_login_oauth2_error_without_description(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(
+                LOGIN_URL,
+                status=400,
+                payload={"error": "invalid_grant"},
+            )
+
+            with pytest.raises(NanitAuthError, match="invalid_grant"):
+                await client.async_login("user@test.com", "pass123")
+
+    async def test_login_api_message_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(
+                LOGIN_URL,
+                status=403,
+                payload={"message": "account locked"},
+            )
+
+            with pytest.raises(NanitAuthError, match="account locked"):
+                await client.async_login("user@test.com", "pass123")
+
 
 class TestLoginMfa:
     async def test_login_mfa_success(self, client: NanitRestClient) -> None:
@@ -138,6 +177,34 @@ class TestRefreshToken:
 
             with pytest.raises(NanitAuthError, match="Access token invalid"):
                 await client.async_refresh_token("bad_acc", "ref")
+
+    async def test_refresh_oauth2_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(
+                REFRESH_URL,
+                status=400,
+                payload={
+                    "error": "unauthorized_client",
+                    "error_description": "Grant type 'implicit' not allowed for the client.",
+                },
+            )
+
+            with pytest.raises(
+                NanitAuthError,
+                match=r"unauthorized_client: Grant type 'implicit' not allowed",
+            ):
+                await client.async_refresh_token("acc", "ref")
+
+    async def test_refresh_api_message_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(
+                REFRESH_URL,
+                status=403,
+                payload={"message": "token revoked"},
+            )
+
+            with pytest.raises(NanitAuthError, match="token revoked"):
+                await client.async_refresh_token("acc", "ref")
 
 
 class TestGetBabies:


### PR DESCRIPTION
## Problem

Users report `unauthorized_client: Grant type 'implicit' not allowed for the client` during login — likely caused by Nanit migrating some accounts to an OAuth2 backend (Auth0 or similar).

The current error handling discards the API error body: `resp.raise_for_status()` only captures the HTTP status code, not the response body. OAuth2-style error responses (`{"error": "...", "error_description": "..."}`) are lost, surfacing as generic "unknown" errors instead of actionable auth failures.

## Fix

- Add `_extract_error_message()` helper that parses both OAuth2-style (`error` + `error_description`) and Nanit-native (`message`) error bodies
- Apply to both `_async_auth_request` and `async_refresh_token` **before** `raise_for_status()`
- Errors now raise `NanitAuthError` with the actual API message, which triggers proper reauth flow in HA instead of a generic failure

## Tests

5 new tests covering OAuth2 errors (with/without description) and API message errors for both login and token refresh. All 27 REST tests pass.