### PR TITLE
feat: standalone Sound & Light setup, identity keyed by speaker uid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 ### Added
 
 - **Standalone Sound & Light support** (#79): the integration no longer requires a camera on the account. Setup now creates whatever devices exist per baby, so a Sound & Light Machine works on its own, alongside a camera, or on an account mixing both. A failed camera no longer blocks a working speaker (and the other way round); setup only fails when nothing on the account could start.
+- **Devices for hardware no longer on the account can now be deleted** from the device page. Deleting a speaker also clears it from the persisted speaker map, so it stays gone (the map otherwise deliberately shields speakers from transient API omissions).
 - Protobuf schema (`sound_light.proto`) with generated code and a CI drift check, replacing the hand-rolled S&L wire parser.
 - `websockets` (>= 13) as an integration requirement, used by the S&L transport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,14 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 
 ### Added
 
+- **Standalone Sound & Light support** (#79): the integration no longer requires a camera on the account. Setup now creates whatever devices exist per baby, so a Sound & Light Machine works on its own, alongside a camera, or on an account mixing both. A failed camera no longer blocks a working speaker (and the other way round); setup only fails when nothing on the account could start.
 - Protobuf schema (`sound_light.proto`) with generated code and a CI drift check, replacing the hand-rolled S&L wire parser.
 - `websockets` (>= 13) as an integration requirement, used by the S&L transport.
+
+### Changed (S&L identity)
+
+- **S&L entities and the S&L device are now identified by the speaker's own uid** instead of the paired camera's. Existing installs migrate automatically on first start: every entity keeps its entity id and history, and the S&L device keeps its name and area. The device is linked to the camera (via_device) only when the baby actually has one.
+- The options flow now selects by baby rather than by camera, shows only the IP fields for devices the baby has, and stores manual speaker IPs keyed by the speaker's uid (existing entries are re-keyed automatically).
 
 ### Fixed
 

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -171,13 +171,10 @@ async def _async_migrate_sl_identities(
     entity_id and history. Once migrated (or on a fresh install) nothing
     here matches and the function is a no-op.
     """
-    pairs: list[tuple[str, str]] = []
-    for baby in hub.babies:
-        speaker_uid = hub.speaker_uid_map.get(baby.uid)
-        if baby.camera_uid and speaker_uid:
-            pairs.append((baby.camera_uid, speaker_uid))
-    if not pairs:
-        return
+    # Pairings come from the hub's combined view (live babies plus the
+    # legacy camera-keyed persisted map), so a pairing whose camera has
+    # since left the account still migrates instead of being swept away.
+    pairs: list[tuple[str, str]] = list(hub.camera_speaker_pairs.items())
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
@@ -186,25 +183,30 @@ async def _async_migrate_sl_identities(
         old_ids = {
             f"{camera_uid}_{suffix}": f"{speaker_uid}_{suffix}" for suffix in _SL_UNIQUE_ID_SUFFIXES
         }
+        collided: list[str] = []
 
         def _migrate_unique_id(
             entity_entry: er.RegistryEntry,
             old_ids: dict[str, str] = old_ids,
+            collided: list[str] = collided,
         ) -> dict[str, Any] | None:
             new_unique_id = old_ids.get(entity_entry.unique_id)
             if new_unique_id is None:
                 return None
             if ent_reg.async_get_entity_id(entity_entry.domain, DOMAIN, new_unique_id):
-                LOGGER.warning(
-                    "Cannot migrate %s to unique_id %s: already taken",
-                    entity_entry.entity_id,
-                    new_unique_id,
-                )
+                collided.append(entity_entry.entity_id)
                 return None
             LOGGER.info("Migrating %s unique_id to %s", entity_entry.entity_id, new_unique_id)
             return {"new_unique_id": new_unique_id}
 
         await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+
+        # An old entity whose target unique_id was already taken can never
+        # be served again (platforms only create speaker-keyed entities),
+        # so drop it rather than leaving a dead registry row forever.
+        for entity_id in collided:
+            LOGGER.warning("Removing %s: its migrated unique_id is already taken", entity_id)
+            ent_reg.async_remove(entity_id)
 
         old_device = dev_reg.async_get_device(identifiers={(DOMAIN, f"{camera_uid}_sound_light")})
         if old_device is not None:
@@ -224,16 +226,35 @@ async def _async_migrate_sl_identities(
 
     # Re-key manual speaker IPs from camera_uid to speaker_uid. Runs before
     # the options update listener is registered, so this does not reload.
+    # Legacy entries are translated first and a directly speaker-keyed
+    # entry wins over a translated legacy one, deterministically.
     speaker_ips: dict[str, str] = dict(entry.options.get(CONF_SPEAKER_IPS, {}))
-    if speaker_ips:
+    if speaker_ips and pairs:
         cam_to_speaker = dict(pairs)
-        migrated_ips = {cam_to_speaker.get(key, key): ip for key, ip in speaker_ips.items()}
+        migrated_ips: dict[str, str] = {}
+        for key, ip in speaker_ips.items():
+            if key in cam_to_speaker:
+                migrated_ips.setdefault(cam_to_speaker[key], ip)
+        for key, ip in speaker_ips.items():
+            if key not in cam_to_speaker:
+                migrated_ips[key] = ip
         if migrated_ips != speaker_ips:
             hass.config_entries.async_update_entry(
                 entry,
                 options={**entry.options, CONF_SPEAKER_IPS: migrated_ips},
             )
             LOGGER.info("Re-keyed speaker IP options by speaker_uid")
+
+    # Persist the resolved speaker map only now, after the migration has
+    # consumed the legacy camera-keyed shape. Persisting earlier would
+    # destroy the pairing a crashed or interrupted first boot still needs.
+    stored_map = entry.data.get("speaker_uid_map", {})
+    if hub.speaker_uid_map and hub.speaker_uid_map != stored_map:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, "speaker_uid_map": hub.speaker_uid_map},
+        )
+        LOGGER.debug("Persisted speaker UID map for %d speaker(s)", len(hub.speaker_uid_map))
 
 
 def _async_remove_stale_devices(
@@ -250,12 +271,23 @@ def _async_remove_stale_devices(
     known_camera_uids = {baby.camera_uid for baby in hub.babies if baby.camera_uid}
 
     # Build the set of valid device identifiers: raw camera UIDs, speaker
-    # UIDs, and legacy S&L identifiers ("{camera_uid}_sound_light") so a
-    # not-yet-migrated S&L device is never treated as stale.
+    # UIDs (live-resolved AND persisted, so a transient resolution failure
+    # can't sweep a healthy speaker), and every legacy S&L identifier
+    # ("{camera_uid}_sound_light") derivable from current cameras or known
+    # pairings, so a not-yet-migrated S&L device is never treated as stale.
     valid_uids = set(known_camera_uids)
-    for uid in known_camera_uids:
+    for uid in known_camera_uids | set(hub.camera_speaker_pairs):
         valid_uids.add(f"{uid}_sound_light")
     valid_uids.update(hub.speaker_uid_map.values())
+    valid_uids.update(hub.camera_speaker_pairs.values())
+    stored_map = entry.data.get("speaker_uid_map", {})
+    if isinstance(stored_map, dict):
+        valid_uids.update(uid for uid in stored_map.values() if isinstance(uid, str))
+
+    # A resolution collapse (babies present but nothing recognized) means
+    # we cannot judge staleness at all this boot — don't remove anything.
+    if not valid_uids:
+        return
 
     for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
         device_uids = {
@@ -263,10 +295,54 @@ def _async_remove_stale_devices(
         }
         if device_uids and not device_uids & valid_uids:
             LOGGER.info(
-                "Removing stale device %s (camera no longer on account)",
+                "Removing stale device %s (no longer on account)",
                 device.name,
             )
-            device_reg.async_remove_device(device.id)
+            # Detach from this entry only; HA deletes the device when the
+            # last config entry releases it, so a device shared with a
+            # second Nanit account (hardware moved between accounts) is
+            # never yanked out from under the other entry.
+            device_reg.async_update_device(device.id, remove_config_entry_id=entry.entry_id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: NanitConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow deleting devices for hardware the account no longer reports.
+
+    Without this hook HA never shows the per-device Delete button, and a
+    speaker that was unpaired from the Nanit account lives forever: the
+    persisted speaker map deliberately re-adds speakers missing from a
+    single /babies response (transient omissions are common), so removal
+    needs an explicit user action. Deleting the device here also drops it
+    from the persisted map so the next reload doesn't resurrect it.
+    """
+    device_uids = {
+        identifier[1] for identifier in device_entry.identifiers if identifier[0] == DOMAIN
+    }
+    if not device_uids:
+        return False
+
+    data = getattr(entry, "runtime_data", None)
+    live_uids: set[str] = data.hub.live_device_uids if data is not None else set()
+    if device_uids & live_uids:
+        # Hardware the account still reports would be recreated on the
+        # next update anyway; disallow so the UI explains itself.
+        return False
+
+    stored_map = entry.data.get("speaker_uid_map", {})
+    if isinstance(stored_map, dict):
+        pruned = {k: v for k, v in stored_map.items() if v not in device_uids}
+        if pruned != stored_map:
+            hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, "speaker_uid_map": pruned},
+            )
+            LOGGER.info(
+                "Removed %s from the persisted speaker map (device deleted by user)",
+                device_uids,
+            )
+    return True
 
 
 _DEPRECATED_ENTITIES: list[tuple[str, str]] = [

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -22,12 +22,13 @@ from .const import (
     CONF_CAMERA_IP,
     CONF_CAMERA_IPS,
     CONF_CAMERA_UID,
+    CONF_SPEAKER_IPS,
     DOMAIN,
     LOGGER,
     PLATFORMS,
 )
 from .frontend import async_register_card
-from .hub import CameraData, NanitHub
+from .hub import CameraData, NanitHub, SpeakerData
 
 
 @dataclass
@@ -36,6 +37,7 @@ class NanitData:
 
     hub: NanitHub
     cameras: dict[str, CameraData]
+    speakers: dict[str, SpeakerData]
 
 
 type NanitConfigEntry = ConfigEntry[NanitData]
@@ -66,8 +68,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> boo
         await hub.async_close()
         raise
 
-    entry.runtime_data = NanitData(hub=hub, cameras=hub.camera_data)
+    entry.runtime_data = NanitData(hub=hub, cameras=hub.camera_data, speakers=hub.speaker_data)
 
+    await _async_migrate_sl_identities(hass, entry, hub)
     _async_remove_stale_devices(hass, entry, hub)
     _async_remove_deprecated_entities(hass, hub)
 
@@ -138,10 +141,105 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
+# Unique-id suffixes owned by Sound & Light entities. Used to migrate
+# exactly these from camera_uid-prefixed to speaker_uid-prefixed ids —
+# camera entities share the camera_uid prefix and must not be touched.
+_SL_UNIQUE_ID_SUFFIXES: tuple[str, ...] = (
+    "sl_temperature",
+    "sl_humidity",
+    "sl_connection_mode",
+    "sl_connectivity",
+    "sound_machine_switch",
+    "sl_sound_switch",
+    "sound_machine_volume",
+    "sound_machine_sound",
+    "sound_light_light",
+)
+
+
+async def _async_migrate_sl_identities(
+    hass: HomeAssistant, entry: NanitConfigEntry, hub: NanitHub
+) -> None:
+    """Move S&L registry identity from camera_uid to speaker_uid (idempotent).
+
+    S&L entities and the S&L device were historically keyed on the camera's
+    uid because setup required a camera. The speaker's own uid is the only
+    identity that always exists, so unique_ids, the device registry
+    identifier, and the speaker-IP option keys all move to it. Runs after
+    the hub has resolved the account's camera→speaker pairing and before
+    platforms register entities, so every migrated entity keeps its
+    entity_id and history. Once migrated (or on a fresh install) nothing
+    here matches and the function is a no-op.
+    """
+    pairs: list[tuple[str, str]] = []
+    for baby in hub.babies:
+        speaker_uid = hub.speaker_uid_map.get(baby.uid)
+        if baby.camera_uid and speaker_uid:
+            pairs.append((baby.camera_uid, speaker_uid))
+    if not pairs:
+        return
+
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    for camera_uid, speaker_uid in pairs:
+        old_ids = {
+            f"{camera_uid}_{suffix}": f"{speaker_uid}_{suffix}" for suffix in _SL_UNIQUE_ID_SUFFIXES
+        }
+
+        def _migrate_unique_id(
+            entity_entry: er.RegistryEntry,
+            old_ids: dict[str, str] = old_ids,
+        ) -> dict[str, Any] | None:
+            new_unique_id = old_ids.get(entity_entry.unique_id)
+            if new_unique_id is None:
+                return None
+            if ent_reg.async_get_entity_id(entity_entry.domain, DOMAIN, new_unique_id):
+                LOGGER.warning(
+                    "Cannot migrate %s to unique_id %s: already taken",
+                    entity_entry.entity_id,
+                    new_unique_id,
+                )
+                return None
+            LOGGER.info("Migrating %s unique_id to %s", entity_entry.entity_id, new_unique_id)
+            return {"new_unique_id": new_unique_id}
+
+        await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+
+        old_device = dev_reg.async_get_device(identifiers={(DOMAIN, f"{camera_uid}_sound_light")})
+        if old_device is not None:
+            if dev_reg.async_get_device(identifiers={(DOMAIN, speaker_uid)}) is None:
+                LOGGER.info(
+                    "Migrating S&L device identifier %s_sound_light to %s",
+                    camera_uid,
+                    speaker_uid,
+                )
+                dev_reg.async_update_device(old_device.id, new_identifiers={(DOMAIN, speaker_uid)})
+            else:
+                LOGGER.warning(
+                    "S&L device identifier %s already exists; leaving legacy device %s",
+                    speaker_uid,
+                    old_device.id,
+                )
+
+    # Re-key manual speaker IPs from camera_uid to speaker_uid. Runs before
+    # the options update listener is registered, so this does not reload.
+    speaker_ips: dict[str, str] = dict(entry.options.get(CONF_SPEAKER_IPS, {}))
+    if speaker_ips:
+        cam_to_speaker = dict(pairs)
+        migrated_ips = {cam_to_speaker.get(key, key): ip for key, ip in speaker_ips.items()}
+        if migrated_ips != speaker_ips:
+            hass.config_entries.async_update_entry(
+                entry,
+                options={**entry.options, CONF_SPEAKER_IPS: migrated_ips},
+            )
+            LOGGER.info("Re-keyed speaker IP options by speaker_uid")
+
+
 def _async_remove_stale_devices(
     hass: HomeAssistant, entry: NanitConfigEntry, hub: NanitHub
 ) -> None:
-    """Remove HA devices for cameras no longer on the Nanit account."""
+    """Remove HA devices for cameras/speakers no longer on the Nanit account."""
     # If the API returned no babies (transient outage, account propagation),
     # skip removal — otherwise we would wipe every device for the entry and
     # force the user to re-add them.
@@ -149,13 +247,15 @@ def _async_remove_stale_devices(
         return
 
     device_reg = dr.async_get(hass)
-    known_camera_uids = {baby.camera_uid for baby in hub.babies}
+    known_camera_uids = {baby.camera_uid for baby in hub.babies if baby.camera_uid}
 
-    # Build the set of valid device identifiers: raw camera UIDs and
-    # derived S&L identifiers ("{camera_uid}_sound_light").
+    # Build the set of valid device identifiers: raw camera UIDs, speaker
+    # UIDs, and legacy S&L identifiers ("{camera_uid}_sound_light") so a
+    # not-yet-migrated S&L device is never treated as stale.
     valid_uids = set(known_camera_uids)
     for uid in known_camera_uids:
         valid_uids.add(f"{uid}_sound_light")
+    valid_uids.update(hub.speaker_uid_map.values())
 
     for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
         device_uids = {
@@ -183,7 +283,7 @@ def _async_remove_deprecated_entities(hass: HomeAssistant, hub: NanitHub) -> Non
     users don't see stale "unavailable" entities.
     """
     ent_reg = er.async_get(hass)
-    camera_uids = {baby.camera_uid for baby in hub.babies}
+    camera_uids = {baby.camera_uid for baby in hub.babies if baby.camera_uid}
 
     for old_domain, key in _DEPRECATED_ENTITIES:
         for camera_uid in camera_uids:

--- a/custom_components/nanit/binary_sensor.py
+++ b/custom_components/nanit/binary_sensor.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit binary sensors for all cameras on the account."""
+    """Set up Nanit binary sensors for all devices on the account."""
     entities: list[BinarySensorEntity] = []
 
     for cam_data in entry.runtime_data.cameras.values():
@@ -90,10 +90,9 @@ async def async_setup_entry(
             for cloud_desc in CLOUD_BINARY_SENSORS:
                 entities.append(NanitCloudBinarySensor(cam_data.cloud_coordinator, cloud_desc))
 
-        # Sound & Light connectivity sensor (optional)
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            entities.append(NanitSLConnectivitySensor(sl_coordinator))
+    # Sound & Light connectivity sensor
+    for speaker_data in entry.runtime_data.speakers.values():
+        entities.append(NanitSLConnectivitySensor(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -197,8 +196,7 @@ class NanitSLConnectivitySensor(NanitSoundLightEntity, BinarySensorEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sl_connectivity"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sl_connectivity"
 
     @property
     def available(self) -> bool:

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -308,41 +308,52 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class NanitOptionsFlow(OptionsFlow):
-    """Handle Nanit options — configure camera IPs for local access.
+    """Handle Nanit options — configure device IPs for local access.
 
     Two-step flow:
-    1. Select which camera to configure (if multiple exist)
-    2. Enter or clear the camera IP for local connectivity
+    1. Select which baby's devices to configure (if multiple exist)
+    2. Enter or clear the camera / speaker IP for local connectivity
+
+    Selection is by baby (not camera) so speaker-only babies are
+    configurable too. Only the fields for devices the baby actually has
+    are shown, and speaker IPs are stored keyed by speaker_uid.
     """
 
     def __init__(self) -> None:
         """Initialize."""
-        self._selected_camera_uid: str = ""
+        self._selected_baby_uid: str = ""
+
+    def _selected_baby(self) -> Any:
+        """Return the Baby row for the current selection, or None."""
+        for baby in self.config_entry.runtime_data.hub.babies:
+            if baby.uid == self._selected_baby_uid:
+                return baby
+        return None
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Select which camera to configure."""
+        """Select which baby's devices to configure."""
         hub = self.config_entry.runtime_data.hub
         babies = hub.babies
 
         if not babies:
             return self.async_abort(reason="no_cameras")
 
-        # Single camera — skip selection, go straight to IP config
+        # Single baby — skip selection, go straight to IP config
         if len(babies) == 1:
-            self._selected_camera_uid = babies[0].camera_uid
+            self._selected_baby_uid = babies[0].uid
             return await self.async_step_camera_ip(user_input)
 
         if user_input is not None:
-            self._selected_camera_uid = user_input["camera"]
+            self._selected_baby_uid = user_input["device"]
             return await self.async_step_camera_ip()
 
-        camera_options = {baby.camera_uid: display_name(baby.name, baby.uid) for baby in babies}
+        device_options = {baby.uid: display_name(baby.name, baby.uid) for baby in babies}
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required("camera"): vol.In(camera_options),
+                    vol.Required("device"): vol.In(device_options),
                 }
             ),
         )
@@ -350,8 +361,15 @@ class NanitOptionsFlow(OptionsFlow):
     async def async_step_camera_ip(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Configure IP for the selected camera."""
+        """Configure IPs for the selected baby's devices."""
         errors: dict[str, str] = {}
+
+        hub = self.config_entry.runtime_data.hub
+        baby = self._selected_baby()
+        if baby is None:
+            return self.async_abort(reason="no_cameras")
+        camera_uid: str | None = baby.camera_uid or None
+        speaker_uid: str | None = hub.speaker_uid_map.get(baby.uid)
 
         if user_input is not None:
             camera_ip = user_input.get(CONF_CAMERA_IP, "").strip()
@@ -372,17 +390,23 @@ class NanitOptionsFlow(OptionsFlow):
             if not errors:
                 # Merge with existing camera IPs
                 current_ips = dict(self.config_entry.options.get(CONF_CAMERA_IPS, {}))
-                if camera_ip:
-                    current_ips[self._selected_camera_uid] = camera_ip
-                else:
-                    current_ips.pop(self._selected_camera_uid, None)
+                if camera_uid:
+                    if camera_ip:
+                        current_ips[camera_uid] = camera_ip
+                    else:
+                        current_ips.pop(camera_uid, None)
 
-                # Merge with existing speaker IPs
+                # Merge with existing speaker IPs, keyed by speaker_uid.
+                # Always drop the legacy camera_uid-keyed entry so a cleared
+                # IP can't be resurrected by the hub's legacy-read fallback.
                 current_speaker_ips = dict(self.config_entry.options.get(CONF_SPEAKER_IPS, {}))
-                if speaker_ip:
-                    current_speaker_ips[self._selected_camera_uid] = speaker_ip
-                else:
-                    current_speaker_ips.pop(self._selected_camera_uid, None)
+                if camera_uid:
+                    current_speaker_ips.pop(camera_uid, None)
+                if speaker_uid:
+                    if speaker_ip:
+                        current_speaker_ips[speaker_uid] = speaker_ip
+                    else:
+                        current_speaker_ips.pop(speaker_uid, None)
 
                 return self.async_create_entry(
                     title="",
@@ -392,34 +416,25 @@ class NanitOptionsFlow(OptionsFlow):
                     },
                 )
 
-        current_ip = self.config_entry.options.get(CONF_CAMERA_IPS, {}).get(
-            self._selected_camera_uid, ""
-        )
-        current_speaker_ip = self.config_entry.options.get(CONF_SPEAKER_IPS, {}).get(
-            self._selected_camera_uid, ""
+        current_ip = self.config_entry.options.get(CONF_CAMERA_IPS, {}).get(camera_uid or "", "")
+        stored_speaker_ips = self.config_entry.options.get(CONF_SPEAKER_IPS, {})
+        current_speaker_ip = stored_speaker_ips.get(speaker_uid or "") or stored_speaker_ips.get(
+            camera_uid or "", ""
         )
 
-        # Resolve camera name for the description placeholder
-        camera_name = self._selected_camera_uid
-        for baby in self.config_entry.runtime_data.hub.babies:
-            if baby.camera_uid == self._selected_camera_uid:
-                camera_name = display_name(baby.name, baby.uid)
-                break
+        schema_fields: dict[Any, Any] = {}
+        if camera_uid:
+            schema_fields[
+                vol.Optional(CONF_CAMERA_IP, description={"suggested_value": current_ip})
+            ] = cv.string
+        if speaker_uid:
+            schema_fields[
+                vol.Optional(CONF_SPEAKER_IP, description={"suggested_value": current_speaker_ip})
+            ] = cv.string
 
         return self.async_show_form(
             step_id="camera_ip",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_CAMERA_IP,
-                        description={"suggested_value": current_ip},
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_SPEAKER_IP,
-                        description={"suggested_value": current_speaker_ip},
-                    ): cv.string,
-                }
-            ),
-            description_placeholders={"camera_name": camera_name},
+            data_schema=vol.Schema(schema_fields),
+            description_placeholders={"camera_name": display_name(baby.name, baby.uid)},
             errors=errors,
         )

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -397,12 +397,15 @@ class NanitOptionsFlow(OptionsFlow):
                         current_ips.pop(camera_uid, None)
 
                 # Merge with existing speaker IPs, keyed by speaker_uid.
-                # Always drop the legacy camera_uid-keyed entry so a cleared
-                # IP can't be resurrected by the hub's legacy-read fallback.
+                # When the speaker is resolvable this session, also drop the
+                # legacy camera_uid-keyed entry so a cleared IP can't be
+                # resurrected by the hub's legacy-read fallback. When it
+                # isn't (no speaker field was shown), leave the legacy
+                # entry alone — the hub may still be using it.
                 current_speaker_ips = dict(self.config_entry.options.get(CONF_SPEAKER_IPS, {}))
-                if camera_uid:
-                    current_speaker_ips.pop(camera_uid, None)
                 if speaker_uid:
+                    if camera_uid:
+                        current_speaker_ips.pop(camera_uid, None)
                     if speaker_ip:
                         current_speaker_ips[speaker_uid] = speaker_ip
                     else:

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -368,8 +368,13 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         entry: NanitConfigEntry,
         sound_light: NanitSoundLight,
         baby: Baby,
+        via_camera_uid: str | None = None,
     ) -> None:
-        """Initialize the Sound & Light coordinator."""
+        """Initialize the Sound & Light coordinator.
+
+        via_camera_uid links the S&L device to the baby's camera device in
+        the registry; None when the baby has no camera (standalone speaker).
+        """
         super().__init__(
             hass,
             _LOGGER,
@@ -378,6 +383,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
         )
         self.sound_light = sound_light
         self.baby = baby
+        self.via_camera_uid = via_camera_uid
         self._unsubscribe: Callable[[], None] | None = None
         self._store: Store[dict[str, Any]] = Store(
             hass,

--- a/custom_components/nanit/diagnostics.py
+++ b/custom_components/nanit/diagnostics.py
@@ -58,9 +58,23 @@ async def async_get_config_entry_diagnostics(
 
         cameras_diag[camera_uid] = cam_diag
 
+    speakers_diag: dict[str, Any] = {}
+    for speaker_uid, speaker_data in entry.runtime_data.speakers.items():
+        coordinator = speaker_data.coordinator
+        speakers_diag[speaker_uid] = {
+            "baby_name": speaker_data.baby.name,
+            "baby_uid": speaker_data.baby.uid,
+            "connected": coordinator.connected,
+            "connection_mode": speaker_data.sound_light.connection_mode,
+            "last_update_success": coordinator.last_update_success,
+            "data": asdict(coordinator.data) if coordinator.data is not None else None,
+        }
+
     return {
         "config_entry_data": async_redact_data(dict(entry.data), TO_REDACT),
         "config_entry_options": async_redact_data(dict(entry.options), TO_REDACT),
         "camera_count": len(cameras_diag),
         "cameras": async_redact_data(cameras_diag, TO_REDACT),
+        "speaker_count": len(speakers_diag),
+        "speakers": async_redact_data(speakers_diag, TO_REDACT),
     }

--- a/custom_components/nanit/diagnostics.py
+++ b/custom_components/nanit/diagnostics.py
@@ -17,6 +17,7 @@ TO_REDACT = {
     "refresh_token",
     "mfa_token",
     "mfa_code",
+    "baby_name",
     "baby_uid",
     "camera_uid",
     "camera_ip",
@@ -32,9 +33,12 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: NanitConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
+    # Sections are keyed by index, not by device uid: async_redact_data
+    # redacts values under matching key names but never dict keys, so
+    # uid-keyed sections would leak the very uids TO_REDACT lists.
     cameras_diag: dict[str, Any] = {}
 
-    for camera_uid, cam_data in entry.runtime_data.cameras.items():
+    for index, cam_data in enumerate(entry.runtime_data.cameras.values()):
         push = cam_data.push_coordinator
         cloud = cam_data.cloud_coordinator
 
@@ -56,12 +60,12 @@ async def async_get_config_entry_diagnostics(
                 "data": ([asdict(e) for e in cloud.data] if cloud.data is not None else None),
             }
 
-        cameras_diag[camera_uid] = cam_diag
+        cameras_diag[f"camera_{index}"] = cam_diag
 
     speakers_diag: dict[str, Any] = {}
-    for speaker_uid, speaker_data in entry.runtime_data.speakers.items():
+    for index, speaker_data in enumerate(entry.runtime_data.speakers.values()):
         coordinator = speaker_data.coordinator
-        speakers_diag[speaker_uid] = {
+        speakers_diag[f"speaker_{index}"] = {
             "baby_name": speaker_data.baby.name,
             "baby_uid": speaker_data.baby.uid,
             "connected": coordinator.connected,

--- a/custom_components/nanit/entity.py
+++ b/custom_components/nanit/entity.py
@@ -65,15 +65,21 @@ class NanitSoundLightEntity(CoordinatorEntity[NanitSoundLightCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device info — separate device from the camera."""
+        """Return device info — its own device, keyed by the speaker's uid.
+
+        Linked to the baby's camera via via_device only when a camera
+        exists on the account (standalone speakers have none).
+        """
         baby = self.coordinator.baby
-        return DeviceInfo(
-            identifiers={(DOMAIN, f"{baby.camera_uid}_sound_light")},
+        info = DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.sound_light.speaker_uid)},
             name=f"{display_name(baby.name, baby.uid)} Sound & Light",
             manufacturer="Nanit",
             model="Sound & Light Machine",
-            via_device=(DOMAIN, baby.camera_uid),
         )
+        if self.coordinator.via_camera_uid:
+            info["via_device"] = (DOMAIN, self.coordinator.via_camera_uid)
+        return info
 
     @property
     def available(self) -> bool:

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -53,6 +54,22 @@ _CAMERA_SETUP_TIMEOUT: float = 60.0
 # transports are launched (connects continue in the background), so this
 # is a safety net rather than an expected wait.
 _SPEAKER_SETUP_TIMEOUT: float = 60.0
+
+# Timeout for the raw /babies fetches (matches aionanit's own request
+# timeout; without it the shared HA session's 5 minute default applies).
+_RAW_FETCH_TIMEOUT = aiohttp.ClientTimeout(total=15)
+
+# Device uids are used as registry identifiers, storage keys, and URL
+# components, so values from the API (or persisted from it) must look like
+# uids before they're trusted. Real ones are short alphanumerics.
+_UID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def _clean_uid(value: Any) -> str | None:
+    """Return the value when it looks like a device uid, else None."""
+    if isinstance(value, str) and _UID_RE.fullmatch(value):
+        return value
+    return None
 
 
 @dataclass
@@ -101,6 +118,8 @@ class NanitHub:
         self._babies: list[Baby] = []
         self._failed_camera_uids: set[str] = set()
         self._speaker_uid_map: dict[str, str] = {}
+        self._camera_speaker_pairs: dict[str, str] = {}
+        self._live_speaker_uids: set[str] = set()
         self._sound_lights: dict[str, NanitSoundLight] = {}
         self._unsubscribe_tokens: Callable[[], None] | None = None
 
@@ -134,6 +153,28 @@ class NanitHub:
         """Return the resolved baby_uid → speaker_uid map."""
         return self._speaker_uid_map
 
+    @property
+    def camera_speaker_pairs(self) -> dict[str, str]:
+        """Return every known camera_uid → speaker_uid pairing.
+
+        Sourced from live babies that carry both devices AND from the
+        legacy camera-keyed persisted map, so the identity migration can
+        still translate a pairing whose camera has since left the account.
+        """
+        return self._camera_speaker_pairs
+
+    @property
+    def live_device_uids(self) -> set[str]:
+        """Return uids of devices the account currently reports.
+
+        Camera uids plus speaker uids taken from the live /babies rows
+        only (not the persisted fallback map), for deciding whether a
+        registry device may be deleted by the user.
+        """
+        live = {baby.camera_uid for baby in self._babies if baby.camera_uid}
+        live |= self._live_speaker_uids
+        return live
+
     async def async_setup(self) -> None:
         """Restore tokens, discover devices, create coordinators for each.
 
@@ -166,16 +207,9 @@ class NanitHub:
 
         speaker_uid_map = await self._async_resolve_speaker_uids(babies)
         self._speaker_uid_map = speaker_uid_map
-
-        # Persist the resolved speaker UIDs so they survive restarts even if
-        # a later /babies response omits them.
-        stored_map = self._entry.data.get("speaker_uid_map", {})
-        if speaker_uid_map and speaker_uid_map != stored_map:
-            self._hass.config_entries.async_update_entry(
-                self._entry,
-                data={**self._entry.data, "speaker_uid_map": speaker_uid_map},
-            )
-            _LOGGER.debug("Persisted speaker UID map for %d camera(s)", len(speaker_uid_map))
+        # NOTE: the resolved map is persisted by the identity migration in
+        # __init__.py, not here — persisting it early would overwrite the
+        # legacy camera-keyed map before the migration has used it.
 
         # Per-device IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
@@ -210,8 +244,13 @@ class NanitHub:
                 owners.append(("speaker", baby))
 
         if not tasks:
-            _LOGGER.warning("No cameras or Sound & Light Machines found on Nanit account")
-            return
+            # Babies exist but nothing could even be attempted (no cameras
+            # and speaker resolution came up empty). Raise so HA retries —
+            # returning here would leave a loaded entry with zero devices
+            # and no recovery path short of a manual reload.
+            raise NanitConnectionError(
+                "No cameras or Sound & Light Machines found on Nanit account"
+            )
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -274,6 +313,14 @@ class NanitHub:
                 f"No devices could be set up: {', '.join(failed_cameras + failed_speakers)}"
             )
 
+        # via_device must point at a camera device that actually registered
+        # this run. The speaker tasks ran concurrently with the camera
+        # tasks, so the link is settled only now.
+        for speaker_data in self._speaker_data.values():
+            coordinator = speaker_data.coordinator
+            if coordinator.via_camera_uid and coordinator.via_camera_uid not in self._camera_data:
+                coordinator.via_camera_uid = None
+
         if failed_cameras:
             _LOGGER.warning(
                 "Some cameras failed to connect: %s. They will be retried on next reload.",
@@ -300,7 +347,13 @@ class NanitHub:
             return await self._async_get_babies_raw()
 
     async def _async_get_babies_raw(self) -> list[Baby]:
-        """Parse /babies directly, allowing camera-less babies."""
+        """Parse /babies directly, allowing camera-less babies.
+
+        Defensive on shape and content: uids are validated before they can
+        reach registry identifiers, storage keys, or URLs, and a malformed
+        row is skipped rather than failing the whole scan. Transport-level
+        failures surface as NanitConnectionError so setup retries.
+        """
         from aionanit.rest import (
             NANIT_API_HEADERS,
             _parse_camera_connected,
@@ -315,29 +368,45 @@ class NanitHub:
         access_token = await tm.async_get_access_token()
         rest = self._client.rest_client
         try:
-            resp = await rest.session.get(
+            async with rest.session.get(
                 f"{rest.base_url}/babies",
                 headers={**NANIT_API_HEADERS, "Authorization": access_token},
-            )
+                timeout=_RAW_FETCH_TIMEOUT,
+            ) as resp:
+                if resp.status == 401:
+                    raise NanitAuthError("Access token invalid")
+                resp.raise_for_status()
+                body = await resp.json()
         except aiohttp.ClientError as err:
             raise NanitConnectionError(str(err)) from err
-        if resp.status == 401:
-            raise NanitAuthError("Access token invalid")
-        resp.raise_for_status()
-        body = await resp.json()
 
-        return [
-            Baby(
-                uid=baby["uid"],
-                name=_sanitize_name(baby.get("name")),
-                camera_uid=baby.get("camera_uid") or "",
-                speaker_uid=((baby.get("speaker") or {}).get("speaker") or {}).get("uid"),
-                network=_parse_network(baby),
-                camera_connected=_parse_camera_connected(baby),
-                camera_last_seen=_parse_camera_last_seen(baby),
+        rows = body.get("babies", []) if isinstance(body, dict) else []
+        babies: list[Baby] = []
+        for baby in rows if isinstance(rows, list) else []:
+            if not isinstance(baby, dict):
+                continue
+            uid = _clean_uid(baby.get("uid"))
+            if uid is None:
+                _LOGGER.debug("Skipping /babies row without a usable uid")
+                continue
+            raw_name = baby.get("name")
+            speaker = baby.get("speaker")
+            speaker_obj = speaker.get("speaker") if isinstance(speaker, dict) else None
+            speaker_uid = (
+                _clean_uid(speaker_obj.get("uid")) if isinstance(speaker_obj, dict) else None
             )
-            for baby in body.get("babies", [])
-        ]
+            babies.append(
+                Baby(
+                    uid=uid,
+                    name=_sanitize_name(raw_name if isinstance(raw_name, str) else None),
+                    camera_uid=_clean_uid(baby.get("camera_uid")) or "",
+                    speaker_uid=speaker_uid,
+                    network=_parse_network(baby),
+                    camera_connected=_parse_camera_connected(baby),
+                    camera_last_seen=_parse_camera_last_seen(baby),
+                )
+            )
+        return babies
 
     async def _async_resolve_speaker_uids(self, babies: list[Baby]) -> dict[str, str]:
         """Resolve each baby's speaker uid, keyed by baby uid.
@@ -346,14 +415,30 @@ class NanitHub:
         map persisted from an earlier run (also accepts the legacy
         camera_uid-keyed shape), then the raw /babies API as final fallback
         for an installed aionanit that predates the speaker_uid field.
+
+        Side effects: records the live speaker uids (for the device
+        removal hook) and every known camera→speaker pairing including
+        legacy persisted ones (for the identity migration, which must be
+        able to translate a pairing whose camera has left the account).
         """
         speaker_uid_map: dict[str, str] = {}
+        self._live_speaker_uids = set()
+        self._camera_speaker_pairs = {}
         for baby in babies:
-            uid = getattr(baby, "speaker_uid", None)
+            uid = _clean_uid(getattr(baby, "speaker_uid", None))
             if uid:
                 speaker_uid_map[baby.uid] = uid
+                self._live_speaker_uids.add(uid)
+                if baby.camera_uid:
+                    self._camera_speaker_pairs[baby.camera_uid] = uid
 
-        stored: dict[str, str] = dict(self._entry.data.get("speaker_uid_map", {}))
+        stored_raw = self._entry.data.get("speaker_uid_map", {})
+        stored: dict[str, str] = {}
+        if isinstance(stored_raw, dict):
+            for key, value in stored_raw.items():
+                clean_key, clean_value = _clean_uid(key), _clean_uid(value)
+                if clean_key and clean_value:
+                    stored[clean_key] = clean_value
         if stored:
             baby_uids = {baby.uid for baby in babies}
             by_camera = {baby.camera_uid: baby.uid for baby in babies if baby.camera_uid}
@@ -362,12 +447,20 @@ class NanitHub:
                     speaker_uid_map.setdefault(key, uid)
                 elif key in by_camera:
                     speaker_uid_map.setdefault(by_camera[key], uid)
+                    self._camera_speaker_pairs.setdefault(key, uid)
+                else:
+                    # Legacy camera-keyed entry whose camera is no longer on
+                    # the account: unusable for setup, still needed by the
+                    # identity migration to rename the old registry rows.
+                    self._camera_speaker_pairs.setdefault(key, uid)
 
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
             except Exception:
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+            else:
+                self._live_speaker_uids |= set(speaker_uid_map.values())
 
         return speaker_uid_map
 
@@ -516,16 +609,22 @@ class NanitHub:
         async with rest.session.get(
             f"{rest.base_url}/babies",
             headers={"Authorization": access_token},
+            timeout=_RAW_FETCH_TIMEOUT,
         ) as resp:
             resp.raise_for_status()
             body = await resp.json()
 
         result: dict[str, str] = {}
-        for baby in body.get("babies", []):
-            baby_uid = baby.get("uid")
-            speaker_data = baby.get("speaker", {})
-            speaker_obj = speaker_data.get("speaker", {})
-            speaker_uid = speaker_obj.get("uid")
+        rows = body.get("babies", []) if isinstance(body, dict) else []
+        for baby in rows if isinstance(rows, list) else []:
+            if not isinstance(baby, dict):
+                continue
+            baby_uid = _clean_uid(baby.get("uid"))
+            speaker_data = baby.get("speaker")
+            speaker_obj = speaker_data.get("speaker") if isinstance(speaker_data, dict) else None
+            speaker_uid = (
+                _clean_uid(speaker_obj.get("uid")) if isinstance(speaker_obj, dict) else None
+            )
             if baby_uid and speaker_uid:
                 result[baby_uid] = speaker_uid
                 _LOGGER.debug("Discovered speaker UID %s for baby %s", speaker_uid, baby_uid)

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -1,16 +1,18 @@
 """Hub for the Nanit integration — owns NanitClient lifecycle.
 
 One hub per config entry (one Nanit account). The hub discovers all
-babies/cameras on the account and creates a camera + coordinators for each.
+devices on the account (cameras and Sound & Light Machines) and creates
+coordinators for each. A baby can have a camera, a speaker, or both —
+setup handles every combination, including speaker-only accounts.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from homeassistant.const import CONF_ACCESS_TOKEN
@@ -47,6 +49,11 @@ _LOGGER = logging.getLogger(__name__)
 # that is powered off) from blocking the entire integration indefinitely.
 _CAMERA_SETUP_TIMEOUT: float = 60.0
 
+# Same idea for a Sound & Light Machine. Its async_start returns once the
+# transports are launched (connects continue in the background), so this
+# is a safety net rather than an expected wait.
+_SPEAKER_SETUP_TIMEOUT: float = 60.0
+
 
 @dataclass
 class CameraData:
@@ -56,15 +63,25 @@ class CameraData:
     baby: Baby
     push_coordinator: NanitPushCoordinator
     cloud_coordinator: NanitCloudCoordinator | None
-    sound_light_coordinator: NanitSoundLightCoordinator | None = None
     network_coordinator: NanitNetworkCoordinator | None = None
 
 
+@dataclass
+class SpeakerData:
+    """Runtime data for a single Sound & Light Machine within the account."""
+
+    sound_light: NanitSoundLight
+    baby: Baby
+    speaker_uid: str
+    coordinator: NanitSoundLightCoordinator
+
+
 class NanitHub:
-    """Manages the NanitClient, token persistence, and all camera instances.
+    """Manages the NanitClient, token persistence, and all device instances.
 
     One hub per config entry (one Nanit account). Discovers all
-    babies/cameras on the account and creates coordinators for each.
+    babies on the account and creates coordinators for each camera
+    and each Sound & Light Machine.
     """
 
     def __init__(
@@ -80,8 +97,10 @@ class NanitHub:
         self._entry = entry
         self._client = NanitClient(session)
         self._camera_data: dict[str, CameraData] = {}
+        self._speaker_data: dict[str, SpeakerData] = {}
         self._babies: list[Baby] = []
         self._failed_camera_uids: set[str] = set()
+        self._speaker_uid_map: dict[str, str] = {}
         self._sound_lights: dict[str, NanitSoundLight] = {}
         self._unsubscribe_tokens: Callable[[], None] | None = None
 
@@ -96,6 +115,11 @@ class NanitHub:
         return self._camera_data
 
     @property
+    def speaker_data(self) -> dict[str, SpeakerData]:
+        """Return per-speaker runtime data, keyed by speaker_uid."""
+        return self._speaker_data
+
+    @property
     def babies(self) -> list[Baby]:
         """Return all discovered babies (including ones that failed to connect)."""
         return self._babies
@@ -105,12 +129,20 @@ class NanitHub:
         """Return UIDs of cameras that failed to connect during setup."""
         return self._failed_camera_uids
 
+    @property
+    def speaker_uid_map(self) -> dict[str, str]:
+        """Return the resolved baby_uid → speaker_uid map."""
+        return self._speaker_uid_map
+
     async def async_setup(self) -> None:
-        """Restore tokens, discover babies, create cameras and coordinators.
+        """Restore tokens, discover devices, create coordinators for each.
+
+        Sets up whatever devices exist on the account: camera only,
+        Sound & Light only, or both per baby.
 
         Raises:
             NanitAuthError: If tokens are invalid (triggers reauth).
-            NanitConnectionError: If ALL cameras fail to connect.
+            NanitConnectionError: If no device on the account could be set up.
 
         """
         # Restore tokens from persisted config entry data
@@ -124,29 +156,19 @@ class NanitHub:
             self._unsubscribe_tokens = tm.on_tokens_refreshed(self._on_tokens_refreshed)
 
         # Fetch babies (also validates tokens)
-        babies = await self._client.async_get_babies()
+        babies = await self._async_get_babies_tolerant()
 
         self._babies = list(babies)
 
         if not babies:
-            _LOGGER.warning("No babies/cameras found on Nanit account")
+            _LOGGER.warning("No babies found on Nanit account")
             return
 
-        # Discover speaker UIDs — try persisted data first, then aionanit,
-        # then raw /babies API as final fallback.
-        speaker_uid_map: dict[str, str] = dict(self._entry.data.get("speaker_uid_map", {}))
-        if not speaker_uid_map:
-            for baby in babies:
-                uid = getattr(baby, "speaker_uid", None)
-                if uid:
-                    speaker_uid_map[baby.camera_uid] = uid
-        if not speaker_uid_map:
-            try:
-                speaker_uid_map = await self._discover_speaker_uids()
-            except Exception:
-                _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+        speaker_uid_map = await self._async_resolve_speaker_uids(babies)
+        self._speaker_uid_map = speaker_uid_map
 
-        # Persist discovered speaker UIDs so they survive restarts
+        # Persist the resolved speaker UIDs so they survive restarts even if
+        # a later /babies response omits them.
         stored_map = self._entry.data.get("speaker_uid_map", {})
         if speaker_uid_map and speaker_uid_map != stored_map:
             self._hass.config_entries.async_update_entry(
@@ -155,67 +177,101 @@ class NanitHub:
             )
             _LOGGER.debug("Persisted speaker UID map for %d camera(s)", len(speaker_uid_map))
 
-        # Per-camera IP configuration from options
+        # Per-device IP configuration from options
         camera_ips: dict[str, str] = self._entry.options.get(CONF_CAMERA_IPS, {})
         speaker_ips: dict[str, str] = self._entry.options.get(CONF_SPEAKER_IPS, {})
 
-        # Create camera + coordinators for each baby
-        failed_cameras: list[str] = []
-        tasks = [
-            asyncio.wait_for(
-                self._setup_camera(
-                    baby,
-                    camera_ips.get(baby.camera_uid),
-                    speaker_ips.get(baby.camera_uid),
-                    speaker_uid_map.get(baby.camera_uid),
-                ),
-                timeout=_CAMERA_SETUP_TIMEOUT,
-            )
-            for baby in babies
-        ]
+        # Create coordinators for every device on the account
+        tasks: list[Coroutine[Any, Any, None]] = []
+        owners: list[tuple[str, Baby]] = []
+        for baby in babies:
+            if baby.camera_uid:
+                tasks.append(
+                    asyncio.wait_for(
+                        self._setup_camera(baby, camera_ips.get(baby.camera_uid)),
+                        timeout=_CAMERA_SETUP_TIMEOUT,
+                    )
+                )
+                owners.append(("camera", baby))
+            speaker_uid = speaker_uid_map.get(baby.uid)
+            if speaker_uid:
+                # Manual speaker IP, keyed by speaker_uid (legacy entries were
+                # keyed by camera_uid; the setup-time migration re-keys them,
+                # this fallback covers the first boot after upgrade).
+                speaker_ip = speaker_ips.get(speaker_uid)
+                if speaker_ip is None and baby.camera_uid:
+                    speaker_ip = speaker_ips.get(baby.camera_uid)
+                tasks.append(
+                    asyncio.wait_for(
+                        self._setup_speaker(baby, speaker_uid, speaker_ip),
+                        timeout=_SPEAKER_SETUP_TIMEOUT,
+                    )
+                )
+                owners.append(("speaker", baby))
+
+        if not tasks:
+            _LOGGER.warning("No cameras or Sound & Light Machines found on Nanit account")
+            return
+
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        for baby, result in zip(babies, results, strict=True):
+        failed_cameras: list[str] = []
+        failed_speakers: list[str] = []
+        for (kind, baby), result in zip(owners, results, strict=True):
             if isinstance(result, NanitAuthError):
                 raise result
-            if isinstance(result, NanitConnectionError | NanitCameraUnavailable | TimeoutError):
-                # getattr: published aionanit 1.8.7 wheels predate camera_connected.
-                cloud_connected = getattr(baby, "camera_connected", None)
-                cloud_status = (
-                    "cloud reports connected=True (transient failure?)"
-                    if cloud_connected is True
-                    else "cloud reports connected=False (camera offline)"
-                    if cloud_connected is False
-                    else "cloud connected status unknown"
-                )
+            if kind == "camera":
+                if isinstance(result, NanitConnectionError | NanitCameraUnavailable | TimeoutError):
+                    # getattr: published aionanit 1.8.7 wheels predate camera_connected.
+                    cloud_connected = getattr(baby, "camera_connected", None)
+                    cloud_status = (
+                        "cloud reports connected=True (transient failure?)"
+                        if cloud_connected is True
+                        else "cloud reports connected=False (camera offline)"
+                        if cloud_connected is False
+                        else "cloud connected status unknown"
+                    )
+                    _LOGGER.warning(
+                        "Camera %s (%s) failed to connect: %s — %s",
+                        baby.name,
+                        baby.camera_uid,
+                        result,
+                        cloud_status,
+                    )
+                    failed_cameras.append(display_name(baby.name, baby.uid))
+                    self._failed_camera_uids.add(baby.camera_uid)
+                    ir.async_create_issue(
+                        self._hass,
+                        DOMAIN,
+                        f"camera_connection_failed_{baby.camera_uid}",
+                        is_fixable=False,
+                        is_persistent=False,
+                        severity=ir.IssueSeverity.WARNING,
+                        translation_key="camera_connection_failed",
+                        translation_placeholders={
+                            "camera_name": display_name(baby.name, baby.uid),
+                            "error": str(result),
+                        },
+                    )
+                elif isinstance(result, BaseException):
+                    raise result
+            elif isinstance(result, Exception):
+                # Speaker failures are non-fatal on their own: the S&L
+                # transport keeps reconnecting in the background, and a
+                # camera on the same account should not be blocked by it.
                 _LOGGER.warning(
-                    "Camera %s (%s) failed to connect: %s — %s",
+                    "Sound & Light Machine for %s failed to start; "
+                    "sound/light entities disabled: %s",
                     baby.name,
-                    baby.camera_uid,
                     result,
-                    cloud_status,
                 )
-                failed_cameras.append(display_name(baby.name, baby.uid))
-                self._failed_camera_uids.add(baby.camera_uid)
-                ir.async_create_issue(
-                    self._hass,
-                    DOMAIN,
-                    f"camera_connection_failed_{baby.camera_uid}",
-                    is_fixable=False,
-                    is_persistent=False,
-                    severity=ir.IssueSeverity.WARNING,
-                    translation_key="camera_connection_failed",
-                    translation_placeholders={
-                        "camera_name": display_name(baby.name, baby.uid),
-                        "error": str(result),
-                    },
-                )
+                failed_speakers.append(display_name(baby.name, baby.uid))
             elif isinstance(result, BaseException):
                 raise result
 
-        if not self._camera_data and failed_cameras:
+        if not self._camera_data and not self._speaker_data:
             raise NanitConnectionError(
-                f"All cameras failed to connect: {', '.join(failed_cameras)}"
+                f"No devices could be set up: {', '.join(failed_cameras + failed_speakers)}"
             )
 
         if failed_cameras:
@@ -224,12 +280,101 @@ class NanitHub:
                 ", ".join(failed_cameras),
             )
 
+    async def _async_get_babies_tolerant(self) -> list[Baby]:
+        """Fetch babies, tolerating rows without a camera.
+
+        aionanit's Baby model requires camera_uid and its parser raises
+        KeyError on an account whose baby has no camera paired. Until the
+        library makes the field optional, fall back to parsing the raw
+        /babies response with camera_uid defaulted to "" (treated as
+        "no camera" throughout the hub).
+        """
+        try:
+            return await self._client.async_get_babies()
+        except KeyError:
+            _LOGGER.debug(
+                "aionanit could not parse /babies (baby without camera?); "
+                "falling back to raw parse",
+                exc_info=True,
+            )
+            return await self._async_get_babies_raw()
+
+    async def _async_get_babies_raw(self) -> list[Baby]:
+        """Parse /babies directly, allowing camera-less babies."""
+        from aionanit.rest import (
+            NANIT_API_HEADERS,
+            _parse_camera_connected,
+            _parse_camera_last_seen,
+            _parse_network,
+            _sanitize_name,
+        )
+
+        tm = self._client.token_manager
+        if tm is None:
+            raise NanitAuthError("Not authenticated — call async_login first")
+        access_token = await tm.async_get_access_token()
+        rest = self._client.rest_client
+        try:
+            resp = await rest.session.get(
+                f"{rest.base_url}/babies",
+                headers={**NANIT_API_HEADERS, "Authorization": access_token},
+            )
+        except aiohttp.ClientError as err:
+            raise NanitConnectionError(str(err)) from err
+        if resp.status == 401:
+            raise NanitAuthError("Access token invalid")
+        resp.raise_for_status()
+        body = await resp.json()
+
+        return [
+            Baby(
+                uid=baby["uid"],
+                name=_sanitize_name(baby.get("name")),
+                camera_uid=baby.get("camera_uid") or "",
+                speaker_uid=((baby.get("speaker") or {}).get("speaker") or {}).get("uid"),
+                network=_parse_network(baby),
+                camera_connected=_parse_camera_connected(baby),
+                camera_last_seen=_parse_camera_last_seen(baby),
+            )
+            for baby in body.get("babies", [])
+        ]
+
+    async def _async_resolve_speaker_uids(self, babies: list[Baby]) -> dict[str, str]:
+        """Resolve each baby's speaker uid, keyed by baby uid.
+
+        Sources, in order: the live /babies response (authoritative), the
+        map persisted from an earlier run (also accepts the legacy
+        camera_uid-keyed shape), then the raw /babies API as final fallback
+        for an installed aionanit that predates the speaker_uid field.
+        """
+        speaker_uid_map: dict[str, str] = {}
+        for baby in babies:
+            uid = getattr(baby, "speaker_uid", None)
+            if uid:
+                speaker_uid_map[baby.uid] = uid
+
+        stored: dict[str, str] = dict(self._entry.data.get("speaker_uid_map", {}))
+        if stored:
+            baby_uids = {baby.uid for baby in babies}
+            by_camera = {baby.camera_uid: baby.uid for baby in babies if baby.camera_uid}
+            for key, uid in stored.items():
+                if key in baby_uids:
+                    speaker_uid_map.setdefault(key, uid)
+                elif key in by_camera:
+                    speaker_uid_map.setdefault(by_camera[key], uid)
+
+        if not speaker_uid_map:
+            try:
+                speaker_uid_map = await self._discover_speaker_uids()
+            except Exception:
+                _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
+
+        return speaker_uid_map
+
     async def _setup_camera(
         self,
         baby: Baby,
         camera_ip: str | None,
-        speaker_ip: str | None,
-        speaker_uid: str | None = None,
     ) -> None:
         """Create a camera instance and its coordinators for a single baby."""
         camera = self._client.camera(
@@ -255,35 +400,6 @@ class NanitHub:
             )
             cloud_coordinator = None
 
-        # Sound & Light Machine coordinator (optional — local WebSocket push)
-        sound_light_coordinator: NanitSoundLightCoordinator | None = None
-        # Use speaker_uid passed from the discovery map; fall back to Baby attr
-        if not speaker_uid:
-            speaker_uid = getattr(baby, "speaker_uid", None)
-
-        if speaker_uid:
-            try:
-                sound_light = self.get_sound_light(speaker_uid, speaker_ip)
-                sound_light_coordinator = NanitSoundLightCoordinator(
-                    self._hass, self._entry, sound_light, baby
-                )
-                await sound_light_coordinator.async_setup()
-            except NanitAuthError:
-                raise
-            except Exception:
-                _LOGGER.warning(
-                    "Sound & Light Machine coordinator for %s failed to start; "
-                    "sound/light entities disabled",
-                    baby.name,
-                    exc_info=True,
-                )
-                sound_light_coordinator = None
-        else:
-            _LOGGER.debug(
-                "No speaker UID for %s; Sound & Light Machine entities skipped",
-                baby.name,
-            )
-
         ir.async_delete_issue(self._hass, DOMAIN, f"camera_connection_failed_{baby.camera_uid}")
 
         # Network diagnostics coordinator (optional — polls GET /babies for WiFi info)
@@ -305,8 +421,31 @@ class NanitHub:
             baby=baby,
             push_coordinator=push_coordinator,
             cloud_coordinator=cloud_coordinator,
-            sound_light_coordinator=sound_light_coordinator,
             network_coordinator=network_coordinator,
+        )
+
+    async def _setup_speaker(
+        self,
+        baby: Baby,
+        speaker_uid: str,
+        speaker_ip: str | None,
+    ) -> None:
+        """Create a Sound & Light instance and its coordinator for a single baby."""
+        sound_light = self.get_sound_light(speaker_uid, speaker_ip)
+        coordinator = NanitSoundLightCoordinator(
+            self._hass,
+            self._entry,
+            sound_light,
+            baby,
+            via_camera_uid=baby.camera_uid or None,
+        )
+        await coordinator.async_setup()
+
+        self._speaker_data[speaker_uid] = SpeakerData(
+            sound_light=sound_light,
+            baby=baby,
+            speaker_uid=speaker_uid,
+            coordinator=coordinator,
         )
 
     @callback
@@ -348,12 +487,13 @@ class NanitHub:
         return sl
 
     async def async_close(self) -> None:
-        """Stop all cameras and clean up."""
+        """Stop all devices and clean up."""
         if self._unsubscribe_tokens is not None:
             self._unsubscribe_tokens()
             self._unsubscribe_tokens = None
         await self._client.async_close()
         self._camera_data.clear()
+        self._speaker_data.clear()
         # Also stop S&L instances
         for sl in list(self._sound_lights.values()):
             try:
@@ -363,7 +503,7 @@ class NanitHub:
         self._sound_lights.clear()
 
     async def _discover_speaker_uids(self) -> dict[str, str]:
-        """Fetch speaker UIDs from the raw /babies API response.
+        """Fetch speaker UIDs from the raw /babies API response, keyed by baby uid.
 
         Fallback for when the installed aionanit package's Baby dataclass
         does not yet include the speaker_uid field.
@@ -382,11 +522,11 @@ class NanitHub:
 
         result: dict[str, str] = {}
         for baby in body.get("babies", []):
-            camera_uid = baby.get("camera_uid")
+            baby_uid = baby.get("uid")
             speaker_data = baby.get("speaker", {})
             speaker_obj = speaker_data.get("speaker", {})
             speaker_uid = speaker_obj.get("uid")
-            if camera_uid and speaker_uid:
-                result[camera_uid] = speaker_uid
-                _LOGGER.debug("Discovered speaker UID %s for camera %s", speaker_uid, camera_uid)
+            if baby_uid and speaker_uid:
+                result[baby_uid] = speaker_uid
+                _LOGGER.debug("Discovered speaker UID %s for baby %s", speaker_uid, baby_uid)
         return result

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -377,7 +377,7 @@ class NanitHub:
                     raise NanitAuthError("Access token invalid")
                 resp.raise_for_status()
                 body = await resp.json()
-        except aiohttp.ClientError as err:
+        except (TimeoutError, aiohttp.ClientError) as err:
             raise NanitConnectionError(str(err)) from err
 
         rows = body.get("babies", []) if isinstance(body, dict) else []
@@ -457,7 +457,7 @@ class NanitHub:
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
-            except Exception:
+            except Exception:  # noqa: BLE001 — intentional catch-all; discovery is best-effort
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
             else:
                 self._live_speaker_uids |= set(speaker_uid_map.values())

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -457,7 +457,7 @@ class NanitHub:
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
-            except Exception:  # noqa: BLE001 — intentional catch-all; discovery is best-effort
+            except Exception:
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
             else:
                 self._live_speaker_uids |= set(speaker_uid_map.values())
@@ -591,7 +591,7 @@ class NanitHub:
         for sl in list(self._sound_lights.values()):
             try:
                 await sl.async_stop()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.debug("Error stopping S&L during close")
         self._sound_lights.clear()
 

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -44,13 +44,12 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit light entities for all cameras on the account."""
+    """Set up Nanit light entities for all devices on the account."""
     entities: list[LightEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
         entities.append(NanitNightLight(cam_data.push_coordinator, cam_data.camera))
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            entities.append(NanitSoundLightLight(sl_coordinator))
+    for speaker_data in entry.runtime_data.speakers.values():
+        entities.append(NanitSoundLightLight(speaker_data.coordinator))
     async_add_entities(entities)
 
 
@@ -225,8 +224,7 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sound_light_light"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sound_light_light"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/nanit/number.py
+++ b/custom_components/nanit/number.py
@@ -25,13 +25,10 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit number entities for all cameras on the account."""
+    """Set up Nanit number entities for all devices on the account."""
     entities: list[NumberEntity] = []
-    for cam_data in entry.runtime_data.cameras.values():
-        # Sound & Light Machine volume (optional)
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            entities.append(NanitSoundMachineVolume(sl_coordinator))
+    for speaker_data in entry.runtime_data.speakers.values():
+        entities.append(NanitSoundMachineVolume(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -53,8 +50,7 @@ class NanitSoundMachineVolume(NanitSoundLightEntity, NumberEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_volume"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sound_machine_volume"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -25,12 +25,10 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit select entities for all cameras on the account."""
+    """Set up Nanit select entities for all devices on the account."""
     entities: list[SelectEntity] = []
-    for cam_data in entry.runtime_data.cameras.values():
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            entities.append(NanitSoundSelect(sl_coordinator))
+    for speaker_data in entry.runtime_data.speakers.values():
+        entities.append(NanitSoundSelect(speaker_data.coordinator))
     async_add_entities(entities)
 
 
@@ -46,8 +44,7 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_sound"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sound_machine_sound"
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -142,24 +142,23 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit sensors for all cameras on the account."""
+    """Set up Nanit sensors for all devices on the account."""
     entities: list[SensorEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
         for description in SENSORS:
             entities.append(NanitSensor(cam_data.push_coordinator, description))
-
-        # Sound & Light Machine sensors (optional)
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            for sl_description in SL_SENSORS:
-                entities.append(NanitSLSensor(sl_coordinator, sl_description))
-            entities.append(NanitSLConnectionModeSensor(sl_coordinator))
 
         # Network diagnostic sensors (optional)
         net_coordinator = cam_data.network_coordinator
         if net_coordinator is not None:
             for net_description in NETWORK_SENSORS:
                 entities.append(NanitNetworkSensor(net_coordinator, net_description))
+
+    # Sound & Light Machine sensors
+    for speaker_data in entry.runtime_data.speakers.values():
+        for sl_description in SL_SENSORS:
+            entities.append(NanitSLSensor(speaker_data.coordinator, sl_description))
+        entities.append(NanitSLConnectionModeSensor(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -200,8 +199,7 @@ class NanitSLSensor(NanitSoundLightEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator)
         self.entity_description = description
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_{description.key}"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_{description.key}"
 
     @property
     def native_value(self) -> float | int | None:
@@ -225,8 +223,7 @@ class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sl_connection_mode"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sl_connection_mode"
 
     @property
     def available(self) -> bool:

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -44,16 +44,16 @@
       "already_configured": "This Nanit account is already configured",
       "reauth_successful": "Re-authentication successful",
       "reauth_email_mismatch": "The email address does not match the original account. Please use the same email.",
-      "no_cameras": "No cameras found on this Nanit account"
+      "no_cameras": "No devices found on this Nanit account"
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Nanit Options",
-        "description": "Select a camera to configure its local IP address.",
+        "description": "Select a device to configure its local IP addresses.",
         "data": {
-          "camera": "Camera"
+          "device": "Device"
         }
       },
       "camera_ip": {
@@ -85,11 +85,21 @@
   },
   "entity": {
     "sensor": {
-      "temperature": { "name": "Temperature" },
-      "humidity": { "name": "Humidity" },
-      "light": { "name": "Light Level" },
-      "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "humidity": {
+        "name": "Humidity"
+      },
+      "light": {
+        "name": "Light Level"
+      },
+      "sl_temperature": {
+        "name": "Temperature"
+      },
+      "sl_humidity": {
+        "name": "Humidity"
+      },
       "sl_connection_mode": {
         "name": "Connection Mode",
         "state": {
@@ -98,36 +108,68 @@
           "unavailable": "Unavailable"
         }
       },
-      "wifi_ssid": { "name": "WiFi SSID" },
-      "wifi_signal": { "name": "WiFi Signal Strength" },
-      "wifi_frequency": { "name": "WiFi Frequency" }
+      "wifi_ssid": {
+        "name": "WiFi SSID"
+      },
+      "wifi_signal": {
+        "name": "WiFi Signal Strength"
+      },
+      "wifi_frequency": {
+        "name": "WiFi Frequency"
+      }
     },
     "binary_sensor": {
-      "motion": { "name": "Motion" },
-      "sound": { "name": "Sound" },
-      "connectivity": { "name": "Connectivity" },
-      "sl_connectivity": { "name": "Connectivity" }
+      "motion": {
+        "name": "Motion"
+      },
+      "sound": {
+        "name": "Sound"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "sl_connectivity": {
+        "name": "Connectivity"
+      }
     },
     "switch": {
-      "camera_power": { "name": "Camera Power" },
-      "sound_machine_switch": { "name": "Power" },
-      "sl_sound_switch": { "name": "Sound" }
+      "camera_power": {
+        "name": "Camera Power"
+      },
+      "sound_machine_switch": {
+        "name": "Power"
+      },
+      "sl_sound_switch": {
+        "name": "Sound"
+      }
     },
     "number": {
-      "sound_machine_volume": { "name": "Volume" }
+      "sound_machine_volume": {
+        "name": "Volume"
+      }
     },
     "light": {
-      "night_light": { "name": "Night Light" },
-      "sound_light_light": { "name": "Light" }
+      "night_light": {
+        "name": "Night Light"
+      },
+      "sound_light_light": {
+        "name": "Light"
+      }
     },
     "select": {
-      "sound_machine_sound": { "name": "Sound Track" }
+      "sound_machine_sound": {
+        "name": "Sound Track"
+      }
     },
     "media_player": {
-      "sound_machine": { "name": "Sound Machine" }
+      "sound_machine": {
+        "name": "Sound Machine"
+      }
     },
     "camera": {
-      "camera": { "name": "Camera" }
+      "camera": {
+        "name": "Camera"
+      }
     }
   }
 }

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -63,17 +63,16 @@ async def async_setup_entry(
     entry: NanitConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nanit switches for all cameras on the account."""
+    """Set up Nanit switches for all devices on the account."""
     entities: list[SwitchEntity] = []
     for cam_data in entry.runtime_data.cameras.values():
         for description in SWITCHES:
             entities.append(NanitSwitch(cam_data.push_coordinator, cam_data.camera, description))
 
-        # Sound & Light Machine switches (optional)
-        sl_coordinator = cam_data.sound_light_coordinator
-        if sl_coordinator is not None:
-            entities.append(NanitSLPowerSwitch(sl_coordinator))
-            entities.append(NanitSLSoundSwitch(sl_coordinator))
+    # Sound & Light Machine switches
+    for speaker_data in entry.runtime_data.speakers.values():
+        entities.append(NanitSLPowerSwitch(speaker_data.coordinator))
+        entities.append(NanitSLSoundSwitch(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -211,8 +210,7 @@ class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sound_machine_switch"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sound_machine_switch"
 
     @property
     def is_on(self) -> bool | None:
@@ -252,8 +250,7 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        baby = coordinator.baby
-        self._attr_unique_id = f"{baby.camera_uid}_sl_sound_switch"
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sl_sound_switch"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -44,16 +44,16 @@
       "already_configured": "This Nanit account is already configured",
       "reauth_successful": "Re-authentication successful",
       "reauth_email_mismatch": "The email address does not match the original account. Please use the same email.",
-      "no_cameras": "No cameras found on this Nanit account"
+      "no_cameras": "No devices found on this Nanit account"
     }
   },
   "options": {
     "step": {
       "init": {
         "title": "Nanit Options",
-        "description": "Select a camera to configure its local IP address.",
+        "description": "Select a device to configure its local IP addresses.",
         "data": {
-          "camera": "Camera"
+          "device": "Device"
         }
       },
       "camera_ip": {
@@ -85,11 +85,21 @@
   },
   "entity": {
     "sensor": {
-      "temperature": { "name": "Temperature" },
-      "humidity": { "name": "Humidity" },
-      "light": { "name": "Light Level" },
-      "sl_temperature": { "name": "Temperature" },
-      "sl_humidity": { "name": "Humidity" },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "humidity": {
+        "name": "Humidity"
+      },
+      "light": {
+        "name": "Light Level"
+      },
+      "sl_temperature": {
+        "name": "Temperature"
+      },
+      "sl_humidity": {
+        "name": "Humidity"
+      },
       "sl_connection_mode": {
         "name": "Connection Mode",
         "state": {
@@ -98,36 +108,68 @@
           "unavailable": "Unavailable"
         }
       },
-      "wifi_ssid": { "name": "WiFi SSID" },
-      "wifi_signal": { "name": "WiFi Signal Strength" },
-      "wifi_frequency": { "name": "WiFi Frequency" }
+      "wifi_ssid": {
+        "name": "WiFi SSID"
+      },
+      "wifi_signal": {
+        "name": "WiFi Signal Strength"
+      },
+      "wifi_frequency": {
+        "name": "WiFi Frequency"
+      }
     },
     "binary_sensor": {
-      "motion": { "name": "Motion" },
-      "sound": { "name": "Sound" },
-      "connectivity": { "name": "Connectivity" },
-      "sl_connectivity": { "name": "Connectivity" }
+      "motion": {
+        "name": "Motion"
+      },
+      "sound": {
+        "name": "Sound"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "sl_connectivity": {
+        "name": "Connectivity"
+      }
     },
     "switch": {
-      "camera_power": { "name": "Camera Power" },
-      "sound_machine_switch": { "name": "Power" },
-      "sl_sound_switch": { "name": "Sound" }
+      "camera_power": {
+        "name": "Camera Power"
+      },
+      "sound_machine_switch": {
+        "name": "Power"
+      },
+      "sl_sound_switch": {
+        "name": "Sound"
+      }
     },
     "number": {
-      "sound_machine_volume": { "name": "Volume" }
+      "sound_machine_volume": {
+        "name": "Volume"
+      }
     },
     "light": {
-      "night_light": { "name": "Night Light" },
-      "sound_light_light": { "name": "Light" }
+      "night_light": {
+        "name": "Night Light"
+      },
+      "sound_light_light": {
+        "name": "Light"
+      }
     },
     "select": {
-      "sound_machine_sound": { "name": "Sound Track" }
+      "sound_machine_sound": {
+        "name": "Sound Track"
+      }
     },
     "media_player": {
-      "sound_machine": { "name": "Sound Machine" }
+      "sound_machine": {
+        "name": "Sound Machine"
+      }
     },
     "camera": {
-      "camera": { "name": "Camera" }
+      "camera": {
+        "name": "Camera"
+      }
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore = [
 "**/*_pb2.py" = ["ALL"]
 "packages/aionanit/**" = ["D", "N818", "BLE001", "SIM105", "SIM117", "E402", "RUF059", "C408"]
 "custom_components/nanit/config_flow.py" = ["BLE001"]
+"custom_components/nanit/hub.py" = ["BLE001"]
 "custom_components/nanit/aionanit_sl/**" = ["BLE001", "D", "SIM105"]
 "tests/unit/test_sl_*" = ["BLE001", "SIM105"]
 

--- a/tests/unit/snapshots/test_entity_registration.ambr
+++ b/tests/unit/snapshots/test_entity_registration.ambr
@@ -63,12 +63,29 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
       'translation_key': 'sl_connectivity',
-      'unique_id': 'cam_1_sl_connectivity',
+      'unique_id': 'speaker_1_sl_connectivity',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_binary_sensor[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSLConnectivitySensor',
+      'device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_connectivity',
+      'unique_id': 'speaker_1_sl_connectivity',
     }),
   ])
 # ---
@@ -106,6 +123,10 @@
       'translation_key': 'camera',
       'unique_id': 'cam_1_camera',
     }),
+  ])
+# ---
+# name: TestEntityRegistration.test_camera[speaker_only]
+  list([
   ])
 # ---
 # name: TestEntityRegistration.test_light[baseline]
@@ -157,13 +178,34 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': None,
       'supported_features': 0,
       'translation_key': 'sound_light_light',
-      'unique_id': 'cam_1_sound_light_light',
+      'unique_id': 'speaker_1_sound_light_light',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_light[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSoundLightLight',
+      'color_modes': list([
+        'hs',
+      ]),
+      'device_class': None,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'supported_features': 0,
+      'translation_key': 'sound_light_light',
+      'unique_id': 'speaker_1_sound_light_light',
     }),
   ])
 # ---
@@ -203,6 +245,10 @@
     }),
   ])
 # ---
+# name: TestEntityRegistration.test_media_player[speaker_only]
+  list([
+  ])
+# ---
 # name: TestEntityRegistration.test_number[baseline]
   list([
   ])
@@ -215,12 +261,29 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': None,
       'translation_key': 'sound_machine_volume',
-      'unique_id': 'cam_1_sound_machine_volume',
+      'unique_id': 'speaker_1_sound_machine_volume',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_number[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSoundMachineVolume',
+      'device_class': None,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sound_machine_volume',
+      'unique_id': 'speaker_1_sound_machine_volume',
     }),
   ])
 # ---
@@ -236,12 +299,29 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': None,
       'translation_key': 'sound_machine_sound',
-      'unique_id': 'cam_1_sound_machine_sound',
+      'unique_id': 'speaker_1_sound_machine_sound',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_select[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSoundSelect',
+      'device_class': None,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sound_machine_sound',
+      'unique_id': 'speaker_1_sound_machine_sound',
     }),
   ])
 # ---
