### PR TITLE
chore: update to python 3.14 and ruff to 0.15.20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix]

--- a/custom_components/nanit/aionanit_sl/sl_protocol.py
+++ b/custom_components/nanit/aionanit_sl/sl_protocol.py
@@ -122,7 +122,7 @@ def try_decode_string(data: bytes) -> str | None:
     """Try to decode bytes as UTF-8 string."""
     try:
         return data.decode("utf-8")
-    except (UnicodeDecodeError, ValueError):
+    except UnicodeDecodeError, ValueError:
         return None
 
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -182,7 +182,7 @@ class NanitSoundLight:
         self._use_cloud_relay = self._device_ip is None
         try:
             await self._async_connect()
-        except (NanitTransportError, NanitConnectionError):
+        except NanitTransportError, NanitConnectionError:
             _LOGGER.warning(
                 "S&L %s initial connection failed; will retry in background",
                 self._speaker_uid,

--- a/custom_components/nanit/frontend/__init__.py
+++ b/custom_components/nanit/frontend/__init__.py
@@ -34,7 +34,7 @@ def _card_resource_version() -> str:
             (Path(__file__).parent.parent / "manifest.json").read_text()
         )
         manifest_version = str(manifest.get("version", "0"))
-    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+    except FileNotFoundError, json.JSONDecodeError, KeyError:
         pass
 
     try:
@@ -51,7 +51,7 @@ try:
         (Path(__file__).parent.parent / "manifest.json").read_text()
     )
     _MANIFEST_VERSION = str(_manifest.get("version", "0"))
-except (FileNotFoundError, json.JSONDecodeError, KeyError):
+except FileNotFoundError, json.JSONDecodeError, KeyError:
     pass
 
 

--- a/justfile
+++ b/justfile
@@ -12,8 +12,8 @@ setup:
     #!/usr/bin/env bash
     set -euo pipefail
     if [ ! -d venv ]; then
-        echo "Creating venv with python3.13 ..."
-        python3.13 -m venv venv
+        echo "Creating venv with python3.14 ..."
+        python3.14 -m venv venv
     fi
     echo "Upgrading pip + setuptools ..."
     venv/bin/python3 -m pip install --upgrade pip setuptools wheel

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -1145,7 +1145,7 @@ class NanitCamera:
                         )
                         # Local is reachable — promote.
                         await probe.async_close()
-                    except (TimeoutError, NanitConnectionError, NanitTransportError):
+                    except TimeoutError, NanitConnectionError, NanitTransportError:
                         _LOGGER.debug("Local probe failed, staying on cloud")
                         continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # The aionanit library has its own pyproject.toml in packages/aionanit/.
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py314"
 line-length = 100
 
 [tool.ruff.lint]

--- a/tools/nanit-network.py
+++ b/tools/nanit-network.py
@@ -121,7 +121,7 @@ async def async_main() -> int:
             try:
                 print(f"\nNext request in {args.watch}s (Ctrl+C to stop)")
                 await asyncio.sleep(args.watch)
-            except (KeyboardInterrupt, asyncio.CancelledError):
+            except KeyboardInterrupt, asyncio.CancelledError:
                 print("\nStopped.")
                 break
 

--- a/tools/release-cli.py
+++ b/tools/release-cli.py
@@ -224,7 +224,7 @@ async def fetch_state() -> State:
                     "url": pr["url"],
                     "labels": [lbl["name"] for lbl in pr.get("labels", [])],
                 }
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError, KeyError:
             pass
 
     return state


### PR DESCRIPTION
Home assistant has dropped support for python 3.13 and 3.12, so we need to update our code to support python 3.14.

This also includes updating ruff to 0.15.20 which is the latest version that supports python 3.14.

Ran `just fix` to fix any linting issues that were caused by the update.