### PR TITLE
fix: auto-reload integration when offline camera reconnects

### DIFF
--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -232,7 +232,12 @@ class NanitNetworkCoordinator(DataUpdateCoordinator[NetworkInfo | None]):
         self.baby = baby
 
     async def _async_update_data(self) -> NetworkInfo | None:
-        """Fetch network info from the Nanit API."""
+        """Fetch network info from the Nanit API.
+
+        Also checks if any cameras that failed to connect during setup now
+        report as connected in the Nanit cloud. If so, triggers a config entry
+        reload so HA re-runs setup and registers the camera's entities.
+        """
         try:
             client = self._hub.client
             assert client.token_manager is not None
@@ -250,6 +255,26 @@ class NanitNetworkCoordinator(DataUpdateCoordinator[NetworkInfo | None]):
                 translation_key="cloud_fetch_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+
+        # Check if any previously-failed camera has come back online.
+        # camera_connected is sourced from the Nanit cloud's own "connected"
+        # field — no extra probe needed.
+        failed = self._hub.failed_camera_uids
+        if failed:
+            recovered = [
+                b for b in babies
+                if b.camera_uid in failed and b.camera_connected is True
+            ]
+            if recovered:
+                names = ", ".join(b.name for b in recovered)
+                _LOGGER.info(
+                    "Previously offline camera(s) now connected per Nanit cloud: %s. "
+                    "Reloading integration to register entities.",
+                    names,
+                )
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
+                )
 
         for baby in babies:
             if baby.camera_uid == self.baby.camera_uid:

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -261,10 +261,7 @@ class NanitNetworkCoordinator(DataUpdateCoordinator[NetworkInfo | None]):
         # field — no extra probe needed.
         failed = self._hub.failed_camera_uids
         if failed:
-            recovered = [
-                b for b in babies
-                if b.camera_uid in failed and b.camera_connected is True
-            ]
+            recovered = [b for b in babies if b.camera_uid in failed and b.camera_connected is True]
             if recovered:
                 names = ", ".join(b.name for b in recovered)
                 _LOGGER.info(

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -80,6 +80,7 @@ class NanitHub:
         self._client = NanitClient(session)
         self._camera_data: dict[str, CameraData] = {}
         self._babies: list[Baby] = []
+        self._failed_camera_uids: set[str] = set()
         self._sound_lights: dict[str, NanitSoundLight] = {}
         self._unsubscribe_tokens: Callable[[], None] | None = None
 
@@ -97,6 +98,11 @@ class NanitHub:
     def babies(self) -> list[Baby]:
         """Return all discovered babies (including ones that failed to connect)."""
         return self._babies
+
+    @property
+    def failed_camera_uids(self) -> set[str]:
+        """Return UIDs of cameras that failed to connect during setup."""
+        return self._failed_camera_uids
 
     async def async_setup(self) -> None:
         """Restore tokens, discover babies, create cameras and coordinators.
@@ -172,13 +178,22 @@ class NanitHub:
             if isinstance(result, NanitAuthError):
                 raise result
             if isinstance(result, NanitConnectionError | NanitCameraUnavailable | TimeoutError):
+                cloud_status = (
+                    "cloud reports connected=True (transient failure?)"
+                    if baby.camera_connected is True
+                    else "cloud reports connected=False (camera offline)"
+                    if baby.camera_connected is False
+                    else "cloud connected status unknown"
+                )
                 _LOGGER.warning(
-                    "Camera %s (%s) failed to connect: %s",
+                    "Camera %s (%s) failed to connect: %s — %s",
                     baby.name,
                     baby.camera_uid,
                     result,
+                    cloud_status,
                 )
                 failed_cameras.append(display_name(baby.name, baby.uid))
+                self._failed_camera_uids.add(baby.camera_uid)
                 ir.async_create_issue(
                     self._hass,
                     DOMAIN,

--- a/packages/aionanit/aionanit/models.py
+++ b/packages/aionanit/aionanit/models.py
@@ -141,6 +141,8 @@ class Baby:
     camera_uid: str
     speaker_uid: str | None = None
     network: NetworkInfo | None = None
+    camera_connected: bool | None = None  # True = camera online per Nanit cloud
+    camera_last_seen: int | None = None  # Unix timestamp of last cloud contact
 
 
 @dataclass(frozen=True)

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -62,6 +62,24 @@ def _parse_network(baby_json: dict[str, Any]) -> NetworkInfo | None:
     )
 
 
+def _parse_camera_connected(baby_json: dict[str, Any]) -> bool | None:
+    """Return the cloud-reported camera connected state, or None if absent."""
+    cam = baby_json.get("camera")
+    if not isinstance(cam, dict):
+        return None
+    val = cam.get("connected")
+    return bool(val) if isinstance(val, bool) else None
+
+
+def _parse_camera_last_seen(baby_json: dict[str, Any]) -> int | None:
+    """Return the Unix timestamp of the camera's last cloud contact, or None."""
+    cam = baby_json.get("camera")
+    if not isinstance(cam, dict):
+        return None
+    val = cam.get("last_seen")
+    return int(val) if isinstance(val, int | float) else None
+
+
 # Headers required by the Nanit API. The API rejects requests without
 # nanit-api-version (especially when MFA is enabled) and may reject
 # requests with a non-mobile User-Agent.
@@ -212,6 +230,8 @@ class NanitRestClient:
                 camera_uid=baby["camera_uid"],
                 speaker_uid=((baby.get("speaker") or {}).get("speaker") or {}).get("uid"),
                 network=_parse_network(baby),
+                camera_connected=_parse_camera_connected(baby),
+                camera_last_seen=_parse_camera_last_seen(baby),
             )
             for baby in body.get("babies", [])
         ]

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -295,6 +295,72 @@ class TestGetBabies:
             with pytest.raises(NanitAuthError):
                 await client.async_get_babies("bad_token")
 
