### PR TITLE
fix: catch TimeoutError in all REST methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 ### Fixed
 
 - Transient network failures during token refresh (DNS blips, timeouts, rate limits) no longer trigger a spurious reauthentication prompt. The token refresh loop now refreshes the token before reconnecting, giving retries five minutes of headroom instead of racing hard expiry in the final minute.
+- All REST calls now classify a hung request or response read (the builtin `TimeoutError` aiohttp raises on its total timeout) as a connection error, matching the token refresh fix above, and connection error messages fall back to the exception type name instead of showing up blank. The Sound & Light device token request also gained the standard 15 second timeout it was missing (#113).
 
 ## [1.8.0] – Unreleased
 

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -145,8 +145,8 @@ class NanitRestClient:
                 headers=NANIT_API_HEADERS,
                 timeout=_DEFAULT_TIMEOUT,
             )
-        except aiohttp.ClientError as err:
-            raise NanitConnectionError(str(err)) from err
+        except (TimeoutError, aiohttp.ClientError) as err:
+            raise NanitConnectionError(str(err) or type(err).__name__) from err
 
         if resp.status == 401:
             raise NanitAuthError("Invalid credentials")
@@ -154,7 +154,10 @@ class NanitRestClient:
         # Nanit returns HTTP 482 when MFA is required. Parse the body
         # before raise_for_status() since 482 is non-standard and aiohttp
         # would raise ClientResponseError for it.
-        body = await resp.json()
+        try:
+            body = await resp.json()
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            raise NanitConnectionError(f"Invalid login response: {err}") from err
 
         if "mfa_token" in body:
             raise NanitMfaRequiredError(body["mfa_token"])
@@ -186,7 +189,7 @@ class NanitRestClient:
             # TimeoutError: aiohttp's total timeout raises the builtin, not
             # a ClientError subclass. A hung refresh (observed with flaky
             # DNS) is transient and must never read as an auth failure.
-            raise NanitConnectionError(str(err)) from err
+            raise NanitConnectionError(str(err) or type(err).__name__) from err
 
         if resp.status == 404:
             raise NanitAuthError("Refresh token expired")
@@ -202,7 +205,7 @@ class NanitRestClient:
 
         try:
             body = await resp.json()
-        except (aiohttp.ClientError, ValueError) as err:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
             raise NanitConnectionError(f"Invalid token refresh response: {err}") from err
 
         error_msg = _extract_error_message(body)
@@ -226,8 +229,8 @@ class NanitRestClient:
                 headers={**NANIT_API_HEADERS, "Authorization": access_token},
                 timeout=_DEFAULT_TIMEOUT,
             )
-        except aiohttp.ClientError as err:
-            raise NanitConnectionError(str(err)) from err
+        except (TimeoutError, aiohttp.ClientError) as err:
+            raise NanitConnectionError(str(err) or type(err).__name__) from err
 
         if resp.status == 401:
             raise NanitAuthError("Access token invalid")
@@ -238,7 +241,7 @@ class NanitRestClient:
         resp.raise_for_status()
         try:
             body = await resp.json()
-        except (aiohttp.ClientError, ValueError) as err:
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
             raise NanitConnectionError(f"Invalid babies response: {err}") from err
 
         return [
@@ -279,15 +282,19 @@ class NanitRestClient:
             resp = await self._session.get(
                 f"{self._base_url}/speakers/{speaker_uid}/udtokens",
                 headers=headers,
+                timeout=_DEFAULT_TIMEOUT,
             )
-        except aiohttp.ClientError as err:
-            raise NanitConnectionError(str(err)) from err
+        except (TimeoutError, aiohttp.ClientError) as err:
+            raise NanitConnectionError(str(err) or type(err).__name__) from err
 
         if resp.status == 401:
             raise NanitAuthError("Access token invalid")
 
         resp.raise_for_status()
-        body = await resp.json(content_type=None)
+        try:
+            body = await resp.json(content_type=None)
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            raise NanitConnectionError(f"Invalid udtokens response: {err}") from err
         token: str | None = body.get("user_device_token", {}).get("token")
         if not token:
             raise NanitConnectionError(f"No token in udtokens response for speaker {speaker_uid}")
@@ -306,14 +313,17 @@ class NanitRestClient:
                 headers={**NANIT_API_HEADERS, "Authorization": access_token},
                 timeout=_DEFAULT_TIMEOUT,
             )
-        except aiohttp.ClientError as err:
-            raise NanitConnectionError(str(err)) from err
+        except (TimeoutError, aiohttp.ClientError) as err:
+            raise NanitConnectionError(str(err) or type(err).__name__) from err
 
         if resp.status == 401:
             raise NanitAuthError("Access token invalid")
 
         resp.raise_for_status()
