### PR TITLE
fix: keep transient failures out of the reauth path, refresh tokens with headroom

### DIFF
--- a/custom_components/nanit/camera.py
+++ b/custom_components/nanit/camera.py
@@ -191,7 +191,7 @@ class NanitCameraEntity(NanitEntity, Camera):
                 "Timed out after %.0fs stopping discarded Nanit stream",
                 _STREAM_STOP_TIMEOUT,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.debug("Failed to stop discarded Nanit stream", exc_info=True)
 
     def _invalidate_stream_if_expired(self) -> None:
@@ -242,7 +242,7 @@ class NanitCameraEntity(NanitEntity, Camera):
         ):
             try:
                 source = await self._camera.async_get_stream_rtmps_url()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.warning("Failed to build RTMPS stream URL", exc_info=True)
                 return None
 
@@ -397,7 +397,7 @@ class NanitCameraEntity(NanitEntity, Camera):
         if self.is_on and stream is not None and stream.outputs():
             try:
                 source = await self._camera.async_get_stream_rtmps_url()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 # Leave the running stream alone — playing until the token
                 # actually dies beats killing it because renewal failed.
                 _LOGGER.warning("Failed to renew RTMPS stream URL", exc_info=True)
@@ -440,7 +440,7 @@ class NanitCameraEntity(NanitEntity, Camera):
             try:
                 await self._async_send_put_streaming(rtmps_url, reconnect_on_failure)
                 return True