+    async def test_get_babies_camera_connected_true(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={
+                    "babies": [
+                        {
+                            "uid": "baby1",
+                            "name": "Ezra",
+                            "camera_uid": "cam1",
+                            "camera": {
+                                "connected": True,
+                                "last_seen": 1783109177,
+                            },
+                        }
+                    ]
+                },
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert babies[0].camera_connected is True
+        assert babies[0].camera_last_seen == 1783109177
+
+    async def test_get_babies_camera_connected_false(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={
+                    "babies": [
+                        {
+                            "uid": "baby1",
+                            "name": "Ezra",
+                            "camera_uid": "cam1",
+                            "camera": {
+                                "connected": False,
+                                "last_seen": 1783000000,
+                            },
+                        }
+                    ]
+                },
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert babies[0].camera_connected is False
+        assert babies[0].camera_last_seen == 1783000000
+
+    async def test_get_babies_camera_connected_absent(self, client: NanitRestClient) -> None:
+        """When the camera object is missing, camera_connected and camera_last_seen are None."""
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={
+                    "babies": [
+                        {
+                            "uid": "baby1",
+                            "name": "Ezra",
+                            "camera_uid": "cam1",
+                        }
+                    ]
+                },
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert babies[0].camera_connected is None
+        assert babies[0].camera_last_seen is None
+
 
 class TestGetEvents:
     async def test_get_events_success(self, client: NanitRestClient) -> None:

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_ACCESS_TOKEN
@@ -312,3 +313,69 @@ async def test_setup_camera_timeout_treated_as_connection_failure(
 
     assert len(hub.camera_data) == 1
     assert MOCK_BABY_2.camera_uid in hub.camera_data
+
+
+async def test_failed_camera_uids_populated(hass: HomeAssistant, mock_nanit_client) -> None:
+    """Cameras that fail to connect are tracked in failed_camera_uids."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_1, MOCK_BABY_2]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+    ):
+
+        def push_factory(_hass, _entry, camera, _baby):
+            mock = MagicMock()
+            if camera.uid == MOCK_BABY_1.camera_uid:
+                mock.async_setup = AsyncMock(side_effect=NanitConnectionError("unreachable"))
+            else:
+                mock.async_setup = AsyncMock()
+            return mock
+
+        push_cls.side_effect = push_factory
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        await hub.async_setup()
+
+    assert MOCK_BABY_1.camera_uid in hub.failed_camera_uids
+    assert MOCK_BABY_2.camera_uid not in hub.failed_camera_uids
+
+
+async def test_failed_camera_uid_logs_cloud_status(
+    hass: HomeAssistant, mock_nanit_client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Log message includes cloud connected=False when camera is known offline."""
+    from aionanit.models import Baby
+
+    offline_baby = Baby(
+        uid=MOCK_BABY_1.uid,
+        name=MOCK_BABY_1.name,
+        camera_uid=MOCK_BABY_1.camera_uid,
+        camera_connected=False,
+    )
+    mock_nanit_client.async_get_babies.return_value = [offline_baby]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator"),
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator"),
+        caplog.at_level("WARNING", logger="custom_components.nanit.hub"),
+    ):
+        push_cls.return_value = MagicMock(
+            async_setup=AsyncMock(side_effect=NanitConnectionError("unreachable"))
+        )
+        try:
+            await hub.async_setup()
+        except NanitConnectionError:
+            pass
+
+    assert "cloud reports connected=False" in caplog.text

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import pytest
+from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -373,9 +374,7 @@ async def test_failed_camera_uid_logs_cloud_status(
         push_cls.return_value = MagicMock(
             async_setup=AsyncMock(side_effect=NanitConnectionError("unreachable"))
         )
-        try:
+        with suppress(NanitConnectionError):
             await hub.async_setup()
-        except NanitConnectionError:
-            pass
 
     assert "cloud reports connected=False" in caplog.text


### PR DESCRIPTION
When a Nanit camera is offline at HA startup and at least one other camera is online, async_setup_entry returns True and the offline camera gets no entities — with no automatic recovery path.

This fix makes the integration self-heal without a manual HA restart:

- Parse camera.connected and camera.last_seen from the /babies API response into the Baby model (aionanit). The Nanit cloud reports camera online/offline status directly in this existing endpoint.

- Track failed camera UIDs in NanitHub.failed_camera_uids after setup. Warning logs now include the cloud-reported connected state so it is immediately clear whether the failure is expected (camera offline) or surprising (camera should be reachable).

- Piggyback on NanitNetworkCoordinator's existing /babies poll: when any previously-failed camera appears with connected=True, schedule a config entry reload via hass.config_entries.async_reload(). This triggers a fresh async_setup_entry which connects the camera and registers its entities cleanly.

No new poll loop is introduced — recovery detection reuses the NETWORK_POLL_INTERVAL cycle already running for connected cameras.