### PR TITLE
fix: defer protobuf imports to avoid blocking HA event loop

### DIFF
--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from aionanit import NanitAuthError, NanitConnectionError
+from aionanit.exceptions import NanitAuthError, NanitConnectionError
 
 from .const import (
     CONF_BABY_NAME,

--- a/custom_components/nanit/aionanit_sl/exceptions.py
+++ b/custom_components/nanit/aionanit_sl/exceptions.py
@@ -1,6 +1,6 @@
 """S&L-specific exceptions."""
 
-from aionanit import NanitError
+from aionanit.exceptions import NanitError
 
 
 class NanitTransportError(NanitError):

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from aionanit import NanitAuthError, NanitCamera, NanitConnectionError
+from aionanit.exceptions import NanitAuthError, NanitConnectionError
 from aionanit.models import Baby, CameraEvent, CameraState, CloudEvent, NetworkInfo
 
 from .aionanit_sl.models import SoundLightEvent, SoundLightEventKind, SoundLightFullState
@@ -37,6 +37,8 @@ from .aionanit_sl.sound_light import NanitSoundLight
 from .const import CLOUD_POLL_INTERVAL, DOMAIN, NETWORK_POLL_INTERVAL
 
 if TYPE_CHECKING:
+    from aionanit import NanitCamera
+
     from . import NanitConfigEntry
     from .hub import NanitHub
 

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -17,13 +17,11 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
-from aionanit import (
+from aionanit.exceptions import (
     NanitAuthError,
-    NanitCamera,
-    NanitClient,
+    NanitCameraUnavailable,
     NanitConnectionError,
 )
-from aionanit.exceptions import NanitCameraUnavailable
 from aionanit.models import Baby
 
 from .aionanit_sl.sound_light import NanitSoundLight
@@ -37,6 +35,8 @@ from .coordinator import (
 from .sanitize import display_name
 
 if TYPE_CHECKING:
+    from aionanit import NanitCamera, NanitClient
+
     from . import NanitConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,6 +73,8 @@ class NanitHub:
         entry: NanitConfigEntry,
     ) -> None:
         """Initialize the hub with an existing session and config entry."""
+        from aionanit.client import NanitClient
+
         self._hass = hass
         self._entry = entry
         self._client = NanitClient(session)

--- a/packages/aionanit/aionanit/__init__.py
+++ b/packages/aionanit/aionanit/__init__.py
@@ -1,8 +1,11 @@
 """aionanit — async Python client for Nanit baby cameras."""
 
-from .auth import TokenManager
-from .camera import NanitCamera
-from .client import NanitClient
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+# Lightweight — no protobuf dependency.
 from .exceptions import (
     NanitAuthError,
     NanitCameraUnavailable,
@@ -32,7 +35,37 @@ from .models import (
     StatusState,
     TransportKind,
 )
-from .rest import NanitRestClient
+
+if TYPE_CHECKING:
+    from .auth import TokenManager as TokenManager
+    from .camera import NanitCamera as NanitCamera
+    from .client import NanitClient as NanitClient
+    from .rest import NanitRestClient as NanitRestClient
+
+# Heavy symbols — lazily imported on first access so that
+# ``import aionanit`` does not pull in the protobuf chain
+# (camera → parsers → proto → nanit_pb2 → google.protobuf).
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "NanitCamera": (".camera", "NanitCamera"),
+    "NanitClient": (".client", "NanitClient"),
+    "NanitRestClient": (".rest", "NanitRestClient"),
+    "TokenManager": (".auth", "TokenManager"),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(module_path, __name__)
+        value = getattr(mod, attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 __all__ = [
     "Baby",


### PR DESCRIPTION
## Problem

`importlib.import_module('custom_components.nanit')` blocks the HA event loop for ~140 ms because `aionanit/__init__.py` eagerly imports the full protobuf chain:

```
aionanit → camera.py → parsers.py → proto/__init__.py → nanit_pb2.py → google.protobuf
```

This triggers:
```
Detected blocking call to import_module with args ('custom_components.nanit',) inside the event loop
```

## Fix

### Library (`packages/aionanit`)
- **PEP 562 lazy imports** in `aionanit/__init__.py` — exceptions and models remain eagerly imported (lightweight, no proto dependency); `NanitCamera`, `NanitClient`, `NanitRestClient`, and `TokenManager` are deferred via `__getattr__` until first access.

### Integration (`custom_components/nanit`)
- Import exceptions/models directly from their submodules (`aionanit.exceptions`, `aionanit.models`) instead of through `aionanit`'s package init.
- Move `NanitCamera` and `NanitClient` to `TYPE_CHECKING` guards in `hub.py` and `coordinator.py`.
- Runtime import of `NanitClient` in `NanitHub.__init__()`.

## Result

| Metric | Before | After |
|--------|--------|-------|
| `import aionanit` | 142 ms | 44 ms |
| Proto chain loaded at import | Yes | No (deferred) |
| Public API backward-compatible | — | Yes |

## Testing
- 223/223 aionanit tests pass
- ruff, ruff-format, mypy all clean
- All public API symbols remain accessible via lazy loading