-            except Exception:  # noqa: BLE001
+            except Exception:
                 if attempt < _STREAM_START_ATTEMPTS:
                     _LOGGER.debug(
                         "PUT_STREAMING attempt %d/%d failed for camera %s, retrying in %.0fs",
@@ -556,6 +556,6 @@ class NanitCameraEntity(NanitEntity, Camera):
         self._invalidate_stream()
         try:
             await self._camera.async_stop_streaming()
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.debug("Failed to stop streaming before sleep", exc_info=True)
         await self._camera.async_set_settings(sleep_mode=True)

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -440,7 +440,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
                 if isinstance(tracks, list) and all(isinstance(t, str) for t in tracks):
                     kwargs["available_tracks"] = tuple(tracks)
             return SoundLightFullState(**kwargs)
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.debug("Failed to restore S&L state", exc_info=True)
             return None
 
@@ -457,7 +457,7 @@ class NanitSoundLightCoordinator(DataUpdateCoordinator[SoundLightFullState]):
                 data["available_tracks"] = list(state.available_tracks)
             if data:
                 await self._store.async_save(data)
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.debug("Failed to save S&L state", exc_info=True)
 
     @callback

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -143,7 +143,7 @@ class NanitHub:
         if not speaker_uid_map:
             try:
                 speaker_uid_map = await self._discover_speaker_uids()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.debug("Speaker UID discovery from raw API failed", exc_info=True)
 
         # Persist discovered speaker UIDs so they survive restarts
@@ -270,7 +270,7 @@ class NanitHub:
                 await sound_light_coordinator.async_setup()
             except NanitAuthError:
                 raise
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.warning(
                     "Sound & Light Machine coordinator for %s failed to start; "
                     "sound/light entities disabled",

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -5,7 +5,7 @@ homeassistant>=2026.5,<2026.7
 pytest-homeassistant-custom-component>=0.13.333,<0.14
 pytest-cov>=7,<8
 aionanit @ file:packages/aionanit
-ruff>=0.15,<0.16
+ruff>=0.16,<0.17
 mypy>=2.1,<3
 pre-commit>=4,<5
 syrupy>=5,<6

--- a/packages/aionanit/aionanit/auth.py
+++ b/packages/aionanit/aionanit/auth.py
@@ -73,7 +73,13 @@ class TokenManager:
             self._refresh_token = refresh_token
             self._expires_at = _expires_at_from_jwt(access_token, expires_in)
 
-    async def async_get_access_token(self, min_ttl: float = 60.0) -> str:
+    async def async_get_access_token(self, min_ttl: float = 300.0) -> str:
+        """Return a valid access token, refreshing when inside min_ttl.
+
+        The default buffer is five minutes so a transient refresh failure
+        leaves headroom for retries (callers naturally retry on their poll
+        cadence) instead of racing the token's hard expiry.
+        """
         callbacks_to_fire: list[Callable[[str, str], None]] = []
         async with self._lock:
             if time.monotonic() + min_ttl >= self._expires_at:
@@ -98,7 +104,14 @@ class TokenManager:
         except (NanitAuthError, NanitConnectionError):
             raise
         except Exception as err:
-            raise NanitAuthError(f"Token refresh failed: {err}") from err
+            # Anything unexpected here is a transport or parsing hiccup, not
+            # a credential rejection: NanitAuthError must stay reserved for
+            # the explicit rejections the REST layer raises, because callers
+            # translate it into a reauth prompt. Wrapping a transient error
+            # (e.g. a timeout that escaped aiohttp's ClientError hierarchy)
+            # as an auth failure forced users into reauth with a perfectly
+            # valid refresh token.
+            raise NanitConnectionError(f"Token refresh failed: {err}") from err
 
         self._access_token = tokens["access_token"]
         self._refresh_token = tokens["refresh_token"]

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -13,6 +13,7 @@ import aiohttp
 
 from .auth import TokenManager
 from .exceptions import (
+    NanitAuthError,
     NanitCameraUnavailable,
     NanitConnectionError,
     NanitRequestTimeout,
@@ -82,6 +83,7 @@ _MAX_LOCAL_FAILURES_BEFORE_CLOUD: int = 3
 _STALE_CONNECTION_THRESHOLD: float = 300.0  # 5 min — reconnect before send
 _HEALTH_CHECK_INTERVAL: float = 270.0  # 4.5 min — periodic session liveness check
 _FRESH_CONNECTION_WINDOW: float = 10.0  # skip reconnect if connected within this
+_TOKEN_REFRESH_MIN_TTL: float = 360.0  # pre-emptive refresh threshold (> the 330s loop gate)
 _DEFAULT_SENSOR_POLL_INTERVAL: float = 120.0  # 2 min — poll sensors camera doesn't push
 _DEFAULT_PLAYBACK_POLL_INTERVAL: float = 30.0  # 30s — poll GET_PLAYBACK for external changes
 _STREAM_TOKEN_MIN_TTL: float = 3300.0  # Keep 45-minute HA sources inside JWT lifetime
@@ -1073,7 +1075,28 @@ class NanitCamera:
                 # the sleep from the fresh expiry.
                 if self._token_manager.expires_in > 330.0:
                     continue
-                _LOGGER.info("Pre-emptive token refresh: forcing reconnect before expiry")
+                # Refresh FIRST (with enough headroom to actually trigger a
+                # refresh), then reconnect once so the new socket carries the
+                # fresh token. Relying on the reconnect's own token fetch
+                # (min_ttl=60) reconnected with the OLD token here, churning
+                # one reconnect per minute until the final minute before
+                # expiry — which also meant the real refresh always ran with
+                # zero retry runway, so one transient failure at that moment
+                # cascaded into a spurious reauth.
+                _LOGGER.info("Pre-emptive token refresh before expiry")
+                try:
+                    await self._token_manager.async_get_access_token(min_ttl=_TOKEN_REFRESH_MIN_TTL)
+                except NanitConnectionError as err:
+                    # Transient — the current token is still valid for a few
+                    # minutes. Retry shortly instead of bouncing the socket.
+                    _LOGGER.warning("Pre-emptive token refresh failed, retrying soon: %s", err)
+                    await asyncio.sleep(60.0)
+                    continue
+                except NanitAuthError as err:
+                    # Genuine rejection: nothing this loop can do. The next
+                    # consumer-facing token fetch surfaces the reauth.
+                    _LOGGER.error("Token refresh rejected, reauthentication required: %s", err)
+                    return
                 try:
                     await self._transport.async_force_reconnect()
                 except Exception:

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -182,7 +182,10 @@ class NanitRestClient:
                 headers={**NANIT_API_HEADERS, "Authorization": access_token},
                 timeout=_DEFAULT_TIMEOUT,
             )
-        except aiohttp.ClientError as err:
+        except (TimeoutError, aiohttp.ClientError) as err:
+            # TimeoutError: aiohttp's total timeout raises the builtin, not
+            # a ClientError subclass. A hung refresh (observed with flaky
+            # DNS) is transient and must never read as an auth failure.
             raise NanitConnectionError(str(err)) from err
 
         if resp.status == 404:
@@ -191,9 +194,10 @@ class NanitRestClient:
         if resp.status == 401:
             raise NanitAuthError("Access token invalid during refresh")
 
-        # Server-side failures are transient — they must not be treated as
-        # auth errors, or a Nanit outage would force reauth in the caller.
-        if resp.status >= 500:
+        # Server-side failures and throttling are transient — they must not
+        # be treated as auth errors, or a Nanit outage (or a rate limit)
+        # would force reauth in the caller.
+        if resp.status == 429 or resp.status >= 500:
             raise NanitConnectionError(f"Token refresh failed with HTTP {resp.status}")
 
         try:

--- a/packages/aionanit/tests/test_auth.py
+++ b/packages/aionanit/tests/test_auth.py
@@ -190,13 +190,37 @@ class TestRefreshFailure:
         with pytest.raises(NanitAuthError, match="Refresh token expired"):
             await token_manager.async_get_access_token()
 
-    async def test_unexpected_error_wrapped_in_auth_error(
+    async def test_unexpected_error_wrapped_in_connection_error(
         self, token_manager: TokenManager, mock_rest: MagicMock
     ) -> None:
+        """Unexpected refresh errors are transient, never a credential rejection.
+
+        Wrapping them as NanitAuthError forced users into reauth with a
+        perfectly valid refresh token (observed live: a refresh timeout
+        during a DNS outage produced a spurious reauth prompt).
+        """
         mock_rest.async_refresh_token.side_effect = RuntimeError("network down")
         token_manager._expires_at = time.monotonic() - 1
 
-        with pytest.raises(NanitAuthError, match="Token refresh failed"):
+        with pytest.raises(NanitConnectionError, match="Token refresh failed"):
+            await token_manager.async_get_access_token()
+
+    async def test_refresh_timeout_wrapped_in_connection_error(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        mock_rest.async_refresh_token.side_effect = TimeoutError()
+        token_manager._expires_at = time.monotonic() - 1
+
+        with pytest.raises(NanitConnectionError):
+            await token_manager.async_get_access_token()
+
+    async def test_connection_error_propagated(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        mock_rest.async_refresh_token.side_effect = NanitConnectionError("dns down")
+        token_manager._expires_at = time.monotonic() - 1
+
+        with pytest.raises(NanitConnectionError, match="dns down"):
             await token_manager.async_get_access_token()
 
     async def test_connection_error_not_wrapped_in_auth_error(
@@ -221,3 +245,22 @@ class TestRefreshFailure:
 
         assert token_manager.access_token == "initial_access"
         assert token_manager.refresh_token == "initial_refresh"
+
+
+class TestProactiveBuffer:
+    async def test_refreshes_inside_five_minute_buffer(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        """The default buffer refreshes with retry headroom, not last-minute."""
+        token_manager._expires_at = time.monotonic() + 200.0
+        token = await token_manager.async_get_access_token()
+        assert token == "new_access"
+        mock_rest.async_refresh_token.assert_called_once()
+
+    async def test_no_refresh_outside_buffer(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        token_manager._expires_at = time.monotonic() + 400.0
+        token = await token_manager.async_get_access_token()
+        assert token == "initial_access"
+        mock_rest.async_refresh_token.assert_not_called()

--- a/packages/aionanit/tests/test_camera_reliability.py
+++ b/packages/aionanit/tests/test_camera_reliability.py
@@ -315,3 +315,85 @@ async def test_reconnect_completes_with_unresponsive_camera() -> None:
     camera._cancel_sensor_poll()
     camera._cancel_playback_poll()
     camera._cancel_local_probe()
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_refreshes_with_headroom_then_reconnects_once() -> None:
+    """The pre-emptive loop refreshes the token FIRST, then reconnects once.
+
+    Relying on the reconnect's own token fetch (min_ttl=60) reconnected with
+    the old token, churning a reconnect per minute and pushing the real
+    refresh into the final minute before expiry.
+    """
+    camera, token_manager = _make_camera()
+    camera._stopped = False
+    token_manager.expires_in = 50.0
+    camera._transport = MagicMock()
+    camera._transport.connected = True
+
+    order: list[str] = []
+
+    async def _record_refresh(min_ttl: float = 60.0) -> str:
+        order.append(f"refresh:{min_ttl}")
+        return "tok"
+
+    token_manager.async_get_access_token = AsyncMock(side_effect=_record_refresh)
+
+    async def _force_and_stop() -> None:
+        order.append("reconnect")
+        camera._stopped = True
+
+    camera._transport.async_force_reconnect = AsyncMock(side_effect=_force_and_stop)
+
+    with patch("aionanit.camera.asyncio.sleep", AsyncMock(return_value=None)):
+        await asyncio.wait_for(camera._token_refresh_loop(), timeout=0.1)
+
+    assert order == ["refresh:360.0", "reconnect"]
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_transient_failure_retries_without_reconnect() -> None:
+    """A transient refresh failure retries shortly and never bounces the socket."""
+    camera, token_manager = _make_camera()
+    camera._stopped = False
+    token_manager.expires_in = 50.0
+    camera._transport = MagicMock()
+    camera._transport.connected = True
+    camera._transport.async_force_reconnect = AsyncMock()
+
+    calls = 0
+
+    async def _fail_then_stop(min_ttl: float = 60.0) -> str:
+        nonlocal calls
+        calls += 1
+        if calls >= 2:
+            camera._stopped = True
+        raise NanitConnectionError("dns down")
+
+    token_manager.async_get_access_token = AsyncMock(side_effect=_fail_then_stop)
+
+    with patch("aionanit.camera.asyncio.sleep", AsyncMock(return_value=None)):
+        await asyncio.wait_for(camera._token_refresh_loop(), timeout=0.1)
+
+    camera._transport.async_force_reconnect.assert_not_awaited()
+    assert calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_auth_rejection_stops_loop() -> None:
+    """A genuine rejection ends the loop; consumer paths surface the reauth."""
+    from aionanit.exceptions import NanitAuthError
+
+    camera, token_manager = _make_camera()
+    camera._stopped = False
+    token_manager.expires_in = 50.0
+    camera._transport = MagicMock()
+    camera._transport.connected = True
+    camera._transport.async_force_reconnect = AsyncMock()
+
+    token_manager.async_get_access_token = AsyncMock(side_effect=NanitAuthError("rejected"))
+
+    with patch("aionanit.camera.asyncio.sleep", AsyncMock(return_value=None)):
+        await asyncio.wait_for(camera._token_refresh_loop(), timeout=0.1)
+
+    camera._transport.async_force_reconnect.assert_not_awaited()

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -164,6 +164,25 @@ class TestRefreshToken:
             "refresh_token": "new_ref",
         }
 
+    async def test_refresh_timeout_is_connection_error(self, client: NanitRestClient) -> None:
+        """aiohttp's total timeout raises builtin TimeoutError, not ClientError.
+
+        It must map to NanitConnectionError: a hung refresh is transient and
+        must never read as an auth failure (which triggers reauth upstream).
+        """
+        with aioresponses() as m:
+            m.post(REFRESH_URL, exception=TimeoutError())
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_refresh_token("acc", "ref")
+
+    async def test_refresh_rate_limit_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(REFRESH_URL, status=429, payload={"error": "too many requests"})
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_refresh_token("acc", "ref")
+
     async def test_refresh_token_expired(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
             m.post(REFRESH_URL, status=404)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ target-version = "py313"
 line-length = 100
 # Generated protobuf modules are protoc output; keep them byte-identical to
 # the generator (the drift check in CI diffs against a fresh protoc run).
-extend-exclude = ["**/*_pb2.py", "**/*_pb2.pyi"]
+extend-exclude = ["**/*_pb2.py", "**/*_pb2.pyi", "*.md"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## What does this do

Chases down a spurious reauth I hit on my own install. During a DNS blip
my access token happened to need its refresh, the refresh request hung
past its timeout, and the integration demanded reauthentication even
though the refresh token was perfectly valid. Every cloud coordinator
stopped polling at that moment; reloading the entry days later
authenticated fine with the same stored tokens.

The chain: aiohttp's total timeout raises the builtin `TimeoutError`,
not a `ClientError`, so it escaped `async_refresh_token`'s transport
catch and hit `TokenManager`'s catch-all, which wrapped it as
`NanitAuthError`. Callers translate that into `ConfigEntryAuthFailed`,
so one hung request became a reauth prompt.

Three changes in `packages/aionanit`:

- `async_refresh_token` catches `TimeoutError` alongside `ClientError`
  and maps it to `NanitConnectionError`.
- `TokenManager` wraps unexpected refresh errors as
  `NanitConnectionError` instead of `NanitAuthError`. Auth errors stay
  reserved for the explicit rejections the REST layer raises (401, 404,
  error body), because that's the only case where reauth actually helps.
- The camera's pre-emptive refresh loop refreshes the token first, then
  reconnects once with the fresh token. Before, the reconnect fetched
  the token with the default 60 second threshold, so it reconnected
  with the old token: the loop churned one reconnect per minute for six
  minutes every cycle (visible as repeated "Pre-emptive token refresh"
  log lines), and the real refresh always landed in the final minute
  before expiry with zero retry runway. A transient refresh failure now
  retries on a short delay without bouncing the socket; a genuine
  rejection ends the loop and surfaces through the next consumer fetch.

Two smaller postures brought over from nanit-sound-light's refresh
logic, which ran for months without ever producing a spurious reauth:
the default refresh buffer moves from 60 seconds to five minutes (every
consumer now refreshes with retry headroom on its own poll cadence
instead of racing hard expiry), and a 429 on the refresh endpoint is
transient rather than an auth rejection. One further idea from there I
left out to keep this reviewable: refreshing and retrying once when a
data call gets a 401 mid-token-life. Happy to follow up with that if
you want it.

## How I tested this

`just check` green (ruff, mypy strict, 432 unit tests, 259 aionanit
tests). New regression tests: a refresh timeout and an unexpected
refresh error both classify as connection errors while explicit
rejections still propagate as auth errors, the loop refreshes with
headroom then reconnects exactly once, retries transient failures
without touching the socket, and stops on a genuine rejection.

Live: this exact failure occurred on my install (v1.9.0). The log
signature matched the diagnosis (refresh at the 3 hour boundary during
a DNS outage, "Token refresh failed" wrapped as auth), and reloading
the entry with the same stored tokens authenticated immediately,
proving the refresh token was never invalid. The per-minute reconnect
churn is also visible in my logs on every token cycle before this fix.

A dev instance can't observe this quickly (the failure needs a token
refresh boundary coinciding with a network blip), so verification is
the regression tests plus the live diagnosis above. Happy to soak it on
my install once released.

## Checklist

- [x] `just check` passes (lint, types, tests)
- [ ] Tested with dev HA instance (`just dev`) and verified the change works
      (library-level fix; see testing notes above)
