### PR TITLE
feat: add S&L battery, charging, wifi, and firmware sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 
 - **Standalone Sound & Light support** (#79): the integration no longer requires a camera on the account. Setup now creates whatever devices exist per baby, so a Sound & Light Machine works on its own, alongside a camera, or on an account mixing both. A failed camera no longer blocks a working speaker (and the other way round); setup only fails when nothing on the account could start.
 - **Devices for hardware no longer on the account can now be deleted** from the device page. Deleting a speaker also clears it from the persisted speaker map, so it stays gone (the map otherwise deliberately shields speakers from transient API omissions).
+- **New Sound & Light sensors**: battery level (the device reports a coarse five-step state of charge), battery charging, firmware version (diagnostic), and WiFi signal strength (diagnostic, disabled by default, with SSID/BSSID/channel as attributes). Battery and WiFi refresh with the 30 second poll; firmware is fetched once per start. The queries are fire-and-forget on the wire, so a speaker that ignores them cannot delay commands.
 - Protobuf schema (`sound_light.proto`) with generated code and a CI drift check, replacing the hand-rolled S&L wire parser.
 - `websockets` (>= 13) as an integration requirement, used by the S&L transport.
 

--- a/custom_components/nanit/aionanit_sl/models.py
+++ b/custom_components/nanit/aionanit_sl/models.py
@@ -42,6 +42,15 @@ class SoundLightFullState:
     temperature_c: float | None = None
     humidity_pct: float | None = None
 
+    # Diagnostics (from the GetStatus / Network / Firmware query types)
+    battery_percent: int | None = None
+    battery_charging: bool | None = None
+    wifi_rssi: int | None = None
+    wifi_ssid: str | None = None
+    wifi_bssid: str | None = None
+    wifi_channel: int | None = None
+    firmware_version: str | None = None
+
     # Routines
     routines: tuple[SoundLightRoutine, ...] = ()
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -78,6 +78,18 @@ _INITIAL_STATE_INTERVAL = 0.5  # seconds
 
 _NO_SOUND = "No sound"
 
+# Transport device-view keys that pass straight through to the state's
+# diagnostics fields (parsed from GetStatus / Network / Firmware responses).
+_DIAGNOSTIC_FIELDS = (
+    "battery_percent",
+    "battery_charging",
+    "wifi_rssi",
+    "wifi_ssid",
+    "wifi_bssid",
+    "wifi_channel",
+    "firmware_version",
+)
+
 
 def _proto_float32(value: Any) -> Any:
     """Round a float through protobuf's float32 wire precision.
@@ -306,6 +318,9 @@ class NanitSoundLight:
         try:
             await self._api.send_saved_sounds_request(self._speaker_uid)
             await self._api.send_ping_for_state(self._speaker_uid)
+            # Prime the diagnostics too so battery/wifi/firmware sensors
+            # populate at startup instead of waiting for the first poll.
+            await self._send_diagnostics_queries()
             for _ in range(_INITIAL_STATE_ATTEMPTS):
                 if _has_usable_state(self._api.get_device_state(self._speaker_uid)):
                     break
@@ -674,6 +689,11 @@ class NanitSoundLight:
             updates["temperature_c"] = view["temperature"]
         if "humidity" in view:
             updates["humidity_pct"] = view["humidity"]
+        # Diagnostics parsed from the GetStatus / Network / Firmware
+        # responses; the transport already sanitizes the device strings.
+        for field in _DIAGNOSTIC_FIELDS:
+            if field in view:
+                updates[field] = view[field]
         # The lamp emits iff isOn && brightness > 0 && !noColor (validated
         # on-device). Only computed once power and brightness are both known,
         # so a restored value isn't clobbered by a partial first frame.
@@ -726,6 +746,12 @@ class NanitSoundLight:
         Real-time state arrives via push; this reconciles optimistic state,
         keeps temperature/humidity fresh, and (via the transport) re-opens
         dropped sockets. It does NOT tear the connection down.
+
+        Each cycle also refreshes the diagnostics: battery and wifi ride
+        their own query request types every poll, firmware only until a
+        version is known (it's static). The queries are fire-and-forget
+        inside the transport, so a device that ignores them can't stall
+        user commands.
         """
         try:
             while not self._stopped:
@@ -734,6 +760,7 @@ class NanitSoundLight:
                     return
                 try:
                     await self._api.send_ping_for_state(self._speaker_uid)
+                    await self._send_diagnostics_queries()
                     await asyncio.sleep(_POLL_SETTLE)
                     self._ingest_device_state()
                     self._on_connection_change(self._speaker_uid)
@@ -741,3 +768,10 @@ class NanitSoundLight:
                     _LOGGER.debug("S&L %s poll failed: %s", self._speaker_uid, err)
         except asyncio.CancelledError:
             return
+
+    async def _send_diagnostics_queries(self) -> None:
+        """Request battery + wifi (every cycle) and firmware (until known)."""
+        await self._api.send_status_request(self._speaker_uid)
+        await self._api.send_network_request(self._speaker_uid)
+        if self._state.firmware_version is None:
+            await self._api.send_firmware_request(self._speaker_uid)

--- a/custom_components/nanit/binary_sensor.py
+++ b/custom_components/nanit/binary_sensor.py
@@ -90,9 +90,10 @@ async def async_setup_entry(
             for cloud_desc in CLOUD_BINARY_SENSORS:
                 entities.append(NanitCloudBinarySensor(cam_data.cloud_coordinator, cloud_desc))
 
-    # Sound & Light connectivity sensor
+    # Sound & Light sensors
     for speaker_data in entry.runtime_data.speakers.values():
         entities.append(NanitSLConnectivitySensor(speaker_data.coordinator))
+        entities.append(NanitSLChargingSensor(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -207,4 +208,26 @@ class NanitSLConnectivitySensor(NanitSoundLightEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return True when the S&L WebSocket is connected."""
         result: bool = self.coordinator.connected
+        return result
+
+
+class NanitSLChargingSensor(NanitSoundLightEntity, BinarySensorEntity):
+    """Battery charging indicator for the Sound & Light Machine."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sl_charging"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the device reports it's charging."""
+        if self.coordinator.data is None:
+            return None
+        result: bool | None = self.coordinator.data.battery_charging
         return result

--- a/custom_components/nanit/icons.json
+++ b/custom_components/nanit/icons.json
@@ -1,14 +1,29 @@
 {
   "entity": {
     "sensor": {
-      "temperature": { "default": "mdi:thermometer" },
-      "humidity": { "default": "mdi:water-percent" },
-      "light": { "default": "mdi:brightness-6" }
+      "temperature": {
+        "default": "mdi:thermometer"
+      },
+      "humidity": {
+        "default": "mdi:water-percent"
+      },
+      "light": {
+        "default": "mdi:brightness-6"
+      },
+      "sl_firmware": {
+        "default": "mdi:chip"
+      }
     },
     "binary_sensor": {
-      "motion": { "default": "mdi:motion-sensor" },
-      "sound": { "default": "mdi:ear-hearing" },
-      "connectivity": { "default": "mdi:wifi" }
+      "motion": {
+        "default": "mdi:motion-sensor"
+      },
+      "sound": {
+        "default": "mdi:ear-hearing"
+      },
+      "connectivity": {
+        "default": "mdi:wifi"
+      }
     },
     "switch": {
       "camera_power": {
@@ -30,7 +45,9 @@
     },
     "number": {},
     "camera": {
-      "camera": { "default": "mdi:baby-face-outline" }
+      "camera": {
+        "default": "mdi:baby-face-outline"
+      }
     }
   }
 }

--- a/custom_components/nanit/sensor.py
+++ b/custom_components/nanit/sensor.py
@@ -43,7 +43,7 @@ class NanitSensorEntityDescription(SensorEntityDescription):
 class NanitSLSensorEntityDescription(SensorEntityDescription):
     """Description for Nanit Sound & Light sensor."""
 
-    value_fn: Callable[[SoundLightFullState], float | int | None]
+    value_fn: Callable[[SoundLightFullState], str | float | int | None]
 
 
 SENSORS: tuple[NanitSensorEntityDescription, ...] = (
@@ -98,6 +98,21 @@ SL_SENSORS: tuple[NanitSLSensorEntityDescription, ...] = (
         value_fn=lambda state: (
             round(state.humidity_pct, 2) if state.humidity_pct is not None else None
         ),
+    ),
+    NanitSLSensorEntityDescription(
+        key="sl_battery",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # The device reports a coarse 5-bucket state of charge, mapped to
+        # representative percentages by the transport.
+        value_fn=lambda state: state.battery_percent,
+    ),
+    NanitSLSensorEntityDescription(
+        key="sl_firmware",
+        translation_key="sl_firmware",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: state.firmware_version,
     ),
 )
 
@@ -159,6 +174,7 @@ async def async_setup_entry(
         for sl_description in SL_SENSORS:
             entities.append(NanitSLSensor(speaker_data.coordinator, sl_description))
         entities.append(NanitSLConnectionModeSensor(speaker_data.coordinator))
+        entities.append(NanitSLWifiSensor(speaker_data.coordinator))
 
     async_add_entities(entities)
 
@@ -202,11 +218,55 @@ class NanitSLSensor(NanitSoundLightEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_{description.key}"
 
     @property
-    def native_value(self) -> float | int | None:
+    def native_value(self) -> str | float | int | None:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
             return None
         return self.entity_description.value_fn(self.coordinator.data)
+
+
+class NanitSLWifiSensor(NanitSoundLightEntity, SensorEntity):
+    """WiFi signal-strength sensor for the S&L, SSID/BSSID/channel as attrs.
+
+    Diagnostic and registry-disabled by default, matching the pattern from
+    nanit-sound-light: RSSI updates every poll cycle, so keeping it off by
+    default avoids recorder churn for users who don't care.
+    """
+
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "sl_wifi_signal"
+
+    def __init__(
+        self,
+        coordinator: NanitSoundLightCoordinator,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.sound_light.speaker_uid}_sl_wifi_signal"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the WiFi RSSI in dBm."""
+        if self.coordinator.data is None:
+            return None
+        result: int | None = self.coordinator.data.wifi_rssi
+        return result
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int | None]:
+        """Return SSID / BSSID / channel as attributes."""
+        state = self.coordinator.data
+        if state is None:
+            return {}
+        return {
+            "ssid": state.wifi_ssid,
+            "bssid": state.wifi_bssid,
+            "channel": state.wifi_channel,
+        }
 
 
 class NanitSLConnectionModeSensor(NanitSoundLightEntity, SensorEntity):

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -116,6 +116,12 @@
       },
       "wifi_frequency": {
         "name": "WiFi Frequency"
+      },
+      "sl_wifi_signal": {
+        "name": "WiFi Signal Strength"
+      },
+      "sl_firmware": {
+        "name": "Firmware"
       }
     },
     "binary_sensor": {

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -116,6 +116,12 @@
       },
       "wifi_frequency": {
         "name": "WiFi Frequency"
+      },
+      "sl_wifi_signal": {
+        "name": "WiFi Signal Strength"
+      },
+      "sl_firmware": {
+        "name": "Firmware"
       }
     },
     "binary_sensor": {

--- a/tests/unit/snapshots/test_entity_registration.ambr
+++ b/tests/unit/snapshots/test_entity_registration.ambr
@@ -58,6 +58,18 @@
       'unique_id': 'cam_1_connectivity',
     }),
     dict({
+      'class': 'NanitSLChargingSensor',
+      'device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'unique_id': 'speaker_1_sl_charging',
+    }),
+    dict({
       'class': 'NanitSLConnectivitySensor',
       'device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
       'device_identifiers': list([
@@ -74,6 +86,18 @@
 # ---
 # name: TestEntityRegistration.test_binary_sensor[speaker_only]
   list([
+    dict({
+      'class': 'NanitSLChargingSensor',
+      'device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'unique_id': 'speaker_1_sl_charging',
+    }),
     dict({
       'class': 'NanitSLConnectivitySensor',
       'device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
@@ -449,6 +473,19 @@
       'unique_id': 'cam_1_wifi_ssid',
     }),
     dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': None,
+      'unique_id': 'speaker_1_sl_battery',
+    }),
+    dict({
       'class': 'NanitSLConnectionModeSensor',
       'device_class': <SensorDeviceClass.ENUM: 'enum'>,
       'device_identifiers': list([
@@ -460,6 +497,19 @@
       'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
       'translation_key': 'sl_connection_mode',
       'unique_id': 'speaker_1_sl_connection_mode',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': None,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_firmware',
+      'unique_id': 'speaker_1_sl_firmware',
     }),
     dict({
       'class': 'NanitSLSensor',
@@ -486,12 +536,38 @@
       'entity_category': None,
       'translation_key': 'sl_temperature',
       'unique_id': 'speaker_1_sl_temperature',
+    }),
+    dict({
+      'class': 'NanitSLWifiSensor',
+      'device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_wifi_signal',
+      'unique_id': 'speaker_1_sl_wifi_signal',
     }),
   ])
 # ---
 # name: TestEntityRegistration.test_sensor[speaker_only]
   list([
     dict({
+      'class': 'NanitSLSensor',
+      'device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': None,
+      'translation_key': None,
+      'unique_id': 'speaker_1_sl_battery',
+    }),
+    dict({
       'class': 'NanitSLConnectionModeSensor',
       'device_class': <SensorDeviceClass.ENUM: 'enum'>,
       'device_identifiers': list([
@@ -503,6 +579,19 @@
       'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
       'translation_key': 'sl_connection_mode',
       'unique_id': 'speaker_1_sl_connection_mode',
+    }),
+    dict({
+      'class': 'NanitSLSensor',
+      'device_class': None,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_firmware',
+      'unique_id': 'speaker_1_sl_firmware',
     }),
     dict({
       'class': 'NanitSLSensor',
@@ -529,6 +618,19 @@
       'entity_category': None,
       'translation_key': 'sl_temperature',
       'unique_id': 'speaker_1_sl_temperature',
+    }),
+    dict({
+      'class': 'NanitSLWifiSensor',
+      'device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+      'device_identifiers': list([
+        tuple(
+          'nanit',
+          'speaker_1',
+        ),
+      ]),
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'translation_key': 'sl_wifi_signal',
+      'unique_id': 'speaker_1_sl_wifi_signal',
     }),
   ])
 # ---

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -954,8 +954,8 @@ async def test_sensor_async_setup_entry_creates_sl_sensors() -> None:
     await sensor_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
 
     entities = async_add_entities.call_args.args[0]
-    # 3 camera sensors + 2 S&L sensors + 1 connection mode = 6
-    assert len(entities) == 6
+    # 3 camera + 4 S&L (temp, humidity, battery, firmware) + connection mode + wifi = 9
+    assert len(entities) == 9
 
 
 async def test_number_async_setup_entry_creates_sl_volume() -> None:
@@ -991,8 +991,8 @@ async def test_binary_sensor_async_setup_entry_creates_sl_connectivity() -> None
     await binary_sensor_platform.async_setup_entry(MagicMock(), entry, async_add_entities)
 
     entities = async_add_entities.call_args.args[0]
-    # 1 push binary sensor + 2 cloud binary sensors + 1 S&L connectivity = 4
-    assert len(entities) == 4
+    # 1 push + 2 cloud + S&L connectivity + S&L charging = 5
+    assert len(entities) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1556,3 +1556,74 @@ async def test_night_light_skips_restore_for_stale_state(stale_state: str) -> No
 
     assert entity.is_on is None
     assert entity.brightness is None
+
+
+# ---------------------------------------------------------------------------
+# S&L diagnostics sensors (battery, charging, wifi, firmware)
+# ---------------------------------------------------------------------------
+
+
+def test_sl_battery_sensor() -> None:
+    from custom_components.nanit.sensor import SL_SENSORS, NanitSLSensor
+
+    desc = next(d for d in SL_SENSORS if d.key == "sl_battery")
+    state = SoundLightFullState(battery_percent=75)
+    entity = NanitSLSensor(_sl_coordinator(state), desc)
+
+    assert entity.native_value == 75
+    assert entity.unique_id == "speaker_1_sl_battery"
+
+
+def test_sl_firmware_sensor() -> None:
+    from custom_components.nanit.sensor import SL_SENSORS, NanitSLSensor
+
+    desc = next(d for d in SL_SENSORS if d.key == "sl_firmware")
+    state = SoundLightFullState(firmware_version="1.3.1")
+    entity = NanitSLSensor(_sl_coordinator(state), desc)
+
+    assert entity.native_value == "1.3.1"
+    assert entity.unique_id == "speaker_1_sl_firmware"
+
+
+def test_sl_wifi_sensor_value_and_attributes() -> None:
+    from custom_components.nanit.sensor import NanitSLWifiSensor
+
+    state = SoundLightFullState(
+        wifi_rssi=-52,
+        wifi_ssid="HomeWifi",
+        wifi_bssid="aa:bb:cc:dd:ee:ff",
+        wifi_channel=11,
+    )
+    entity = NanitSLWifiSensor(_sl_coordinator(state))
+
+    assert entity.native_value == -52
+    assert entity.unique_id == "speaker_1_sl_wifi_signal"
+    assert entity.extra_state_attributes == {
+        "ssid": "HomeWifi",
+        "bssid": "aa:bb:cc:dd:ee:ff",
+        "channel": 11,
+    }
+    assert entity.entity_registry_enabled_default is False
+
+
+def test_sl_wifi_sensor_no_data() -> None:
+    from custom_components.nanit.sensor import NanitSLWifiSensor
+
+    entity = NanitSLWifiSensor(_sl_coordinator(None))
+
+    assert entity.native_value is None
+    assert entity.extra_state_attributes == {}
+
+
+def test_sl_charging_sensor() -> None:
+    from custom_components.nanit.binary_sensor import NanitSLChargingSensor
+
+    entity = NanitSLChargingSensor(_sl_coordinator(SoundLightFullState(battery_charging=True)))
+    assert entity.is_on is True
+    assert entity.unique_id == "speaker_1_sl_charging"
+
+    entity_off = NanitSLChargingSensor(_sl_coordinator(SoundLightFullState(battery_charging=False)))
+    assert entity_off.is_on is False
+
+    entity_unknown = NanitSLChargingSensor(_sl_coordinator(None))
+    assert entity_unknown.is_on is None

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -608,3 +608,75 @@ class TestReviewRegressions:
         await _flushed(sl)
 
         assert sl.state.brightness is None
+
+
+class TestDiagnostics:
+    async def test_diagnostics_map_onto_model(self) -> None:
+        sl = _make_sound_light()
+        api = _mock_transport(sl)
+        api.get_device_state.return_value = {
+            "battery_percent": 75,
+            "battery_charging": True,
+            "wifi_rssi": -52,
+            "wifi_ssid": "HomeWifi",
+            "wifi_bssid": "aa:bb:cc:dd:ee:ff",
+            "wifi_channel": 11,
+            "firmware_version": "1.3.1",
+        }
+        sl._ingest_device_state()
+
+        s = sl.state
+        assert s.battery_percent == 75
+        assert s.battery_charging is True
+        assert s.wifi_rssi == -52
+        assert s.wifi_ssid == "HomeWifi"
+        assert s.wifi_bssid == "aa:bb:cc:dd:ee:ff"
+        assert s.wifi_channel == 11
+        assert s.firmware_version == "1.3.1"
+
+    async def test_charging_false_flows_through(self) -> None:
+        """isCharging=False must land as False, not be dropped as falsy."""
+        sl = _make_sound_light()
+        api = _mock_transport(sl)
+        api.get_device_state.return_value = {"battery_charging": False}
+        sl._ingest_device_state()
+        assert sl.state.battery_charging is False
+
+    async def test_diagnostics_queries_fetch_firmware_only_until_known(self) -> None:
+        sl = _make_sound_light()
+        api = _mock_transport(sl)
+        api.send_status_request = AsyncMock()
+        api.send_network_request = AsyncMock()
+        api.send_firmware_request = AsyncMock()
+
+        await sl._send_diagnostics_queries()
+        assert api.send_status_request.await_count == 1
+        assert api.send_network_request.await_count == 1
+        assert api.send_firmware_request.await_count == 1
+
+        api.get_device_state.return_value = {"firmware_version": "1.3.1"}
+        sl._ingest_device_state()
+        await sl._send_diagnostics_queries()
+        # Battery + wifi refresh every cycle; firmware is static, fetched once
+        assert api.send_status_request.await_count == 2
+        assert api.send_network_request.await_count == 2
+        assert api.send_firmware_request.await_count == 1
+
+    async def test_poll_loop_issues_diagnostics_queries(self, monkeypatch) -> None:
+        monkeypatch.setattr(sound_light_mod, "_POLL_INTERVAL", 0.01)
+        monkeypatch.setattr(sound_light_mod, "_POLL_SETTLE", 0)
+        sl = _make_sound_light()
+        api = _mock_transport(sl)
+        api.send_ping_for_state = AsyncMock()
+        api.send_status_request = AsyncMock()
+        api.send_network_request = AsyncMock()
+        api.send_firmware_request = AsyncMock()
+
+        task = asyncio.get_running_loop().create_task(sl._poll_loop())
+        await asyncio.sleep(0.05)
+        sl._stopped = True
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+        assert api.send_status_request.await_count >= 1
+        assert api.send_network_request.await_count >= 1


### PR DESCRIPTION
> Stacked on #109, which should merge first: this diff shows only the sensor work once #109 lands.

## What does this do

Third PR of the merge plan in #102: the extra Sound & Light sensors.
Purely additive, no unique id or behavior changes to existing entities.

The transport ported in #105 already carried the query senders and
parsers for the `GetStatus`, `Network`, and `Firmware` request types,
unused until now. This wires them into the facade's 30 second poll:
battery and wifi refresh every cycle, firmware is fetched once per start
(it's static), and all three are primed at startup so the sensors
populate right away. The queries are fire-and-forget on the wire (no
ack awaited), so a speaker that ignores them cannot stall user commands.

New entities per speaker:

- **Battery** sensor. The device reports a coarse five-step state of
  charge, mapped to representative percentages (10/25/50/75/90).
- **Charging** binary sensor. The device omits the charging flag when not
  charging, and the parser treats absence in a battery report as "not
  charging", so unplugging flips it off rather than sticking.
- **Firmware version** diagnostic sensor.
- **WiFi signal strength** diagnostic sensor, disabled by default (it
  updates every poll cycle, which is recorder churn most people don't
  want), with SSID, BSSID, and channel as attributes.

Device strings (SSID, BSSID, firmware) go through the transport's
existing sanitizer (length clamp plus printable check) before being
exposed.

## How I tested this

`just check` green: ruff, mypy strict, 439 unit tests (85% coverage), 226
aionanit tests. New tests cover the state mapping (including charging
false flowing through rather than being dropped as falsy), the
firmware-once query cadence, the poll wiring, and each new entity's
values and attributes. Snapshots gain exactly the four new entities in
the full and speaker-only scenarios.

Dev instance: against the real speaker, over the cloud relay (a second
HA instance held the device's single local slot, so this also exercised
relay coexistence). Battery reported 90 (top bucket), firmware matched
the device, and the wifi sensor showed a plausible dBm with SSID, BSSID,
and channel attributes matching the actual access point. Plugging the
power cable in flipped the charging sensor on and unplugging flipped it
back. Firmware was fetched exactly once per setup (verified in the debug
log across two setups). One observable worth noting: right after a
restart the firmware sensor can read unknown for up to one poll cycle
(~30s) while the startup prime races its response; it self-heals on the
next publish.

## Checklist

- [x] `just check` passes (lint, types, tests)
- [x] Tested with dev HA instance (`just dev`) and verified the change works