-        body = await resp.json()
+        try:
+            body = await resp.json()
+        except (TimeoutError, aiohttp.ClientError, ValueError) as err:
+            raise NanitConnectionError(f"Invalid events response: {err}") from err
 
         return [
             CloudEvent(

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -56,6 +56,24 @@ class TestLogin:
             with pytest.raises(NanitAuthError, match="Invalid credentials"):
                 await client.async_login("user@test.com", "wrong")
 
+    async def test_login_timeout_is_connection_error(self, client: NanitRestClient) -> None:
+        """aiohttp's total timeout raises builtin TimeoutError, not ClientError."""
+        with aioresponses() as m:
+            m.post(LOGIN_URL, exception=TimeoutError())
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_login("user@test.com", "pass123")
+
+    async def test_login_non_json_response_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        """A non-JSON body (e.g. an HTML error page) is transient, not auth."""
+        with aioresponses() as m:
+            m.post(LOGIN_URL, status=200, body="<html>oops</html>", content_type="text/html")
+
+            with pytest.raises(NanitConnectionError, match="Invalid login response"):
+                await client.async_login("user@test.com", "pass123")
+
     async def test_login_mfa_required(self, client: NanitRestClient) -> None:
         with aioresponses() as m:
             m.post(
@@ -401,6 +419,14 @@ class TestGetBabies:
         assert babies[0].camera_connected is None
         assert babies[0].camera_last_seen is None
 
+    async def test_get_babies_timeout_is_connection_error(self, client: NanitRestClient) -> None:
+        """aiohttp's total timeout raises builtin TimeoutError, not ClientError."""
+        with aioresponses() as m:
+            m.get(BABIES_URL, exception=TimeoutError())
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_get_babies("token123")
+
 
 class TestGetEvents:
     async def test_get_events_success(self, client: NanitRestClient) -> None:
@@ -445,6 +471,23 @@ class TestGetEvents:
             with pytest.raises(NanitConnectionError):
                 await client.async_get_events("token123", "baby123")
 
+    async def test_get_events_timeout_is_connection_error(self, client: NanitRestClient) -> None:
+        """aiohttp's total timeout raises builtin TimeoutError, not ClientError."""
+        with aioresponses() as m:
+            m.get(EVENTS_URL, exception=TimeoutError())
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_get_events("token123", "baby123")
+
+    async def test_get_events_non_json_response_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(EVENTS_URL, status=200, body="<html>oops</html>", content_type="text/html")
+
+            with pytest.raises(NanitConnectionError, match="Invalid events response"):
+                await client.async_get_events("token123", "baby123")
+
 
 class TestGetDeviceToken:
     async def test_get_device_token_success(self, client: NanitRestClient) -> None:
@@ -476,4 +519,23 @@ class TestGetDeviceToken:
             m.get(DEVICE_TOKEN_URL, payload={"user_device_token": {}})
 
             with pytest.raises(NanitConnectionError, match="No token"):
+                await client.async_get_device_token("acc123", "spk001")
+
+    async def test_get_device_token_timeout_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        """aiohttp's total timeout raises builtin TimeoutError, not ClientError."""
+        with aioresponses() as m:
+            m.get(DEVICE_TOKEN_URL, exception=TimeoutError())
+
+            with pytest.raises(NanitConnectionError):
+                await client.async_get_device_token("acc123", "spk001")
+
+    async def test_get_device_token_malformed_body_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(DEVICE_TOKEN_URL, status=200, body="not json", content_type="text/html")
+
+            with pytest.raises(NanitConnectionError, match="Invalid udtokens response"):
                 await client.async_get_device_token("acc123", "spk001")


### PR DESCRIPTION
## What does this do

Fixes #113. aiohttp's total timeout raises the builtin `TimeoutError`, not a `ClientError` subclass. #112 fixed the classification for `async_refresh_token`, and this applies the same treatment to the rest of the client so a hung request anywhere maps to `NanitConnectionError` instead of escaping unclassified:

- `_async_auth_request` (login and MFA), `async_get_babies`, `async_get_events`, and `async_get_device_token` now catch `TimeoutError` alongside `ClientError`.
- Body reads are covered by the same total timeout, so the response parses classify `TimeoutError` too, and the previously unguarded body reads (login, events, udtokens) now wrap transport and JSON failures as `NanitConnectionError` instead of leaking raw aiohttp errors. A proxy error page during login now surfaces as `cannot_connect` in the config flow rather than `unknown`.
- `async_get_device_token` passed no timeout at all, leaving it to the session default, which is 5 minutes on the shared Home Assistant session. It now uses the client's standard 15s timeout, so a blackholed udtokens request can no longer stall the Sound & Light connect path for minutes (the caller is best effort and falls back to the cloud relay).
- Connection error messages now fall back to the exception type name when the exception stringifies empty (`str(TimeoutError())` is an empty string), so logs and the config flow show `TimeoutError` instead of a blank after the colon. This also cleans up the same wart on the #112 refresh path.

## Testing

Seven new regression tests in `test_rest.py`: a `TimeoutError` to `NanitConnectionError` test for each method, plus non-JSON body classification tests for the newly guarded reads. All seven fail without the fix. Full suites green (266 aionanit, 478 unit, coverage 86.8%, mypy strict, ruff). Changelog entry included.

One deliberate non-change: `raise_for_status()` still sits outside the wrapping, so 4xx classification behaves exactly as before. Tightening that is a separate conversation since it changes what callers see for 403/404, and I'd rather keep this PR mechanical.
