### PR TITLE
feat: add activity data discovery tools for issue #49

### DIFF
--- a/docs/activity-api-discovery.md
+++ b/docs/activity-api-discovery.md
@@ -1,0 +1,170 @@
+# API Discovery Guide: Nanit Care Logs Endpoints
+
+> **Purpose**: Step-by-step guide for a tester with the Nanit **Insights plan** to capture the API endpoints used by the Care Logs feature (feeding, diaper changes, activity log).
+>
+> **Context**: [Issue #49](https://github.com/wealthystudent/ha-nanit/issues/49) — no public documentation exists for these endpoints. We need someone with an active Insights subscription to intercept the app's network traffic.
+
+---
+
+## Prerequisites
+
+- A phone (iOS or Android) with the **Nanit app** installed and logged in
+- An active **Nanit Insights plan** (Care Logs feature must be visible in the app)
+- A computer on the **same Wi-Fi network** as the phone
+- ~15 minutes
+
+---
+
+## Option A: mitmproxy (Free, Cross-Platform)
+
+### 1. Install mitmproxy on your computer
+
+**macOS:**
+```bash
+brew install mitmproxy
+```
+
+**Linux:**
+```bash
+pip install mitmproxy
+# or: sudo apt install mitmproxy
+```
+
+**Windows:**
+Download from https://mitmproxy.org/
+
+### 2. Start the proxy
+
+```bash
+mitmweb --listen-port 8080
+```
+
+This opens a web UI at http://127.0.0.1:8081 where you'll see captured traffic.
+
+### 3. Configure your phone to use the proxy
+
+1. Find your computer's local IP address:
+   - macOS: `ipconfig getifaddr en0`
+   - Linux: `hostname -I | awk '{print $1}'`
+   - Windows: `ipconfig` → look for IPv4 Address
+2. On your phone, go to **Wi-Fi settings** → tap your connected network
+3. Set **HTTP Proxy** to **Manual**:
+   - Server: `<your computer's IP>`
+   - Port: `8080`
+
+### 4. Install the mitmproxy CA certificate
+
+This is required to decrypt HTTPS traffic from the Nanit app.
+
+1. On your phone's browser, navigate to: **http://mitm.it**
+2. Download and install the certificate for your OS (iOS or Android)
+
+**iOS:**
+- Tap the iOS link to download the profile
+- Go to **Settings → General → VPN & Device Management** → install the profile
+- Go to **Settings → General → About → Certificate Trust Settings** → enable "mitmproxy"
+
+**Android:**
+- Download the `.cer` file
+- Go to **Settings → Security → Install a certificate → CA certificate**
+- Select the downloaded file
+
+### 5. Capture the Care Logs traffic
+
+With the proxy running and phone configured:
+
+1. **Open the Nanit app** on your phone
+2. Navigate to the **Activity** or **Care Logs** tab
+3. **Scroll through existing entries** (this triggers GET requests)
+4. **Add a new feeding** (bottle or nursing) — this triggers POST requests
+5. **Add a new diaper change** — another POST request
+6. **Delete an entry** if possible — might trigger DELETE request
+
+### 6. Export the results
+
+In the mitmweb UI (http://127.0.0.1:8081):
+
+1. Filter flows by domain: type `~d api.nanit.com` in the filter bar
+2. Look for requests to paths containing words like:
+   - `activities`, `care_logs`, `logs`, `feedings`, `diapers`, `timeline`
+   - Any path under `/babies/{uid}/` that isn't `/messages` or `/snapshot`
+3. For each interesting request, click it and note:
+   - **Full URL** (method + path + query params)
+   - **Request headers** (especially any special ones beyond Authorization)
+   - **Request body** (for POST/PUT requests)
+   - **Response body** (the JSON data structure)
+
+**To export all flows:**
+```bash
+# In terminal where mitmproxy is running, or use:
+mitmdump -r ~/.mitmproxy/flows -w nanit-capture.txt --set flow_detail=3
+```
+
+Or simply **screenshot** each interesting request/response from the mitmweb UI.
+
+### 7. Clean up
+
+1. Remove the proxy setting from your phone's Wi-Fi
+2. (Optional) Remove the CA certificate from your phone
+3. Stop mitmproxy with Ctrl+C
+
+---
+
+## Option B: Proxyman (macOS only, GUI, easier)
+
+If the tester uses macOS and prefers a GUI:
+
+1. Download [Proxyman](https://proxyman.io/) (free tier works)
+2. Follow their [iOS setup guide](https://docs.proxyman.io/debug-devices/ios-device)
+3. In Proxyman, right-click `api.nanit.com` → **Enable SSL Proxying**
+4. Perform the same app actions as Step 5 above
+5. Export/screenshot the captured requests
+
+---
+
+## What We Need From You
+
+Please share the following for **each new endpoint** you find:
+
+```
+## Endpoint: [name]
+
+**Request:**
+- Method: GET/POST/PUT/DELETE
+- URL: https://api.nanit.com/babies/{baby_uid}/...
+- Query params: ?limit=20&...
+- Body (if POST/PUT): { ... }
+
+**Response:**
+- Status: 200
+- Body: { ... }
+```
+
+**Critical data points:**
+- The exact URL path (e.g., `/babies/{uid}/activities` or `/babies/{uid}/care_logs`)
+- The JSON structure of the response (field names, data types)
+- Whether pagination exists (look for `next_page`, `offset`, `cursor` fields)
+- What fields a feeding entry contains (amount, unit, type, timestamp, etc.)
+- What fields a diaper entry contains (type, timestamp, notes, etc.)
+
+---
+
+## Alternative: Run the Probe Script First
+
+Before doing the full proxy intercept, you can run our automated probe script which tries common endpoint patterns:
+
+```bash
+# From the ha-nanit repo root:
+just login              # authenticate first
+python3 tools/nanit-activities.py --verbose
+```
+
+If any endpoints return **403 Forbidden** instead of 404, that confirms they exist but are subscription-gated. If you have the Insights plan and they return 200, we might not need the proxy intercept at all!
+
+---
+
+## Sharing Results
+
+Post your findings in [Issue #49](https://github.com/wealthystudent/ha-nanit/issues/49) or share directly with the maintainer. Even partial results (e.g., "I found the endpoint but the response is complex") are valuable — we can iterate from there.
+
+**Security note:** Redact your `access_token` and any personal data (baby names, UIDs) before sharing publicly. Replace them with placeholders like `{baby_uid}` and `{token}`.

--- a/tools/nanit-activities.py
+++ b/tools/nanit-activities.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Probe Nanit cloud API for activity/feeding/care log endpoints.
+
+This is a discovery tool for issue #49 (Feeding and Activity Data).
+It tries speculative API endpoints to determine which ones exist and
+whether they return data, are gated behind a subscription, or don't exist.
+
+Reads session from .nanit-session (created by nanit-login.py).
+
+Interpretation guide:
+  - HTTP 200 + data  → Endpoint exists and works! Capture the response.
+  - HTTP 200 + empty → Endpoint exists but no data (maybe no logs entered).
+  - HTTP 403         → Endpoint exists but requires a higher subscription tier.
+  - HTTP 401         → Token expired. Run: just login
+  - HTTP 404         → Endpoint does not exist at this path.
+  - HTTP 5xx         → Server error (endpoint may exist but is broken).
+
+Usage:
+    python3 tools/nanit-activities.py              # probe all endpoints
+    python3 tools/nanit-activities.py --verbose    # include full response bodies
+    python3 tools/nanit-activities.py --endpoint activities  # probe one endpoint
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from aionanit.rest import NANIT_API_HEADERS
+
+SESSION_FILE = Path(__file__).resolve().parents[1] / ".nanit-session"
+BASE_URL = "https://api.nanit.com"
+
+# Speculative endpoints to probe, based on Nanit URL patterns.
+# Format: (name, method, path_template, params, description)
+ENDPOINTS: list[tuple[str, str, str, dict[str, Any], str]] = [
+    (
+        "activities",
+        "GET",
+        "/babies/{baby_uid}/activities",
+        {"limit": 20},
+        "Speculative: activity/care log feed",
+    ),
+    (
+        "care_logs",
+        "GET",
+        "/babies/{baby_uid}/care_logs",
+        {"limit": 20},
+        "Speculative: care logs (feeding, diaper)",
+    ),
+    (
+        "logs",
+        "GET",
+        "/babies/{baby_uid}/logs",
+        {"limit": 20},
+        "Speculative: generic logs endpoint",
+    ),
+    (
+        "feedings",
+        "GET",
+        "/babies/{baby_uid}/feedings",
+        {"limit": 20},
+        "Speculative: feeding-specific endpoint",
+    ),
+    (
+        "diapers",
+        "GET",
+        "/babies/{baby_uid}/diapers",
+        {"limit": 20},
+        "Speculative: diaper-specific endpoint",
+    ),
+    (
+        "insights",
+        "GET",
+        "/babies/{baby_uid}/insights",
+        {},
+        "Speculative: insights/analytics data",
+    ),
+    (
+        "sleep",
+        "GET",
+        "/babies/{baby_uid}/sleep",
+        {},
+        "Speculative: sleep sessions/analysis",
+    ),
+    (
+        "sleep_summary",
+        "GET",
+        "/babies/{baby_uid}/sleep_summary",
+        {},
+        "Speculative: sleep summary/stats",
+    ),
+    (
+        "timeline",
+        "GET",
+        "/babies/{baby_uid}/timeline",
+        {"limit": 20},
+        "Speculative: activity timeline",
+    ),
+    (
+        "events",
+        "GET",
+        "/babies/{baby_uid}/events",
+        {"limit": 20},
+        "Known older endpoint (may return more event types than /messages)",
+    ),
+    (
+        "messages_extended",
+        "GET",
+        "/babies/{baby_uid}/messages",
+        {"limit": 50},
+        "Known endpoint with larger limit (check for non-MOTION/SOUND types)",
+    ),
+    (
+        "subscriptions",
+        "GET",
+        "/babies/{baby_uid}/subscriptions",
+        {},
+        "Subscription/plan info (reveals your tier)",
+    ),
+    (
+        "permissions",
+        "GET",
+        "/babies/{baby_uid}/permissions",
+        {},
+        "Baby permissions (may show feature gates)",
+    ),
+    (
+        "user",
+        "GET",
+        "/user",
+        {},
+        "Current user info (may show subscription tier)",
+    ),
+]
+
+
+def _format_status(status: int) -> str:
+    """Return a colored/annotated status interpretation."""
+    if status == 200:
+        return f"{status} OK (endpoint exists!)"
+    if status == 401:
+        return f"{status} UNAUTHORIZED (token expired — run: just login)"
+    if status == 403:
+        return f"{status} FORBIDDEN (endpoint exists but subscription-gated!)"
+    if status == 404:
+        return f"{status} NOT FOUND (endpoint does not exist)"
+    if status == 405:
+        return f"{status} METHOD NOT ALLOWED (endpoint exists, wrong HTTP method)"
+    if status >= 500:
+        return f"{status} SERVER ERROR (endpoint may exist but is broken)"
+    return f"{status} (unexpected)"
+
+
+async def _probe_endpoint(
+    session: aiohttp.ClientSession,
+    token: str,
+    baby_uid: str,
+    name: str,
+    method: str,
+    path_template: str,
+    params: dict[str, Any],
+    description: str,
+    verbose: bool,
+) -> dict[str, Any]:
+    """Probe a single endpoint and return the result."""
+    path = path_template.format(baby_uid=baby_uid)
+    url = f"{BASE_URL}{path}"
+    headers = {**NANIT_API_HEADERS, "Authorization": token}
+
+    result: dict[str, Any] = {
+        "name": name,
+        "method": method,
+        "url": url,
+        "params": params,
+        "description": description,
+    }
+
+    try:
+        if method == "GET":
+            resp = await session.get(
+                url,
+                params=params if params else None,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            )
+        else:
+            resp = await session.request(
+                method,
+                url,
+                params=params if params else None,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            )
+
+        result["status"] = resp.status
+        result["status_text"] = _format_status(resp.status)
+
+        # Try to parse response body
+        content_type = resp.headers.get("Content-Type", "")
+        if "json" in content_type or resp.status in (200, 403):
+            try:
+                body = await resp.json(content_type=None)
+                result["body"] = body
+                if isinstance(body, dict):
+                    result["keys"] = list(body.keys())
+            except (json.JSONDecodeError, aiohttp.ContentTypeError):
+                text = await resp.text()
+                result["body_text"] = text[:500] if text else "(empty)"
+        else:
+            text = await resp.text()
+            result["body_text"] = text[:200] if text else "(empty)"
+
+    except aiohttp.ClientError as err:
+        result["error"] = str(err)
+
+    return result
+
+
+async def async_main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe Nanit API for activity/feeding/care log endpoints.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Interpretation:
+  200 + data  = Endpoint works! We found it.
+  200 + empty = Endpoint exists but no data logged yet.
+  403         = Endpoint exists but needs higher subscription (Insights plan).
+  404         = Endpoint does not exist at this path.
+  401         = Token expired. Run: just login
+""",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Show full response bodies"
+    )
+    parser.add_argument(
+        "--endpoint",
+        "-e",
+        help="Probe only this endpoint (by name)",
+        choices=[ep[0] for ep in ENDPOINTS],
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output raw JSON results"
+    )
+    args = parser.parse_args()
+
+    if not SESSION_FILE.exists():
+        print("No session found. Run: just login", file=sys.stderr)
+        return 1
+
+    data = json.loads(SESSION_FILE.read_text())
+    token = data["access_token"]
+    baby_uid = data["baby_uid"]
+    baby_name = data.get("baby_name", "unknown")
+
+    endpoints_to_probe = ENDPOINTS
+    if args.endpoint:
+        endpoints_to_probe = [ep for ep in ENDPOINTS if ep[0] == args.endpoint]
+
+    print(f"Probing Nanit API for activity endpoints...")
+    print(f"Baby: {baby_name} (uid={baby_uid})")
+    print(f"Endpoints to probe: {len(endpoints_to_probe)}")
+    print("=" * 70)
+
+    results: list[dict[str, Any]] = []
+
+    async with aiohttp.ClientSession() as session:
+        for name, method, path_template, params, description in endpoints_to_probe:
+            result = await _probe_endpoint(
+                session, token, baby_uid, name, method, path_template, params,
+                description, args.verbose,
+            )
+            results.append(result)
+
+            if not args.json:
+                print(f"\n  [{name}] {method} {result['url']}")
+                print(f"  {description}")
+                if params:
+                    print(f"  Params: {params}")
+                print(f"  Result: {result.get('status_text', result.get('error', 'unknown'))}")
+
+                if result.get("keys"):
+                    print(f"  Response keys: {result['keys']}")
+
+                if args.verbose and result.get("body"):
+                    print(f"  Body: {json.dumps(result['body'], indent=2)[:2000]}")
+                elif args.verbose and result.get("body_text"):
+                    print(f"  Body: {result['body_text']}")
+
+                # Highlight interesting findings
+                status = result.get("status", 0)
+                if status == 200:
+                    body = result.get("body")
+                    if isinstance(body, dict) and body:
+                        print("  >>> FOUND DATA! This endpoint works.")
+                    elif isinstance(body, list) and body:
+                        print(f"  >>> FOUND {len(body)} items! This endpoint works.")
+                    elif isinstance(body, dict) and not body:
+                        print("  >>> Endpoint exists but returned empty object.")
+                    elif isinstance(body, list) and not body:
+                        print("  >>> Endpoint exists but returned empty list (no data logged?).")
+                elif status == 403:
+                    print("  >>> ENDPOINT EXISTS but is subscription-gated (needs Insights plan).")
+
+            # Stop early if token is expired
+            if result.get("status") == 401:
+                if not args.json:
+                    print("\n  Token expired. Run: just login")
+                break
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+    else:
+        # Summary
+        print("\n" + "=" * 70)
+        print("SUMMARY")
+        print("=" * 70)
+
+        found = [r for r in results if r.get("status") == 200]
+        gated = [r for r in results if r.get("status") == 403]
+        missing = [r for r in results if r.get("status") == 404]
+        method_wrong = [r for r in results if r.get("status") == 405]
+
+        if found:
+            print(f"\n  WORKING ({len(found)}):")
+            for r in found:
+                keys = r.get("keys", [])
+                print(f"    - {r['name']}: {r['url']} (keys: {keys})")
+
+        if gated:
+            print(f"\n  SUBSCRIPTION-GATED ({len(gated)}):")
+            for r in gated:
+                print(f"    - {r['name']}: {r['url']}")
+            print("    These endpoints EXIST but need a higher plan (Insights).")
+            print("    A tester with Insights can confirm they return data.")
+
+        if method_wrong:
+            print(f"\n  WRONG METHOD ({len(method_wrong)}):")
+            for r in method_wrong:
+                print(f"    - {r['name']}: {r['url']} (try POST?)")
+
+        if missing:
+            print(f"\n  NOT FOUND ({len(missing)}):")
+            for r in missing:
+                print(f"    - {r['name']}: {r['url']}")
+
+        # Actionable next steps
+        print("\n" + "-" * 70)
+        print("NEXT STEPS")
+        print("-" * 70)
+        if gated:
+            print("  Subscription-gated endpoints were found! A tester with the")
+            print("  Insights plan should run this script to confirm they get data.")
+        elif found:
+            print("  Working endpoints found! Run with --verbose to see full data.")
+            print("  Share the output in the GitHub issue.")
+        else:
+            print("  No activity endpoints found with these guesses.")
+            print("  A tester with Insights should use mitmproxy to capture the")
+            print("  actual API calls made by the Nanit app. See the tester guide.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(async_main()))


### PR DESCRIPTION
## Summary

Adds discovery tooling to investigate Nanit Care Logs API endpoints (feeding, diaper changes, activity log) for #49.

### What's included

- **`tools/nanit-activities.py`** — Probe script that tries 14 speculative API endpoints and reports status codes (200 = works, 403 = exists but subscription-gated, 404 = doesn't exist)
- **`docs/activity-api-discovery.md`** — Step-by-step mitmproxy interception guide for testers with the Insights plan

### Background

No publicly documented API endpoint exists for Nanit Care Logs. The endpoints almost certainly exist (the app syncs data across devices), but nobody in the community has captured them yet. These tools enable:

1. **Cheap probing** — run the script to learn which paths return 403 vs 404
2. **Full discovery** — a tester with Insights can follow the mitmproxy guide to capture actual API traffic

### Usage

```bash
just login
python3 tools/nanit-activities.py --verbose
```

### Next steps (after discovery)

Once endpoints are confirmed, implementation follows existing patterns:
- `async_get_activities()` in `NanitRestClient`
- New data models + polling coordinator
- Sensor entities (last feeding, last diaper, etc.)

Closes #49 (partially — full implementation pending endpoint discovery)