@@ -317,45 +397,6 @@
       'unique_id': 'cam_1_light',
     }),
     dict({
-      'class': 'NanitSLConnectionModeSensor',
-      'device_class': <SensorDeviceClass.ENUM: 'enum'>,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1_sound_light',
-        ),
-      ]),
-      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-      'translation_key': 'sl_connection_mode',
-      'unique_id': 'cam_1_sl_connection_mode',
-    }),
-    dict({
-      'class': 'NanitSLSensor',
-      'device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1_sound_light',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'sl_humidity',
-      'unique_id': 'cam_1_sl_humidity',
-    }),
-    dict({
-      'class': 'NanitSLSensor',
-      'device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'device_identifiers': list([
-        tuple(
-          'nanit',
-          'cam_1_sound_light',
-        ),
-      ]),
-      'entity_category': None,
-      'translation_key': 'sl_temperature',
-      'unique_id': 'cam_1_sl_temperature',
-    }),
-    dict({
       'class': 'NanitSensor',
       'device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
       'device_identifiers': list([
@@ -407,6 +448,88 @@
       'translation_key': 'wifi_ssid',
       'unique_id': 'cam_1_wifi_ssid',
     }),
+    dict({
+      'class': 'NanitSLConnectionModeSensor',
+      'device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_connection_mode',
+      'unique_id': 'speaker_1_sl_connection_mode',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sl_humidity',
+      'unique_id': 'speaker_1_sl_humidity',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sl_temperature',
+      'unique_id': 'speaker_1_sl_temperature',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_sensor[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSLConnectionModeSensor',
+      'device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_connection_mode',
+      'unique_id': 'speaker_1_sl_connection_mode',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sl_humidity',
+      'unique_id': 'speaker_1_sl_humidity',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sl_temperature',
+      'unique_id': 'speaker_1_sl_temperature',
+    }),
   ])
 # ---
 # name: TestEntityRegistration.test_switch[baseline]
@@ -447,12 +570,12 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': None,
       'translation_key': 'sl_sound_switch',
-      'unique_id': 'cam_1_sl_sound_switch',
+      'unique_id': 'speaker_1_sl_sound_switch',
     }),
     dict({
       'class': 'NanitSLPowerSwitch',
@@ -460,12 +583,42 @@
       'device_identifiers': list([
         tuple(
           'nanit',
-          'cam_1_sound_light',
+          'speaker_1',
         ),
       ]),
       'entity_category': None,
       'translation_key': 'sound_machine_switch',
-      'unique_id': 'cam_1_sound_machine_switch',
+      'unique_id': 'speaker_1_sound_machine_switch',
+    }),
+  ])
+# ---
+# name: TestEntityRegistration.test_switch[speaker_only]
+  list([
+    dict({
+      'class': 'NanitSLSoundSwitch',
+      'device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sl_sound_switch',
+      'unique_id': 'speaker_1_sl_sound_switch',
+    }),
+    dict({
+      'class': 'NanitSLPowerSwitch',
+      'device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': 'sound_machine_switch',
+      'unique_id': 'speaker_1_sound_machine_switch',
     }),
   ])
 # ---

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -871,3 +871,27 @@ async def test_options_flow_clearing_speaker_ip_also_drops_legacy_key(
     result_data = _as_dict(result)
     assert result_data.get("type") is FlowResultType.CREATE_ENTRY
     assert result_data["data"][CONF_SPEAKER_IPS] == {}
+
+
+async def test_options_flow_unresolved_speaker_keeps_legacy_ip(
+    hass: HomeAssistant,
+) -> None:
+    """Saving camera options must not discard a legacy speaker IP the hub still uses."""
+    hass = await _resolve_hass(hass)
+    baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1", speaker_uid=None)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_SPEAKER_IPS: {"cam_1": "192.168.1.90"}},
+    )
+    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[baby], speaker_uid_map={}))
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_CAMERA_IP: "192.168.1.91"},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+    assert result_data["data"][CONF_SPEAKER_IPS] == {"cam_1": "192.168.1.90"}

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -16,12 +16,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from aionanit.models import Baby
 from custom_components.nanit import config_flow as nanit_config_flow
 from custom_components.nanit.const import (
     CONF_CAMERA_IP,
     CONF_CAMERA_IPS,
     CONF_MFA_CODE,
     CONF_REFRESH_TOKEN,
+    CONF_SPEAKER_IP,
+    CONF_SPEAKER_IPS,
     CONF_STORE_CREDENTIALS,
     DOMAIN,
 )
