### PR TITLE
fix: harden state restore on HA restart

### DIFF
--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -138,6 +138,12 @@ def _async_remove_stale_devices(
     hass: HomeAssistant, entry: NanitConfigEntry, hub: NanitHub
 ) -> None:
     """Remove HA devices for cameras no longer on the Nanit account."""
+    # If the API returned no babies (transient outage, account propagation),
+    # skip removal — otherwise we would wipe every device for the entry and
+    # force the user to re-add them.
+    if not hub.babies:
+        return
+
     device_reg = dr.async_get(hass)
     known_camera_uids = {baby.camera_uid for baby in hub.babies}
 

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.components.light.const import ColorMode
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -78,11 +78,16 @@ class NanitNightLight(NanitEntity, RestoreEntity, LightEntity):
             self._sync_from_state(coordinator.data)
 
     async def async_added_to_hass(self) -> None:
-        """Restore last known state on startup."""
+        """Restore last known state on startup.
+
+        Only restore from concrete on/off states; treat unavailable/unknown
+        as "no info" so a disconnect at shutdown doesn't pin the entity to
+        off until the next coordinator update.
+        """
         await super().async_added_to_hass()
         if self._attr_is_on is None:
             last_state = await self.async_get_last_state()
-            if last_state is not None:
+            if last_state is not None and last_state.state in (STATE_ON, STATE_OFF):
                 self._attr_is_on = last_state.state == STATE_ON
                 if (brightness := last_state.attributes.get(ATTR_BRIGHTNESS)) is not None:
                     self._attr_brightness = int(brightness)

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity, SwitchEntityDescription
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -101,11 +101,17 @@ class NanitSwitch(NanitEntity, RestoreEntity, SwitchEntity):
             self._attr_is_on = self.entity_description.value_fn(coordinator.data)
 
     async def async_added_to_hass(self) -> None:
-        """Restore last known state on startup."""
+        """Restore last known state on startup.
+
+        Only restore from concrete on/off states; treat unavailable/unknown
+        as "no info" so a disconnect at shutdown doesn't pin the entity to
+        off until the next coordinator update.
+        """
         await super().async_added_to_hass()
         if (
             self._attr_is_on is None
             and (last_state := await self.async_get_last_state()) is not None
+            and last_state.state in (STATE_ON, STATE_OFF)
         ):
             self._attr_is_on = last_state.state == STATE_ON
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -193,6 +193,47 @@ async def test_active_device_not_removed(
     mock_device_registry.async_remove_device.assert_not_called()
 
 
+async def test_no_devices_removed_when_babies_list_empty(
+    hass: HomeAssistant,
+    mock_nanit_client,
+) -> None:
+    """If the API transiently returns no babies, don't wipe existing HA devices."""
+    mock_nanit_client.async_get_babies.return_value = []
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+
+    mock_device_registry = MagicMock()
+    existing_device = MagicMock()
+    existing_device.identifiers = {(DOMAIN, MOCK_BABY_1.camera_uid)}
+    existing_device.id = "device_existing"
+    existing_device.name = "Existing Camera"
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[existing_device],
+        ),
+    ):
+        assert await async_setup_entry(hass, entry)
+
+    mock_device_registry.async_remove_device.assert_not_called()
+
+
 async def test_deprecated_switch_entity_removed_on_setup(
     hass: HomeAssistant,
     mock_nanit_client,

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -704,6 +704,25 @@ async def test_nanit_switch_async_added_to_hass_restores_state() -> None:
     assert entity._attr_is_on is True
 
 
+@pytest.mark.parametrize("stale_state", ["unavailable", "unknown"])
+async def test_nanit_switch_skips_restore_for_stale_state(stale_state: str) -> None:
+    """Unavailable/unknown last-state must not pin the switch to off on restart."""
+    coordinator = _push_coordinator(None)
+    camera = MagicMock(uid="cam_1")
+    entity = NanitSwitch(coordinator, camera, _switch_desc)
+    _disable_state_writes(entity)
+
+    last_state = MagicMock()
+    last_state.state = stale_state
+    entity.async_get_last_state = AsyncMock(return_value=last_state)
+    entity.async_on_remove = MagicMock()
+
+    with patch("homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass"):
+        await entity.async_added_to_hass()
+
+    assert entity._attr_is_on is None
+
+
 # ---------------------------------------------------------------------------
 # S&L Sound switch — is_on returns None when no data
 # ---------------------------------------------------------------------------
@@ -1444,3 +1463,21 @@ async def test_night_light_async_added_to_hass_skips_restore_when_data_present()
         await entity.async_added_to_hass()
 
     assert entity.is_on is True
+
+
+@pytest.mark.parametrize("stale_state", ["unavailable", "unknown"])
+async def test_night_light_skips_restore_for_stale_state(stale_state: str) -> None:
+    """Unavailable/unknown last-state must not pin the light to off on restart."""
+    entity, _ = _night_light_entity(data_is_none=True)
+
+    last_state = MagicMock()
+    last_state.state = stale_state
+    last_state.attributes = {ATTR_BRIGHTNESS: 180}
+    entity.async_get_last_state = AsyncMock(return_value=last_state)
+    entity.async_on_remove = MagicMock()
+
+    with patch("homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass"):
+        await entity.async_added_to_hass()
+
+    assert entity.is_on is None
+    assert entity.brightness is None


### PR DESCRIPTION
- Skip stale-device cleanup when the babies API returns empty so a transient outage cannot wipe every device for the entry.
- Only restore camera_power switch and night-light state from concrete on/off; treat unavailable/unknown last-states as "no info" so a disconnect at shutdown does not pin entities to off until the next coordinator update.