### PR TITLE
fix: increase playback duration from 8h to 24h to prevent overnight shutoff

### DIFF
--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -412,7 +412,7 @@ class NanitCamera:
         self._update_state(control=new_control, kind=CameraEventKind.CONTROL_UPDATE)
         return new_control
 
-    _DEFAULT_PLAYBACK_DURATION: int = 28800  # 8 hours
+    _DEFAULT_PLAYBACK_DURATION: int = 86400  # 24 hours
 
     async def async_start_playback(
         self,

--- a/packages/aionanit/tests/test_playback_wire_format.py
+++ b/packages/aionanit/tests/test_playback_wire_format.py
@@ -118,7 +118,7 @@ class TestCurrentPlaybackWireFormat:
 
         playback = _decode_playback_from_sent(sent[0])
         assert playback.HasField("duration")
-        assert playback.duration == 28800
+        assert playback.duration == 86400
 
         raw = playback.SerializeToString()
         field_numbers = _extract_field_numbers(raw)

--- a/tools/nanit-sound.py
+++ b/tools/nanit-sound.py
@@ -416,6 +416,64 @@ async def cmd_stop(session: SoundSession, _arg: str | None = None) -> None:
     print("\n  → Listen: did the sound stop?")
 
 
+# ── 3b. PUT_PLAYBACK STARTED with duration=0 — infinite? ────────────────
+
+
+@sound_command(
+    name="start-d0",
+    description="PUT_PLAYBACK STARTED with duration=0 — test if 0 means infinite",
+    hint=(
+        "Sends PUT_PLAYBACK { status: STARTED, duration: 0 }.\n"
+        "  If the camera plays indefinitely, duration=0 means 'no limit'.\n"
+        "  If it stops immediately or after one track, 0 is not infinite.\n"
+        "  Compare with 'start' (no duration) and 'start-duration 60' (1 min)."
+    ),
+)
+async def cmd_start_d0(session: SoundSession, _arg: str | None = None) -> None:
+    print("  Sending PUT_PLAYBACK (status=STARTED, duration=0) ...")
+    playback = Playback(status=PlaybackStatus.STARTED, duration=0)
+    await session.send_typed_and_dump(
+        RequestType.PUT_PLAYBACK,
+        "PUT_PLAYBACK { status: STARTED, duration: 0 }",
+        playback=playback,
+    )
+    print("\n  → Listen: is the camera playing? Does it keep playing past ~1 min?")
+    print("  → If it plays indefinitely, duration=0 = infinite (this is our fix).")
+
+
+# ── 3c. PUT_PLAYBACK STARTED with custom duration ───────────────────────
+
+
+@sound_command(
+    name="start-duration",
+    description="PUT_PLAYBACK STARTED with custom duration (seconds)",
+    hint=(
+        "Sends PUT_PLAYBACK { status: STARTED, duration: N }.\n"
+        "  Try 60 (1 min) to quickly confirm firmware honors the value.\n"
+        "  If it stops after exactly 60s, the duration field works as expected."
+    ),
+    takes_arg="SECONDS",
+)
+async def cmd_start_duration(session: SoundSession, arg: str | None = None) -> None:
+    if arg is None:
+        arg = input("  Duration in seconds: ").strip()
+
+    try:
+        duration = int(arg)
+    except ValueError:
+        print(f"  ✗ Invalid duration: {arg!r} (expected integer)")
+        return
+
+    print(f"  Sending PUT_PLAYBACK (status=STARTED, duration={duration}) ...")
+    playback = Playback(status=PlaybackStatus.STARTED, duration=duration)
+    await session.send_typed_and_dump(
+        RequestType.PUT_PLAYBACK,
+        f"PUT_PLAYBACK {{ status: STARTED, duration: {duration} }}",
+        playback=playback,
+    )
+    print(f"\n  → Listen: does it stop after exactly {duration}s?")
+
+
 # ── 4. GET_SOUNDTRACKS — discover available tracks ──────────────────────
 
 


### PR DESCRIPTION
Fixes #87

**Problem:** The integration sends `PUT_PLAYBACK` with `duration=28800` (8 hours). The camera firmware stops playback when the duration expires. Users with bedtime automations at ~7:30pm see white noise stop around 3:30am.

**Fix:** Increase `_DEFAULT_PLAYBACK_DURATION` from 28800 (8h) to 86400 (24h). This covers any realistic overnight session while still turning off after 24h if forgotten (e.g. vacation).

**Testing:** Verified against live camera firmware that `duration` controls how long the camera loops the track before auto-stopping.