### PR TITLE
fix: pre-compute card resource version at import time

### DIFF
--- a/custom_components/nanit/frontend/__init__.py
+++ b/custom_components/nanit/frontend/__init__.py
@@ -6,6 +6,7 @@ Lovelace resource so the card appears in the card picker automatically.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -27,24 +28,9 @@ _CARD_URL = f"{_URL_BASE}/{_CARD_FILENAME}"
 _REGISTERED_KEY = "nanit_card_registered"
 
 
-def _card_resource_version() -> str:
-    manifest_version = "0"
-    try:
-        manifest: dict[str, Any] = json.loads(
-            (Path(__file__).parent.parent / "manifest.json").read_text()
-        )
-        manifest_version = str(manifest.get("version", "0"))
-    except (FileNotFoundError, json.JSONDecodeError, KeyError):
-        pass
-
-    try:
-        card_hash = hashlib.sha256((_CARD_DIR / _CARD_FILENAME).read_bytes()).hexdigest()[:12]
-    except FileNotFoundError:
-        return manifest_version
-
-    return f"{manifest_version}-{card_hash}"
-
-
+# Pre-compute at import time — these files are static (part of the installed
+# package) and never change until the next HACS update/reinstall.  Reading them
+# here avoids blocking I/O inside the async event loop.
 _MANIFEST_VERSION: str = "0"
 try:
     _manifest: dict[str, Any] = json.loads(
@@ -53,6 +39,14 @@ try:
     _MANIFEST_VERSION = str(_manifest.get("version", "0"))
 except (FileNotFoundError, json.JSONDecodeError, KeyError):
     pass
+
+_CARD_HASH: str = ""
+with contextlib.suppress(FileNotFoundError):
+    _CARD_HASH = hashlib.sha256((_CARD_DIR / _CARD_FILENAME).read_bytes()).hexdigest()[:12]
+
+_CARD_RESOURCE_VERSION: str = (
+    f"{_MANIFEST_VERSION}-{_CARD_HASH}" if _CARD_HASH else _MANIFEST_VERSION
+)
 
 
 async def async_register_card(hass: HomeAssistant) -> None:
@@ -81,7 +75,7 @@ async def async_register_card(hass: HomeAssistant) -> None:
         _LOGGER.debug("Lovelace in YAML mode — skipping automatic card resource registration")
         return
 
-    resource_url = f"{_CARD_URL}?v={_card_resource_version()}"
+    resource_url = f"{_CARD_URL}?v={_CARD_RESOURCE_VERSION}"
     resources = cast(ResourceStorageCollection, lovelace_data.resources)
 
     if not resources.loaded:

--- a/tests/unit/test_frontend.py
+++ b/tests/unit/test_frontend.py
@@ -9,10 +9,10 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.nanit.frontend import (
+    _CARD_RESOURCE_VERSION,
     _CARD_URL,
     _MANIFEST_VERSION,
     _REGISTERED_KEY,
-    _card_resource_version,
     async_register_card,
 )
 
@@ -91,7 +91,7 @@ async def test_register_card_updates_existing_resource(hass: HomeAssistant) -> N
 async def test_register_card_skips_update_when_url_matches(hass: HomeAssistant) -> None:
     with patch(f"{_FRONTEND_MODULE}._CARD_DIR", Path(__file__).parent):
         with patch(f"{_FRONTEND_MODULE}._CARD_FILENAME", "conftest.py"):
-            current_url = f"{_CARD_URL}?v={_card_resource_version()}"
+            current_url = f"{_CARD_URL}?v={_CARD_RESOURCE_VERSION}"
             resources = _mock_resources([{"id": "res1", "url": current_url}])
             _setup_hass_for_card(hass, resources)
 
@@ -151,3 +151,32 @@ async def test_register_card_loads_resources_when_not_loaded(hass: HomeAssistant
 
     resources.async_load.assert_awaited_once()
     resources.async_create_item.assert_awaited_once()
+
+
+def test_card_resource_version_precomputed_at_import() -> None:
+    """Verify the version string is pre-computed and contains a content hash."""
+    assert _CARD_RESOURCE_VERSION, "version string must not be empty"
+    assert _MANIFEST_VERSION in _CARD_RESOURCE_VERSION
+    parts = _CARD_RESOURCE_VERSION.split("-", 1)
+    assert len(parts) == 2, "version must be '{manifest_version}-{hash}'"
+    assert len(parts[1]) == 12, "hash suffix must be 12 hex chars"
+
+
+async def test_register_card_no_blocking_io(hass: HomeAssistant) -> None:
+    """Ensure async_register_card performs no file reads (all pre-computed)."""
+    resources = _mock_resources()
+    _setup_hass_for_card(hass, resources)
+
+    def _fail_read_text(*args: object, **kwargs: object) -> str:
+        raise AssertionError("read_text called inside async path")
+
+    def _fail_read_bytes(*args: object, **kwargs: object) -> bytes:
+        raise AssertionError("read_bytes called inside async path")
+
+    with patch(f"{_FRONTEND_MODULE}._CARD_DIR", Path(__file__).parent):
+        with patch(f"{_FRONTEND_MODULE}._CARD_FILENAME", "conftest.py"):
+            with patch.object(Path, "read_text", _fail_read_text):
+                with patch.object(Path, "read_bytes", _fail_read_bytes):
+                    await async_register_card(hass)
+
+    assert hass.data[_REGISTERED_KEY] is True


### PR DESCRIPTION
Move manifest version read and card hash computation to module-level constants evaluated at import time. This eliminates blocking file I/O inside the async event loop during card registration.

Closes #103