@@ -674,7 +677,7 @@ async def test_reauth_mfa_connection_error_shows_error(
 async def test_options_flow_init_no_cameras_aborts(hass: HomeAssistant) -> None:
     hass = await _resolve_hass(hass)
     entry = MockConfigEntry(domain=DOMAIN, options={})
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[]))
+    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[], speaker_uid_map={}))
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -688,7 +691,9 @@ async def test_options_flow_init_single_camera_goes_to_camera_ip(
 ) -> None:
     hass = await _resolve_hass(hass)
     entry = MockConfigEntry(domain=DOMAIN, options={})
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[MOCK_BABY_1]))
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1], speaker_uid_map={})
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -702,7 +707,9 @@ async def test_options_flow_init_multiple_cameras_shows_selector(
 ) -> None:
     hass = await _resolve_hass(hass)
     entry = MockConfigEntry(domain=DOMAIN, options={})
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[MOCK_BABY_1, MOCK_BABY_2]))
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1, MOCK_BABY_2], speaker_uid_map={})
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -714,7 +721,9 @@ async def test_options_flow_init_multiple_cameras_shows_selector(
 async def test_options_flow_camera_ip_sets_ip(hass: HomeAssistant) -> None:
     hass = await _resolve_hass(hass)
     entry = MockConfigEntry(domain=DOMAIN, options={CONF_CAMERA_IPS: {}})
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[MOCK_BABY_1]))
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1], speaker_uid_map={})
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -733,7 +742,9 @@ async def test_options_flow_multi_camera_select_then_set_ip(
 ) -> None:
     hass = await _resolve_hass(hass)
     entry = MockConfigEntry(domain=DOMAIN, options={CONF_CAMERA_IPS: {}})
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[MOCK_BABY_1, MOCK_BABY_2]))
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1, MOCK_BABY_2], speaker_uid_map={})
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -742,7 +753,7 @@ async def test_options_flow_multi_camera_select_then_set_ip(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {"camera": MOCK_BABY_2.camera_uid},
+        {"device": MOCK_BABY_2.uid},
     )
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "camera_ip"
@@ -765,7 +776,9 @@ async def test_options_flow_camera_ip_clears_ip_when_empty(
         domain=DOMAIN,
         options={CONF_CAMERA_IPS: {MOCK_BABY_1.camera_uid: "192.168.1.30"}},
     )
