### PR TITLE
fix: move sensor override pickers below toggles in card editor

### DIFF
--- a/custom_components/nanit/frontend/nanit-card.js
+++ b/custom_components/nanit/frontend/nanit-card.js
@@ -714,22 +714,6 @@ function t(t,e,i,s){var n,r=arguments.length,a=r<3?e:null===s?s=Object.getOwnPro
           allow-custom-entity
           @value-changed=${t=>this._entityChanged("camera_entity_id",t)}
         ></ha-entity-picker>
-        <ha-entity-picker
-          .hass=${this.hass}
-          .value=${this._config.temperature_entity_id||""}
-          .includeDomains=${["sensor"]}
-          .label=${"Temperature Entity Override"}
-          allow-custom-entity
-          @value-changed=${t=>this._entityChanged("temperature_entity_id",t)}
-        ></ha-entity-picker>
-        <ha-entity-picker
-          .hass=${this.hass}
-          .value=${this._config.humidity_entity_id||""}
-          .includeDomains=${["sensor"]}
-          .label=${"Humidity Entity Override"}
-          allow-custom-entity
-          @value-changed=${t=>this._entityChanged("humidity_entity_id",t)}
-        ></ha-entity-picker>
         <label class="toggle-row">
           <span>Hide baby name</span>
           <ha-switch
@@ -765,6 +749,22 @@ function t(t,e,i,s){var n,r=arguments.length,a=r<3?e:null===s?s=Object.getOwnPro
             @change=${t=>this._toggleChanged("hide_sound_machine",t)}
           ></ha-switch>
         </label>
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.temperature_entity_id||""}
+          .includeDomains=${["sensor"]}
+          .label=${"Temperature Entity Override"}
+          allow-custom-entity
+          @value-changed=${t=>this._entityChanged("temperature_entity_id",t)}
+        ></ha-entity-picker>
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.humidity_entity_id||""}
+          .includeDomains=${["sensor"]}
+          .label=${"Humidity Entity Override"}
+          allow-custom-entity
+          @value-changed=${t=>this._entityChanged("humidity_entity_id",t)}
+        ></ha-entity-picker>
       </div>
     `:F}};bt.styles=a`
     .editor {

--- a/frontend/src/nanit-card-editor.ts
+++ b/frontend/src/nanit-card-editor.ts
@@ -63,22 +63,6 @@ export class NanitCardEditor extends LitElement {
           allow-custom-entity
           @value-changed=${(ev: CustomEvent) => this._entityChanged("camera_entity_id", ev)}
         ></ha-entity-picker>
-        <ha-entity-picker
-          .hass=${this.hass}
-          .value=${this._config.temperature_entity_id || ""}
-          .includeDomains=${["sensor"]}
-          .label=${"Temperature Entity Override"}
-          allow-custom-entity
-          @value-changed=${(ev: CustomEvent) => this._entityChanged("temperature_entity_id", ev)}
-        ></ha-entity-picker>
-        <ha-entity-picker
-          .hass=${this.hass}
-          .value=${this._config.humidity_entity_id || ""}
-          .includeDomains=${["sensor"]}
-          .label=${"Humidity Entity Override"}
-          allow-custom-entity
-          @value-changed=${(ev: CustomEvent) => this._entityChanged("humidity_entity_id", ev)}
-        ></ha-entity-picker>
         <label class="toggle-row">
           <span>Hide baby name</span>
           <ha-switch
@@ -119,6 +103,22 @@ export class NanitCardEditor extends LitElement {
               this._toggleChanged("hide_sound_machine", ev)}
           ></ha-switch>
         </label>
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.temperature_entity_id || ""}
+          .includeDomains=${["sensor"]}
+          .label=${"Temperature Entity Override"}
+          allow-custom-entity
+          @value-changed=${(ev: CustomEvent) => this._entityChanged("temperature_entity_id", ev)}
+        ></ha-entity-picker>
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.humidity_entity_id || ""}
+          .includeDomains=${["sensor"]}
+          .label=${"Humidity Entity Override"}
+          allow-custom-entity
+          @value-changed=${(ev: CustomEvent) => this._entityChanged("humidity_entity_id", ev)}
+        ></ha-entity-picker>
       </div>
     `;
   }


### PR DESCRIPTION
sensor override pickers were added above the toggle rows, pushing them below the visible fold in the card editor dialog. moves them to the bottom since they are optional advanced fields.