-    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(babies=[MOCK_BABY_1]))
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1], speaker_uid_map={})
+    )
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -777,3 +790,84 @@ async def test_options_flow_camera_ip_clears_ip_when_empty(
     result_data = _as_dict(result)
     assert result_data.get("type") is FlowResultType.CREATE_ENTRY
     assert result_data["data"][CONF_CAMERA_IPS] == {}
+
+
+async def test_options_flow_speaker_only_baby_shows_speaker_field_only(
+    hass: HomeAssistant,
+) -> None:
+    """A baby without a camera gets only the speaker IP field, saved by speaker_uid."""
+    hass = await _resolve_hass(hass)
+    speaker_only_baby = Baby(uid="baby_9", name="Den", camera_uid="", speaker_uid="spk_9")
+    entry = MockConfigEntry(domain=DOMAIN, options={})
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[speaker_only_baby], speaker_uid_map={"baby_9": "spk_9"})
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "camera_ip"
+    schema_keys = {str(key) for key in _as_dict(result)["data_schema"].schema}
+    assert schema_keys == {CONF_SPEAKER_IP}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SPEAKER_IP: "192.168.1.40"},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+    assert result_data["data"][CONF_SPEAKER_IPS] == {"spk_9": "192.168.1.40"}
+    assert result_data["data"][CONF_CAMERA_IPS] == {}
+
+
+async def test_options_flow_speaker_ip_saved_by_speaker_uid_and_legacy_key_dropped(
+    hass: HomeAssistant,
+) -> None:
+    """Saving re-keys the speaker IP by speaker_uid and drops a legacy camera_uid key."""
+    hass = await _resolve_hass(hass)
+    baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1", speaker_uid="spk_1")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_SPEAKER_IPS: {"cam_1": "192.168.1.50"}},
+    )
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[baby], speaker_uid_map={"baby_1": "spk_1"})
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SPEAKER_IP: "192.168.1.51"},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+    assert result_data["data"][CONF_SPEAKER_IPS] == {"spk_1": "192.168.1.51"}
+
+
+async def test_options_flow_clearing_speaker_ip_also_drops_legacy_key(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the speaker IP removes both the speaker_uid and legacy keys."""
+    hass = await _resolve_hass(hass)
+    baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1", speaker_uid="spk_1")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_SPEAKER_IPS: {"cam_1": "192.168.1.50", "spk_1": "192.168.1.51"}},
+    )
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[baby], speaker_uid_map={"baby_1": "spk_1"})
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SPEAKER_IP: ""},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+    assert result_data["data"][CONF_SPEAKER_IPS] == {}

--- a/tests/unit/test_entity_registration.py
+++ b/tests/unit/test_entity_registration.py
@@ -154,13 +154,17 @@ def _cloud_coordinator() -> MagicMock:
     return coordinator
 
 
-def _sl_coordinator() -> MagicMock:
+def _sl_coordinator(baby: Baby | None = None, via_camera_uid: str | None = "cam_1") -> MagicMock:
     coordinator = MagicMock()
     coordinator.data = SoundLightFullState()
-    coordinator.baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1")
+    coordinator.baby = baby or Baby(
+        uid="baby_1", name="Nursery", camera_uid="cam_1", speaker_uid="speaker_1"
+    )
     coordinator.last_update_success = True
     coordinator.connected = True
+    coordinator.via_camera_uid = via_camera_uid
     coordinator.sound_light = MagicMock()
+    coordinator.sound_light.speaker_uid = "speaker_1"
     coordinator.sound_light.async_set_light_enabled = AsyncMock()
     coordinator.sound_light.async_set_brightness = AsyncMock()
     coordinator.sound_light.async_set_color = AsyncMock()
@@ -185,32 +189,42 @@ def _network_coordinator() -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def _baseline_cam_data() -> MagicMock:
+def _baseline_scenario() -> tuple[dict[str, Any], dict[str, Any]]:
     """Camera with push coordinator only (no S&L, no cloud, no network)."""
     push = _push_coordinator()
     cam_data = MagicMock()
     cam_data.push_coordinator = push
     cam_data.camera = push.camera
     cam_data.cloud_coordinator = None
-    cam_data.sound_light_coordinator = None
     cam_data.network_coordinator = None
-    return cam_data
+    return {"cam_1": cam_data}, {}
 
 
-def _full_cam_data() -> MagicMock:
-    """Camera with all optional coordinators enabled."""
+def _full_scenario() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Camera with all optional coordinators plus a paired S&L speaker."""
     push = _push_coordinator()
     cam_data = MagicMock()
     cam_data.push_coordinator = push
     cam_data.camera = push.camera
     cam_data.cloud_coordinator = _cloud_coordinator()
-    cam_data.sound_light_coordinator = _sl_coordinator()
     cam_data.network_coordinator = _network_coordinator()
-    return cam_data
+    speaker_data = MagicMock()
+    speaker_data.coordinator = _sl_coordinator()
+    speaker_data.speaker_uid = "speaker_1"
+    return {"cam_1": cam_data}, {"speaker_1": speaker_data}
 
 
-def _mock_entry(cam_data: MagicMock) -> MagicMock:
-    return MagicMock(runtime_data=MagicMock(cameras={"cam_1": cam_data}))
+def _speaker_only_scenario() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Standalone S&L speaker on an account with no camera."""
+    baby = Baby(uid="baby_1", name="Nursery", camera_uid="", speaker_uid="speaker_1")
+    speaker_data = MagicMock()
+    speaker_data.coordinator = _sl_coordinator(baby=baby, via_camera_uid=None)
+    speaker_data.speaker_uid = "speaker_1"
+    return {}, {"speaker_1": speaker_data}
+
+
+def _mock_entry(cameras: dict[str, Any], speakers: dict[str, Any]) -> MagicMock:
+    return MagicMock(runtime_data=MagicMock(cameras=cameras, speakers=speakers))
 
 
 # ---------------------------------------------------------------------------
@@ -220,10 +234,10 @@ def _mock_entry(cam_data: MagicMock) -> MagicMock:
 
 async def _setup_and_capture(
     platform_module: Any,
-    cam_data: MagicMock,
+    scenario: tuple[dict[str, Any], dict[str, Any]],
 ) -> list[Any]:
     """Call a platform's async_setup_entry and return the captured entities."""
-    entry = _mock_entry(cam_data)
+    entry = _mock_entry(*scenario)
     async_add_entities = MagicMock()
     await platform_module.async_setup_entry(MagicMock(), entry, async_add_entities)
     assert async_add_entities.call_count == 1, "async_add_entities should be called exactly once"
@@ -236,83 +250,86 @@ async def _setup_and_capture(
 
 
 @pytest.mark.parametrize(
-    ("scenario_name", "cam_data_factory"),
+    ("scenario_name", "scenario_factory"),
     [
-        ("baseline", _baseline_cam_data),
-        ("full", _full_cam_data),
+        ("baseline", _baseline_scenario),
+        ("full", _full_scenario),
+        ("speaker_only", _speaker_only_scenario),
     ],
-    ids=["baseline", "full"],
+    ids=["baseline", "full", "speaker_only"],
 )
 class TestEntityRegistration:
     async def test_camera(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(camera_platform, cam_data_factory())
+        entities = await _setup_and_capture(camera_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_sensor(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(sensor_platform, cam_data_factory())
+        entities = await _setup_and_capture(sensor_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_binary_sensor(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(binary_sensor_platform, cam_data_factory())
+        entities = await _setup_and_capture(binary_sensor_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_switch(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(switch_platform, cam_data_factory())
+        entities = await _setup_and_capture(switch_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_number(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(number_platform, cam_data_factory())
+        entities = await _setup_and_capture(number_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_light(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(light_platform, cam_data_factory())
+        entities = await _setup_and_capture(light_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_select(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(select_platform, cam_data_factory())
+        entities = await _setup_and_capture(select_platform, scenario_factory())
         assert _serialize_entities(entities) == snapshot
 
     async def test_media_player(
         self,
         scenario_name: str,
-        cam_data_factory: Any,
+        scenario_factory: Any,
         snapshot: SnapshotAssertion,
     ) -> None:
-        entities = await _setup_and_capture(media_player_platform, cam_data_factory())
+        scenario = scenario_factory()
+        entities = await _setup_and_capture(media_player_platform, scenario)
         assert _serialize_entities(entities) == snapshot
-        assert len(entities) == 1
+        # One media player per camera (it wraps the camera's sound machine)
+        assert len(entities) == len(scenario[0])

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -409,3 +409,231 @@ async def test_failed_camera_logs_unknown_cloud_status_on_legacy_baby(
             await hub.async_setup()
 
     assert "cloud connected status unknown" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Standalone speaker setup (camera optional)
+# ---------------------------------------------------------------------------
+
+Baby = importlib.import_module("aionanit.models").Baby
+
+MOCK_BABY_BOTH = Baby(uid="baby_4", name="Nursery", camera_uid="cam_4", speaker_uid="spk_4")
+MOCK_BABY_SPEAKER_ONLY = Baby(uid="baby_5", name="Den", camera_uid="", speaker_uid="spk_5")
+
+
+def _speaker_patches():
+    return (
+        patch("custom_components.nanit.hub.NanitSoundLight"),
+        patch("custom_components.nanit.hub.NanitSoundLightCoordinator"),
+    )
+
+
+async def test_setup_speaker_only_account(hass: HomeAssistant, mock_nanit_client) -> None:
+    """An account whose baby has no camera still gets a working S&L entry."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_SPEAKER_ONLY]
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with sl_patch, coord_patch as coord_cls:
+        coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert hub.camera_data == {}
+    assert set(hub.speaker_data) == {"spk_5"}
+    assert hub.speaker_data["spk_5"].baby is MOCK_BABY_SPEAKER_ONLY
+    assert coord_cls.call_args.kwargs["via_camera_uid"] is None
+    mock_nanit_client.camera.assert_not_called()
+
+
+async def test_setup_camera_and_speaker(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A baby with both devices gets a camera and a speaker, linked via_device."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_BOTH]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+        sl_patch,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        sl_coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert set(hub.camera_data) == {"cam_4"}
+    assert set(hub.speaker_data) == {"spk_4"}
+    assert sl_coord_cls.call_args.kwargs["via_camera_uid"] == "cam_4"
+    assert hub.speaker_uid_map == {"baby_4": "spk_4"}
+
+
+async def test_setup_speaker_only_failure_raises(hass: HomeAssistant, mock_nanit_client) -> None:
+    """When the only device on the account fails, setup raises so HA retries."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_SPEAKER_ONLY]
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with sl_patch, coord_patch as coord_cls:
+        coord_cls.return_value = MagicMock(
+            async_setup=AsyncMock(side_effect=NanitConnectionError("unreachable"))
+        )
+        with pytest.raises(NanitConnectionError):
+            await hub.async_setup()
+
+    assert hub.speaker_data == {}
+
+
+async def test_setup_speaker_failure_keeps_camera(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A failing speaker must not take down a working camera."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_BOTH]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+        sl_patch,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        sl_coord_cls.return_value = MagicMock(async_setup=AsyncMock(side_effect=ValueError("boom")))
+        await hub.async_setup()
+
+    assert set(hub.camera_data) == {"cam_4"}
+    assert hub.speaker_data == {}
+
+
+async def test_setup_camera_failure_keeps_speaker(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A failing camera must not take down a working speaker (partial failure)."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_BOTH]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        sl_patch,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(
+            async_setup=AsyncMock(side_effect=NanitConnectionError("unreachable"))
+        )
+        sl_coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert hub.camera_data == {}
+    assert set(hub.speaker_data) == {"spk_4"}
+    assert hub.failed_camera_uids == {"cam_4"}
+
+
+async def test_get_babies_falls_back_to_raw_parse_on_keyerror(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """A /babies row without camera_uid breaks aionanit's parser; the raw parse covers it."""
+    mock_nanit_client.async_get_babies.side_effect = KeyError("camera_uid")
+
+    resp = MagicMock()
+    resp.status = 200
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(
+        return_value={
+            "babies": [
+                {
+                    "uid": "baby_5",
+                    "name": "Den",
+                    "speaker": {"speaker": {"uid": "spk_5"}},
+                }
+            ]
+        }
+    )
+    mock_nanit_client.rest_client.base_url = "https://api.example.invalid"
+    mock_nanit_client.rest_client.session.get = AsyncMock(return_value=resp)
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with sl_patch, coord_patch as coord_cls:
+        coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert hub.camera_data == {}
+    assert set(hub.speaker_data) == {"spk_5"}
+    assert hub.babies[0].camera_uid == ""
+    assert hub.babies[0].speaker_uid == "spk_5"
+
+
+async def test_legacy_camera_keyed_speaker_map_translates(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """A persisted speaker map keyed by camera_uid (old shape) still resolves."""
+    baby = Baby(uid="baby_4", name="Nursery", camera_uid="cam_4", speaker_uid=None)
+    mock_nanit_client.async_get_babies.return_value = [baby]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**mock_entry_data_v2(), "speaker_uid_map": {"cam_4": "spk_4"}},
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+        sl_patch,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        sl_coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert hub.speaker_uid_map == {"baby_4": "spk_4"}
+    assert set(hub.speaker_data) == {"spk_4"}
+    # The persisted map is re-keyed by baby uid
+    assert entry.data["speaker_uid_map"] == {"baby_4": "spk_4"}
+
+
+async def test_legacy_camera_keyed_speaker_ip_still_applies(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """A speaker IP stored under the camera_uid (old shape) reaches the facade."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_BOTH]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+    entry = _make_entry(hass, options={"speaker_ips": {"cam_4": "192.168.1.60"}})
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+        sl_patch as sl_cls,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        sl_coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert sl_cls.call_args.kwargs["device_ip"] == "192.168.1.60"

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -559,8 +559,11 @@ async def test_get_babies_falls_back_to_raw_parse_on_keyerror(
             ]
         }
     )
+    resp_cm = MagicMock()
+    resp_cm.__aenter__ = AsyncMock(return_value=resp)
+    resp_cm.__aexit__ = AsyncMock(return_value=False)
     mock_nanit_client.rest_client.base_url = "https://api.example.invalid"
-    mock_nanit_client.rest_client.session.get = AsyncMock(return_value=resp)
+    mock_nanit_client.rest_client.session.get = MagicMock(return_value=resp_cm)
 
     entry = _make_entry(hass)
     hub = NanitHub(hass, MagicMock(), entry)
@@ -609,8 +612,10 @@ async def test_legacy_camera_keyed_speaker_map_translates(
 
     assert hub.speaker_uid_map == {"baby_4": "spk_4"}
     assert set(hub.speaker_data) == {"spk_4"}
-    # The persisted map is re-keyed by baby uid
-    assert entry.data["speaker_uid_map"] == {"baby_4": "spk_4"}
+    # The legacy pairing is retained for the identity migration; the
+    # re-keyed map is persisted by the migration step, not the hub
+    assert hub.camera_speaker_pairs == {"cam_4": "spk_4"}
+    assert entry.data["speaker_uid_map"] == {"cam_4": "spk_4"}
 
 
 async def test_legacy_camera_keyed_speaker_ip_still_applies(
@@ -637,3 +642,77 @@ async def test_legacy_camera_keyed_speaker_ip_still_applies(
         await hub.async_setup()
 
     assert sl_cls.call_args.kwargs["device_ip"] == "192.168.1.60"
+
+
+async def test_setup_babies_without_devices_raises(hass: HomeAssistant, mock_nanit_client) -> None:
+    """Babies with no cameras and no resolvable speakers must retry, not load empty."""
+    mock_nanit_client.async_get_babies.return_value = [
+        Baby(uid="baby_7", name="Nook", camera_uid="", speaker_uid=None)
+    ]
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with pytest.raises(NanitConnectionError):
+        await hub.async_setup()
+
+
+async def test_raw_parse_skips_malformed_rows(hass: HomeAssistant, mock_nanit_client) -> None:
+    """Rows with bad shapes or hostile uid values are dropped, not fatal."""
+    mock_nanit_client.async_get_babies.side_effect = KeyError("camera_uid")
+
+    resp = MagicMock()
+    resp.status = 200
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(
+        return_value={
+            "babies": [
+                "not-a-dict",
+                {"name": "no uid"},
+                {"uid": "../../evil", "speaker": {"speaker": {"uid": "spk_ok"}}},
+                {"uid": "baby_8", "name": 42, "speaker": "not-a-dict"},
+                {"uid": "baby_9", "name": "Den", "speaker": {"speaker": {"uid": "bad/uid"}}},
+                {"uid": "baby_10", "name": "Loft", "speaker": {"speaker": {"uid": "spk_10"}}},
+            ]
+        }
+    )
+    resp_cm = MagicMock()
+    resp_cm.__aenter__ = AsyncMock(return_value=resp)
+    resp_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_nanit_client.rest_client.base_url = "https://api.example.invalid"
+    mock_nanit_client.rest_client.session.get = MagicMock(return_value=resp_cm)
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with sl_patch, coord_patch as coord_cls:
+        coord_cls.return_value = MagicMock(async_setup=AsyncMock())
+        await hub.async_setup()
+
+    assert {baby.uid for baby in hub.babies} == {"baby_8", "baby_9", "baby_10"}
+    # Only the row with a clean speaker uid produced a speaker
+    assert set(hub.speaker_data) == {"spk_10"}
+
+
+async def test_via_device_cleared_when_camera_fails(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A speaker must not reference a camera device that never registered."""
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_BOTH]
+    mock_nanit_client.camera.side_effect = lambda **kw: _make_mock_camera(kw["uid"], kw["baby_uid"])
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    sl_patch, coord_patch = _speaker_patches()
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        sl_patch,
+        coord_patch as sl_coord_cls,
+    ):
+        push_cls.return_value = MagicMock(
+            async_setup=AsyncMock(side_effect=NanitConnectionError("unreachable"))
+        )
+        coordinator = MagicMock(async_setup=AsyncMock())
+        coordinator.via_camera_uid = "cam_4"
+        sl_coord_cls.return_value = coordinator
+        await hub.async_setup()
+
+    assert hub.speaker_data["spk_4"].coordinator.via_camera_uid is None

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -152,7 +152,9 @@ async def test_stale_device_removed_when_camera_no_longer_on_account(
     ):
         assert await async_setup_entry(hass, entry)
 
-    mock_device_registry.async_remove_device.assert_called_once_with("device_stale")
+    mock_device_registry.async_update_device.assert_called_once_with(
+        "device_stale", remove_config_entry_id=entry.entry_id
+    )
 
 
 async def test_active_device_not_removed(
@@ -190,7 +192,7 @@ async def test_active_device_not_removed(
     ):
         assert await async_setup_entry(hass, entry)
 
-    mock_device_registry.async_remove_device.assert_not_called()
+    mock_device_registry.async_update_device.assert_not_called()
 
 
 async def test_no_devices_removed_when_babies_list_empty(
@@ -231,7 +233,7 @@ async def test_no_devices_removed_when_babies_list_empty(
     ):
         assert await async_setup_entry(hass, entry)
 
-    mock_device_registry.async_remove_device.assert_not_called()
+    mock_device_registry.async_update_device.assert_not_called()
 
 
 async def test_deprecated_switch_entity_removed_on_setup(
@@ -357,7 +359,7 @@ from types import SimpleNamespace
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.nanit import _async_migrate_sl_identities
+from custom_components.nanit import _async_migrate_sl_identities, _async_remove_stale_devices
 from custom_components.nanit.const import CONF_SPEAKER_IPS
 
 Baby = importlib.import_module("aionanit.models").Baby
@@ -377,10 +379,19 @@ def _migration_entry(hass: HomeAssistant, options: dict | None = None) -> MockCo
     return entry
 
 
-def _migration_hub(babies=None, speaker_uid_map=None) -> SimpleNamespace:
+def _migration_hub(babies=None, speaker_uid_map=None, camera_speaker_pairs=None) -> SimpleNamespace:
+    babies = babies if babies is not None else [_MIG_BABY]
+    speaker_uid_map = speaker_uid_map if speaker_uid_map is not None else {"baby_4": "spk_4"}
+    if camera_speaker_pairs is None:
+        camera_speaker_pairs = {
+            baby.camera_uid: speaker_uid_map[baby.uid]
+            for baby in babies
+            if baby.camera_uid and baby.uid in speaker_uid_map
+        }
     return SimpleNamespace(
-        babies=babies if babies is not None else [_MIG_BABY],
-        speaker_uid_map=speaker_uid_map if speaker_uid_map is not None else {"baby_4": "spk_4"},
+        babies=babies,
+        speaker_uid_map=speaker_uid_map,
+        camera_speaker_pairs=camera_speaker_pairs,
     )
 
 
@@ -421,8 +432,8 @@ async def test_sl_migration_moves_device_identifier(hass: HomeAssistant) -> None
     assert migrated.identifiers == {(DOMAIN, "spk_4")}
 
 
-async def test_sl_migration_collision_keeps_existing(hass: HomeAssistant) -> None:
-    """If the target unique_id already exists, the old entity is left alone."""
+async def test_sl_migration_collision_removes_dead_old_entity(hass: HomeAssistant) -> None:
+    """If the target unique_id already exists, the unusable old entity is dropped."""
     entry = _migration_entry(hass)
     ent_reg = er.async_get(hass)
     old = ent_reg.async_get_or_create(
@@ -434,7 +445,7 @@ async def test_sl_migration_collision_keeps_existing(hass: HomeAssistant) -> Non
 
     await _async_migrate_sl_identities(hass, entry, _migration_hub())
 
-    assert ent_reg.async_get(old.entity_id).unique_id == "cam_4_sound_machine_switch"
+    assert ent_reg.async_get(old.entity_id) is None
     assert ent_reg.async_get(new.entity_id).unique_id == "spk_4_sound_machine_switch"
 
 
@@ -477,3 +488,128 @@ async def test_sl_migration_idempotent(hass: HomeAssistant) -> None:
     assert ent_reg.async_get(old.entity_id).unique_id == "spk_4_sound_light_light"
     assert dev_reg.async_get(device.id).identifiers == {(DOMAIN, "spk_4")}
     assert entry.options[CONF_SPEAKER_IPS] == {"spk_4": "192.168.1.72"}
+
+
+async def test_sl_migration_runs_when_camera_left_account(hass: HomeAssistant) -> None:
+    """A pairing whose camera was unpaired pre-upgrade still migrates.
+
+    The pairing comes from the legacy persisted map (via the hub's
+    camera_speaker_pairs), and the stale sweep must then keep the renamed
+    device rather than deleting the user's S&L history.
+    """
+    entry = _migration_entry(hass)
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    old_entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "cam_4_sl_temperature", config_entry=entry
+    )
+    old_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "cam_4_sound_light")},
+    )
+
+    standalone = Baby(uid="baby_4", name="Nursery", camera_uid="", speaker_uid="spk_4")
+    hub = _migration_hub(
+        babies=[standalone],
+        speaker_uid_map={"baby_4": "spk_4"},
+        camera_speaker_pairs={"cam_4": "spk_4"},
+    )
+
+    await _async_migrate_sl_identities(hass, entry, hub)
+    _async_remove_stale_devices(hass, entry, hub)
+
+    migrated_entity = ent_reg.async_get(old_entity.entity_id)
+    assert migrated_entity is not None
+    assert migrated_entity.unique_id == "spk_4_sl_temperature"
+    migrated_device = dev_reg.async_get(old_device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {(DOMAIN, "spk_4")}
+
+
+async def test_stale_sweep_skipped_when_nothing_recognized(hass: HomeAssistant) -> None:
+    """Babies present but zero resolvable devices: don't judge staleness."""
+    entry = _migration_entry(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "spk_4")},
+    )
+
+    hub = _migration_hub(
+        babies=[Baby(uid="baby_4", name="Nursery", camera_uid="", speaker_uid=None)],
+        speaker_uid_map={},
+        camera_speaker_pairs={},
+    )
+    _async_remove_stale_devices(hass, entry, hub)
+
+    assert dev_reg.async_get(device.id) is not None
+
+
+async def test_stale_sweep_protects_persisted_speakers(hass: HomeAssistant) -> None:
+    """A speaker known only from the persisted map survives a transient outage."""
+    entry = _migration_entry(hass)
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "speaker_uid_map": {"baby_4": "spk_4"}}
+    )
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "spk_4")},
+    )
+
+    hub = _migration_hub(
+        babies=[Baby(uid="baby_4", name="Nursery", camera_uid="cam_4", speaker_uid=None)],
+        speaker_uid_map={},
+        camera_speaker_pairs={},
+    )
+    _async_remove_stale_devices(hass, entry, hub)
+
+    assert dev_reg.async_get(device.id) is not None
+
+
+async def test_remove_config_entry_device_denies_live_hardware(hass: HomeAssistant) -> None:
+    from custom_components.nanit import async_remove_config_entry_device
+
+    entry = _migration_entry(hass)
+    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(live_device_uids={"spk_4"}))
+    device = SimpleNamespace(identifiers={(DOMAIN, "spk_4")})
+
+    assert await async_remove_config_entry_device(hass, entry, device) is False
+
+
+async def test_remove_config_entry_device_allows_and_prunes_map(hass: HomeAssistant) -> None:
+    from custom_components.nanit import async_remove_config_entry_device
+
+    entry = _migration_entry(hass)
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "speaker_uid_map": {"baby_4": "spk_4", "baby_5": "spk_5"}}
+    )
+    entry.runtime_data = SimpleNamespace(hub=SimpleNamespace(live_device_uids={"spk_5"}))
+    device = SimpleNamespace(identifiers={(DOMAIN, "spk_4")})
+
+    assert await async_remove_config_entry_device(hass, entry, device) is True
+    assert entry.data["speaker_uid_map"] == {"baby_5": "spk_5"}
+
+
+async def test_sl_migration_persists_rekeyed_map(hass: HomeAssistant) -> None:
+    """The baby-keyed map lands in entry.data only after migration ran."""
+    entry = _migration_entry(hass)
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "speaker_uid_map": {"cam_4": "spk_4"}}
+    )
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    assert entry.data["speaker_uid_map"] == {"baby_4": "spk_4"}
+
+
+async def test_sl_migration_ip_rekey_prefers_speaker_keyed_entry(hass: HomeAssistant) -> None:
+    """When legacy and speaker-keyed IPs both exist, the speaker-keyed one wins."""
+    entry = _migration_entry(
+        hass,
+        options={CONF_SPEAKER_IPS: {"cam_4": "192.168.1.80", "spk_4": "192.168.1.81"}},
+    )
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    assert entry.options[CONF_SPEAKER_IPS] == {"spk_4": "192.168.1.81"}

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -346,3 +346,134 @@ async def test_migrate_version_gt_2_returns_false(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     assert not await async_migrate_entry(hass, entry)
+
+
+# ---------------------------------------------------------------------------
+# S&L identity migration (camera_uid -> speaker_uid)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.nanit import _async_migrate_sl_identities
+from custom_components.nanit.const import CONF_SPEAKER_IPS
+
+Baby = importlib.import_module("aionanit.models").Baby
+
+_MIG_BABY = Baby(uid="baby_4", name="Nursery", camera_uid="cam_4", speaker_uid="spk_4")
+
+
+def _migration_entry(hass: HomeAssistant, options: dict | None = None) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+        options=options or {},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _migration_hub(babies=None, speaker_uid_map=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        babies=babies if babies is not None else [_MIG_BABY],
+        speaker_uid_map=speaker_uid_map if speaker_uid_map is not None else {"baby_4": "spk_4"},
+    )
+
+
+async def test_sl_migration_moves_unique_ids_and_keeps_entity_id(
+    hass: HomeAssistant,
+) -> None:
+    entry = _migration_entry(hass)
+    ent_reg = er.async_get(hass)
+    old = ent_reg.async_get_or_create(
+        "switch", DOMAIN, "cam_4_sound_machine_switch", config_entry=entry
+    )
+    camera_entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "cam_4_temperature", config_entry=entry
+    )
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    migrated = ent_reg.async_get(old.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == "spk_4_sound_machine_switch"
+    assert migrated.entity_id == old.entity_id
+    # Camera entities sharing the prefix are untouched
+    assert ent_reg.async_get(camera_entity.entity_id).unique_id == "cam_4_temperature"
+
+
+async def test_sl_migration_moves_device_identifier(hass: HomeAssistant) -> None:
+    entry = _migration_entry(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "cam_4_sound_light")},
+    )
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    migrated = dev_reg.async_get(device.id)
+    assert migrated is not None
+    assert migrated.identifiers == {(DOMAIN, "spk_4")}
+
+
+async def test_sl_migration_collision_keeps_existing(hass: HomeAssistant) -> None:
+    """If the target unique_id already exists, the old entity is left alone."""
+    entry = _migration_entry(hass)
+    ent_reg = er.async_get(hass)
+    old = ent_reg.async_get_or_create(
+        "switch", DOMAIN, "cam_4_sound_machine_switch", config_entry=entry
+    )
+    new = ent_reg.async_get_or_create(
+        "switch", DOMAIN, "spk_4_sound_machine_switch", config_entry=entry
+    )
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    assert ent_reg.async_get(old.entity_id).unique_id == "cam_4_sound_machine_switch"
+    assert ent_reg.async_get(new.entity_id).unique_id == "spk_4_sound_machine_switch"
+
+
+async def test_sl_migration_rekeys_speaker_ip_options(hass: HomeAssistant) -> None:
+    entry = _migration_entry(hass, options={CONF_SPEAKER_IPS: {"cam_4": "192.168.1.70"}})
+
+    await _async_migrate_sl_identities(hass, entry, _migration_hub())
+
+    assert entry.options[CONF_SPEAKER_IPS] == {"spk_4": "192.168.1.70"}
+
+
+async def test_sl_migration_noop_for_standalone_speaker(hass: HomeAssistant) -> None:
+    """A speaker-only baby has no camera pairing, so there is nothing to migrate."""
+    entry = _migration_entry(hass, options={CONF_SPEAKER_IPS: {"spk_5": "192.168.1.71"}})
+    standalone = Baby(uid="baby_5", name="Den", camera_uid="", speaker_uid="spk_5")
+
+    await _async_migrate_sl_identities(
+        hass, entry, _migration_hub(babies=[standalone], speaker_uid_map={"baby_5": "spk_5"})
+    )
+
+    assert entry.options[CONF_SPEAKER_IPS] == {"spk_5": "192.168.1.71"}
+
+
+async def test_sl_migration_idempotent(hass: HomeAssistant) -> None:
+    entry = _migration_entry(hass, options={CONF_SPEAKER_IPS: {"cam_4": "192.168.1.72"}})
+    ent_reg = er.async_get(hass)
+    old = ent_reg.async_get_or_create(
+        "light", DOMAIN, "cam_4_sound_light_light", config_entry=entry
+    )
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "cam_4_sound_light")},
+    )
+
+    hub = _migration_hub()
+    await _async_migrate_sl_identities(hass, entry, hub)
+    await _async_migrate_sl_identities(hass, entry, hub)
+
+    assert ent_reg.async_get(old.entity_id).unique_id == "spk_4_sound_light_light"
+    assert dev_reg.async_get(device.id).identifiers == {(DOMAIN, "spk_4")}
+    assert entry.options[CONF_SPEAKER_IPS] == {"spk_4": "192.168.1.72"}

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -463,8 +463,8 @@ async def test_async_get_config_entry_diagnostics_returns_expected_structure() -
     assert "config_entry_data" in result
     assert "config_entry_options" in result
     assert "cameras" in result
-    assert "cam_1" in result["cameras"]
-    assert result["cameras"]["cam_1"]["push_coordinator"]["connected"] is True
+    assert "camera_0" in result["cameras"]
+    assert result["cameras"]["camera_0"]["push_coordinator"]["connected"] is True
 
 
 async def test_async_get_config_entry_diagnostics_redacts_sensitive_fields() -> None:
@@ -500,7 +500,8 @@ async def test_async_get_config_entry_diagnostics_redacts_sensitive_fields() -> 
     assert result["config_entry_options"]["camera_ips"] == REDACTED
     assert result["config_entry_options"]["speaker_ip"] == REDACTED
     assert result["config_entry_options"]["speaker_ips"] == REDACTED
-    assert result["cameras"]["cam_1"]["baby_uid"] == REDACTED
+    assert result["cameras"]["camera_0"]["baby_uid"] == REDACTED
+    assert result["cameras"]["camera_0"]["baby_name"] == REDACTED
 
 
 async def test_async_get_config_entry_diagnostics_includes_cloud_data_when_present() -> None:
@@ -523,7 +524,7 @@ async def test_async_get_config_entry_diagnostics_includes_cloud_data_when_prese
 
     result = await async_get_config_entry_diagnostics(MagicMock(), entry)
 
-    cloud_diag = result["cameras"]["cam_1"]["cloud_coordinator"]
+    cloud_diag = result["cameras"]["camera_0"]["cloud_coordinator"]
     assert cloud_diag["last_update_success"] is False
     assert cloud_diag["last_exception"] == "cloud boom"
     assert cloud_diag["data"][0]["event_type"] == "MOTION"

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -55,7 +55,9 @@ def _sl_coordinator(
     coordinator.baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1")
     coordinator.last_update_success = last_update_success
     coordinator.connected = True
+    coordinator.via_camera_uid = "cam_1"
     coordinator.sound_light = MagicMock()
+    coordinator.sound_light.speaker_uid = "speaker_1"
     coordinator.sound_light.async_set_light_enabled = AsyncMock()
     coordinator.sound_light.async_set_brightness = AsyncMock()
     coordinator.sound_light.async_set_color = AsyncMock()
@@ -376,18 +378,20 @@ async def test_sl_sound_switch_handles_transport_error_gracefully(
 
 async def test_light_async_setup_entry_adds_entities_for_sound_light_coordinators() -> None:
     sl_coordinator = _sl_coordinator(SoundLightFullState())
-    cam_with_sl = MagicMock(
+    cam_1 = MagicMock(
         push_coordinator=MagicMock(data=None),
         camera=MagicMock(uid="cam_1"),
-        sound_light_coordinator=sl_coordinator,
     )
-    cam_without_sl = MagicMock(
+    cam_2 = MagicMock(
         push_coordinator=MagicMock(data=None),
         camera=MagicMock(uid="cam_2"),
-        sound_light_coordinator=None,
     )
+    speaker = MagicMock(coordinator=sl_coordinator)
     entry = MagicMock(
-        runtime_data=MagicMock(cameras={"cam_1": cam_with_sl, "cam_2": cam_without_sl})
+        runtime_data=MagicMock(
+            cameras={"cam_1": cam_1, "cam_2": cam_2},
+            speakers={"speaker_1": speaker},
+        )
     )
     async_add_entities = MagicMock()
 
@@ -402,19 +406,8 @@ async def test_light_async_setup_entry_adds_entities_for_sound_light_coordinator
 
 async def test_select_async_setup_entry_adds_entities_for_sound_light_coordinators() -> None:
     sl_coordinator = _sl_coordinator(SoundLightFullState())
-    cam_with_sl = MagicMock(
-        push_coordinator=MagicMock(data=None),
-        camera=MagicMock(uid="cam_1"),
-        sound_light_coordinator=sl_coordinator,
-    )
-    cam_without_sl = MagicMock(
-        push_coordinator=MagicMock(data=None),
-        camera=MagicMock(uid="cam_2"),
-        sound_light_coordinator=None,
-    )
-    entry = MagicMock(
-        runtime_data=MagicMock(cameras={"cam_1": cam_with_sl, "cam_2": cam_without_sl})
-    )
+    speaker = MagicMock(coordinator=sl_coordinator)
+    entry = MagicMock(runtime_data=MagicMock(cameras={}, speakers={"speaker_1": speaker}))
     async_add_entities = MagicMock()
 
     await select_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
@@ -426,18 +419,20 @@ async def test_select_async_setup_entry_adds_entities_for_sound_light_coordinato
 
 async def test_switch_async_setup_entry_adds_camera_and_sound_light_switches() -> None:
     sl_coordinator = _sl_coordinator(SoundLightFullState())
-    cam_with_sl = MagicMock(
+    cam_1 = MagicMock(
         push_coordinator=MagicMock(),
         camera=MagicMock(uid="cam_1"),
-        sound_light_coordinator=sl_coordinator,
     )
-    cam_without_sl = MagicMock(
+    cam_2 = MagicMock(
         push_coordinator=MagicMock(),
         camera=MagicMock(uid="cam_2"),
-        sound_light_coordinator=None,
     )
+    speaker = MagicMock(coordinator=sl_coordinator)
     entry = MagicMock(
-        runtime_data=MagicMock(cameras={"cam_1": cam_with_sl, "cam_2": cam_without_sl})
+        runtime_data=MagicMock(
+            cameras={"cam_1": cam_1, "cam_2": cam_2},
+            speakers={"speaker_1": speaker},
+        )
     )
     async_add_entities = MagicMock()
 
@@ -807,7 +802,7 @@ def test_sl_sensor_temperature() -> None:
     entity = NanitSLSensor(coordinator, desc)
 
     assert entity.native_value == pytest.approx(23.46)
-    assert entity.unique_id == "cam_1_sl_temperature"
+    assert entity.unique_id == "speaker_1_sl_temperature"
 
 
 def test_sl_sensor_humidity() -> None:
@@ -855,7 +850,7 @@ def test_sl_connection_mode_sensor() -> None:
     entity = NanitSLConnectionModeSensor(coordinator)
 
     assert entity.native_value == "cloud"
-    assert entity.unique_id == "cam_1_sl_connection_mode"
+    assert entity.unique_id == "speaker_1_sl_connection_mode"
 
 
 def test_sl_connection_mode_sensor_available_with_data() -> None:
@@ -889,7 +884,7 @@ def test_sl_volume_native_value() -> None:
     entity = NanitSoundMachineVolume(coordinator)
 
     assert entity.native_value == 50.0
-    assert entity.unique_id == "cam_1_sound_machine_volume"
+    assert entity.unique_id == "speaker_1_sound_machine_volume"
 
 
 def test_sl_volume_returns_none_when_no_data() -> None:
@@ -947,10 +942,12 @@ async def test_sensor_async_setup_entry_creates_sl_sensors() -> None:
     sl_coordinator = _sl_coordinator(SoundLightFullState())
     cam_data = MagicMock(
         push_coordinator=_push_coordinator(_camera_state()),
-        sound_light_coordinator=sl_coordinator,
         network_coordinator=None,
     )
-    entry = MagicMock(runtime_data=MagicMock(cameras={"cam_1": cam_data}))
+    speaker = MagicMock(coordinator=sl_coordinator)
+    entry = MagicMock(
+        runtime_data=MagicMock(cameras={"cam_1": cam_data}, speakers={"speaker_1": speaker})
+    )
     async_add_entities = MagicMock()
 
     await sensor_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
@@ -964,12 +961,8 @@ async def test_number_async_setup_entry_creates_sl_volume() -> None:
     from custom_components.nanit import number as number_platform
 
     sl_coordinator = _sl_coordinator(SoundLightFullState())
-    cam_data = MagicMock(
-        push_coordinator=_push_coordinator(_camera_state()),
-        camera=MagicMock(uid="cam_1"),
-        sound_light_coordinator=sl_coordinator,
-    )
-    entry = MagicMock(runtime_data=MagicMock(cameras={"cam_1": cam_data}))
+    speaker = MagicMock(coordinator=sl_coordinator)
+    entry = MagicMock(runtime_data=MagicMock(cameras={}, speakers={"speaker_1": speaker}))
     async_add_entities = MagicMock()
 
     await number_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
@@ -987,9 +980,11 @@ async def test_binary_sensor_async_setup_entry_creates_sl_connectivity() -> None
     cam_data = MagicMock(
         push_coordinator=_push_coordinator(_camera_state()),
         cloud_coordinator=cloud_coordinator,
-        sound_light_coordinator=sl_coordinator,
     )
-    entry = MagicMock(runtime_data=MagicMock(cameras={"cam_1": cam_data}))
+    speaker = MagicMock(coordinator=sl_coordinator)
+    entry = MagicMock(
+        runtime_data=MagicMock(cameras={"cam_1": cam_data}, speakers={"speaker_1": speaker})
+    )
     async_add_entities = MagicMock()
 
     await binary_sensor_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
@@ -1061,9 +1056,20 @@ def test_sl_entity_device_info() -> None:
     entity = NanitSoundLightLight(coordinator)
     info = entity.device_info
 
-    assert ("nanit", "cam_1_sound_light") in info["identifiers"]
+    assert ("nanit", "speaker_1") in info["identifiers"]
     assert info["name"] == "Nursery Sound & Light"
     assert info["manufacturer"] == "Nanit"
+    assert info["via_device"] == ("nanit", "cam_1")
+
+
+def test_sl_entity_device_info_standalone_has_no_via_device() -> None:
+    coordinator = _sl_coordinator(SoundLightFullState())
+    coordinator.via_camera_uid = None
+    entity = NanitSoundLightLight(coordinator)
+    info = entity.device_info
+
+    assert ("nanit", "speaker_1") in info["identifiers"]
+    assert "via_device" not in info
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this do

Second PR of the merge plan in #102, in two connected parts.

**Setup no longer requires a camera** (#79). The hub now walks the
account's babies and sets up whatever devices exist: camera only, Sound &
Light only, or both. A speaker-only account gets a fully working entry.
Failures are per device, so a dead camera no longer blocks a working
speaker (or the other way round), and setup only raises when nothing on
the account could start. One wrinkle worth knowing: aionanit's `Baby`
model requires `camera_uid` and its parser raises on an account whose
baby has no camera, so the hub falls back to parsing the raw `/babies`
response itself and treats an absent camera uid as "no camera". I kept
aionanit untouched since it has its own release cycle; making the field
optional there can follow up separately, and the fallback covers current
releases either way.

**S&L identity moves from the camera's uid to the speaker's own uid.**
Until now every S&L entity unique id was `{camera_uid}_{key}` and the
device identifier was `{camera_uid}_sound_light`, which cannot exist for
a camera-less account. New installs now key everything on the speaker
uid. Existing installs migrate automatically on first start:

- Entity unique ids move via `async_migrate_entries`, scoped to an
  explicit list of S&L suffixes so camera entities sharing the prefix are
  untouched. Every migrated entity keeps its entity id and history.
- The device registry identifier moves via `async_update_device`, keeping
  the device's name, area, and user customizations.
- `via_device` now links to the camera only when the baby actually has
  one.
- Manual speaker IPs in the options are re-keyed by speaker uid.

The migration runs during setup (after the account scan resolves the
camera-to-speaker pairing, before platforms register entities) rather
than as a config entry version bump, because the pairing needed to
translate the ids comes from the account scan and may not be in older
installs' stored data. It is idempotent and a no-op once done or on
fresh installs.

The options flow follows: you now pick a baby rather than a camera, only
the IP fields for devices that baby has are shown, and a speaker-only
baby is configurable at all (it wasn't before).

The entity registration snapshots change in this PR, deliberately: the
S&L unique ids are the point. The baseline (camera-only) snapshots are
byte-identical, and a new speaker-only scenario is snapshotted.

A few things came out of an adversarial review pass I ran on the
migration before opening this (some with executed repros), all fixed
here:

- A pairing whose camera left the account before the upgrade still
  migrates: pairings come from live babies plus the legacy persisted
  map, and the re-keyed map is persisted only after the migration has
  consumed the legacy shape, so an interrupted first boot keeps it.
- The stale-device sweep detaches devices from this entry rather than
  deleting them outright (a device shared with a second Nanit account
  is never yanked from the other entry), protects persisted and
  pairing-derived speaker identifiers, and skips entirely when
  resolution recognized nothing that boot.
- New `async_remove_config_entry_device` hook: hardware the account no
  longer reports can be deleted from the device page (previously there
  was no Delete button at all), and deleting a speaker prunes it from
  the persisted map so it stays gone. The map deliberately shields
  speakers from transient API omissions, so removal needs that explicit
  user action.
- An account with babies but zero resolvable devices now raises so HA
  retries, instead of loading a healthy-looking entry with no entities.
- The raw /babies fallback validates uid type and shape before values
  can reach registry identifiers, storage keys, or URLs, skips
  malformed rows, and carries the same timeout as the library path.

Diagnostics gains a speakers section (connection state, mode, current
S&L state). While there I switched both the cameras and speakers
sections to index keys and added the baby name to the redaction list:
`async_redact_data` never redacts dict keys, so the uid-keyed sections
were leaking the exact ids the redaction list names.

## How I tested this

`just check` green: ruff, mypy strict, 430 unit tests (85% coverage), 226
aionanit tests. New tests cover the hub combinations (speaker only,
camera plus speaker, each side failing with the other surviving, the raw
/babies fallback incl. malformed rows, legacy map and IP shapes) and the
migration both ways (existing registry entries migrate with entity id
preserved, camera entities untouched, the camera-left-the-account path,
collision cleanup, sweep guards, the device removal hook, options
re-key, idempotency, fresh installs get speaker-keyed ids via the
snapshots).

Dev instance: upgraded in place over a config volume carrying the
pre-migration state from #105's verification (all nine S&L entities
keyed on the camera uid, the legacy `_sound_light` device identifier,
and the legacy camera-keyed speaker map in the entry data). On first
start every S&L entity kept its exact entity id and registry row with
the unique id moved to the speaker uid, the device kept its registry row
with the identifier renamed and via_device still pointing at the camera,
the persisted map re-keyed, and camera entities were untouched. Recorder
history is continuous across the migration (checked the temperature and
humidity graphs spanning it). A config entry reload later in the session
re-ran the migration as a clean no-op, so idempotency also got a live
check. Speaker-only cannot be tested live here (my account has a
camera); that path is covered by the hub tests and raw-parse fixtures.

## Checklist

- [x] `just check` passes (lint, types, tests)
- [x] Tested with dev HA instance (`just dev`) and verified the change works
