### PR TITLE
fix: let mixed camera and camera-less accounts finish setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 
 - Transient network failures during token refresh (DNS blips, timeouts, rate limits) no longer trigger a spurious reauthentication prompt. The token refresh loop now refreshes the token before reconnecting, giving retries five minutes of headroom instead of racing hard expiry in the final minute.
 - All REST calls now classify a hung request or response read (the builtin `TimeoutError` aiohttp raises on its total timeout) as a connection error, matching the token refresh fix above, and connection error messages fall back to the exception type name instead of showing up blank. The Sound & Light device token request also gained the standard 15 second timeout it was missing (#113).
+- Accounts mixing a camera baby with a camera-less baby (a standalone Sound & Light for one child, a camera for another) no longer fail setup in an endless retry loop. The babies parser tolerates rows without a camera_uid, and the optional cloud and network coordinators now degrade to disabled sensors when their first refresh fails instead of blocking the whole entry.
 
 ## [1.8.0] – Unreleased
 

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -240,10 +240,10 @@ class NanitNetworkCoordinator(DataUpdateCoordinator[NetworkInfo | None]):
         reload so HA re-runs setup and registers the camera's entities.
         """
         try:
-            client = self._hub.client
-            assert client.token_manager is not None
-            token = await client.token_manager.async_get_access_token()
-            babies = await client.rest_client.async_get_babies(token)
+            # The hub's tolerant fetch parses camera-less baby rows (mixed
+            # accounts), including on published aionanit wheels whose strict
+            # parser raises KeyError on them.
+            babies = await self._hub.async_get_babies_tolerant()
         except NanitAuthError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
 
 from aionanit.exceptions import (
@@ -197,7 +198,7 @@ class NanitHub:
             self._unsubscribe_tokens = tm.on_tokens_refreshed(self._on_tokens_refreshed)
 
         # Fetch babies (also validates tokens)
-        babies = await self._async_get_babies_tolerant()
+        babies = await self.async_get_babies_tolerant()
 
         self._babies = list(babies)
 
@@ -327,14 +328,15 @@ class NanitHub:
                 ", ".join(failed_cameras),
             )
 
-    async def _async_get_babies_tolerant(self) -> list[Baby]:
+    async def async_get_babies_tolerant(self) -> list[Baby]:
         """Fetch babies, tolerating rows without a camera.
 
-        aionanit's Baby model requires camera_uid and its parser raises
-        KeyError on an account whose baby has no camera paired. Until the
-        library makes the field optional, fall back to parsing the raw
-        /babies response with camera_uid defaulted to "" (treated as
-        "no camera" throughout the hub).
+        aionanit's parser now defaults camera_uid to "" on camera-less
+        rows, but published wheels up to 1.10.0 raise KeyError on them.
+        Keep the raw-parse fallback until the fixed library release is
+        the required minimum (camera_uid "" means "no camera" throughout
+        the hub). Also used by NanitNetworkCoordinator so its polling
+        survives mixed accounts on old wheels.
         """
         try:
             return await self._client.async_get_babies()
@@ -484,12 +486,17 @@ class NanitHub:
         try:
             cloud_coordinator = NanitCloudCoordinator(self._hass, self._entry, self, baby)
             await cloud_coordinator.async_config_entry_first_refresh()
-        except NanitAuthError:
+        except ConfigEntryAuthFailed:
             raise
-        except NanitConnectionError:
+        except ConfigEntryNotReady as err:
+            # first_refresh surfaces every non-auth failure as
+            # ConfigEntryNotReady. This coordinator is optional: degrade to
+            # disabled cloud sensors instead of letting one transient cloud
+            # failure retry-loop the whole entry.
             _LOGGER.warning(
-                "Cloud coordinator for %s failed to start; cloud sensors disabled",
+                "Cloud coordinator for %s failed to start; cloud sensors disabled (%s)",
                 baby.name,
+                err,
             )
             cloud_coordinator = None
 
@@ -500,12 +507,13 @@ class NanitHub:
         try:
             network_coordinator = NanitNetworkCoordinator(self._hass, self._entry, self, baby)
             await network_coordinator.async_config_entry_first_refresh()
-        except NanitAuthError:
+        except ConfigEntryAuthFailed:
             raise
-        except NanitConnectionError:
-            _LOGGER.debug(
-                "Network coordinator for %s failed to start; network sensors disabled",
+        except ConfigEntryNotReady as err:
+            _LOGGER.warning(
+                "Network coordinator for %s failed to start; network sensors disabled (%s)",
                 baby.name,
+                err,
             )
             network_coordinator = None
 

--- a/packages/aionanit/aionanit/models.py
+++ b/packages/aionanit/aionanit/models.py
@@ -138,7 +138,7 @@ class NetworkInfo:
 class Baby:
     uid: str
     name: str
-    camera_uid: str
+    camera_uid: str  # "" = no camera paired (standalone Sound & Light baby)
     speaker_uid: str | None = None
     network: NetworkInfo | None = None
     camera_connected: bool | None = None  # True = camera online per Nanit cloud

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -40,7 +40,7 @@ def _extract_error_message(body: dict[str, Any]) -> str | None:
 
 
 def _sanitize_name(raw: str | None) -> str:
-    if not raw:
+    if not raw or not isinstance(raw, str):
         return ""
     stripped = _HTML_TAG_RE.sub("", raw)
     return "".join(ch for ch in stripped if unicodedata.category(ch)[0] != "C").strip()
@@ -244,11 +244,14 @@ class NanitRestClient:
         except (TimeoutError, aiohttp.ClientError, ValueError) as err:
             raise NanitConnectionError(f"Invalid babies response: {err}") from err
 
+        # A baby without a camera (standalone Sound & Light) has no
+        # camera_uid in its row — default it to "" so mixed accounts parse
+        # instead of raising KeyError on the camera-less row.
         return [
             Baby(
                 uid=baby["uid"],
-                name=_sanitize_name(baby["name"]),
-                camera_uid=baby["camera_uid"],
+                name=_sanitize_name(baby.get("name")),
+                camera_uid=baby.get("camera_uid") or "",
                 speaker_uid=((baby.get("speaker") or {}).get("speaker") or {}).get("uid"),
                 network=_parse_network(baby),
                 camera_connected=_parse_camera_connected(baby),

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -427,6 +427,42 @@ class TestGetBabies:
             with pytest.raises(NanitConnectionError):
                 await client.async_get_babies("token123")
 
+    async def test_get_babies_camera_less_row(self, client: NanitRestClient) -> None:
+        """A speaker-only baby has no camera_uid; mixed accounts must parse."""
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={
+                    "babies": [
+                        {"uid": "baby1", "name": "Ezra", "camera_uid": "cam1"},
+                        {
+                            "uid": "baby2",
+                            "name": "Mae",
+                            "speaker": {"speaker": {"uid": "spk9"}},
+                        },
+                    ]
+                },
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert babies[0].camera_uid == "cam1"
+        assert babies[1].camera_uid == ""
+        assert babies[1].speaker_uid == "spk9"
+
+    async def test_get_babies_null_camera_uid_and_missing_name(
+        self, client: NanitRestClient
+    ) -> None:
+        """Explicit null camera_uid and an absent name both parse defensively."""
+        with aioresponses() as m:
+            m.get(
+                BABIES_URL,
+                payload={"babies": [{"uid": "baby3", "camera_uid": None}]},
+            )
+            babies = await client.async_get_babies("token123")
+
+        assert babies[0].camera_uid == ""
+        assert babies[0].name == ""
+
 
 class TestGetEvents:
     async def test_get_events_success(self, client: NanitRestClient) -> None:

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -9,9 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from aionanit.models import Baby, NetworkInfo
 from custom_components.nanit.const import CONF_CAMERA_IPS, CONF_REFRESH_TOKEN, DOMAIN
+from custom_components.nanit.coordinator import NanitNetworkCoordinator
 from custom_components.nanit.hub import NanitHub
 
 from .conftest import (
@@ -415,8 +418,6 @@ async def test_failed_camera_logs_unknown_cloud_status_on_legacy_baby(
 # Standalone speaker setup (camera optional)
 # ---------------------------------------------------------------------------
 
-Baby = importlib.import_module("aionanit.models").Baby
-
 MOCK_BABY_BOTH = Baby(uid="baby_4", name="Nursery", camera_uid="cam_4", speaker_uid="spk_4")
 MOCK_BABY_SPEAKER_ONLY = Baby(uid="baby_5", name="Den", camera_uid="", speaker_uid="spk_5")
 
@@ -716,3 +717,99 @@ async def test_via_device_cleared_when_camera_fails(hass: HomeAssistant, mock_na
         await hub.async_setup()
 
     assert hub.speaker_data["spk_4"].coordinator.via_camera_uid is None
+
+
+async def test_cloud_coordinator_failure_degrades_not_blocks(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """A failing optional cloud coordinator disables its sensors, not the entry.
+
+    first_refresh surfaces failure as ConfigEntryNotReady; letting it escape
+    _setup_camera would retry-loop the whole entry forever (regression test
+    for the mixed-account setup loop).
+    """
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(
+            async_config_entry_first_refresh=AsyncMock(side_effect=ConfigEntryNotReady())
+        )
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        await hub.async_setup()
+
+    data = hub.camera_data[MOCK_BABY_1.camera_uid]
+    assert data.cloud_coordinator is None
+    assert data.network_coordinator is not None
+
+
+async def test_network_coordinator_failure_degrades_not_blocks(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """A failing optional network coordinator disables its sensors, not the entry."""
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(
+            async_config_entry_first_refresh=AsyncMock(side_effect=ConfigEntryNotReady())
+        )
+        await hub.async_setup()
+
+    data = hub.camera_data[MOCK_BABY_1.camera_uid]
+    assert data.cloud_coordinator is not None
+    assert data.network_coordinator is None
+
+
+async def test_first_refresh_auth_failure_propagates(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """ConfigEntryAuthFailed from a coordinator must still reach HA setup."""
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+    ):
+        push_cls.return_value = MagicMock(async_setup=AsyncMock())
+        cloud_cls.return_value = MagicMock(
+            async_config_entry_first_refresh=AsyncMock(side_effect=ConfigEntryAuthFailed())
+        )
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        with pytest.raises(ConfigEntryAuthFailed):
+            await hub.async_setup()
+
+
+async def test_network_coordinator_survives_camera_less_row(
+    hass: HomeAssistant, mock_nanit_client
+) -> None:
+    """The network coordinator polls via the hub's tolerant fetch.
+
+    A camera-less baby row on a mixed account must not blow up the poll
+    (regression test for the mixed-account setup loop: the coordinator
+    previously used aionanit's strict parser, which raised KeyError).
+    """
+    net = NetworkInfo(ssid="wifi", frequency_mhz=5200, signal_dbm=-50)
+    cam_baby = Baby(uid="baby_1", name="Nursery", camera_uid="cam_1", network=net)
+    speaker_baby = Baby(uid="baby_9", name="Mae", camera_uid="", speaker_uid="spk_9")
+
+    hub = MagicMock()
+    hub.async_get_babies_tolerant = AsyncMock(return_value=[cam_baby, speaker_baby])
+    hub.failed_camera_uids = set()
+    entry = _make_entry(hass)
+
+    coordinator = NanitNetworkCoordinator(hass, entry, hub, cam_baby)
+    assert await coordinator._async_update_data() is net

--- a/tests/unit/test_network_recovery.py
+++ b/tests/unit/test_network_recovery.py
@@ -31,8 +31,7 @@ def _make_entry(hass: HomeAssistant) -> MockConfigEntry:
 def _make_hub(babies: list[object], failed: set[str]) -> MagicMock:
     hub = MagicMock()
     hub.failed_camera_uids = failed
-    hub.client.token_manager.async_get_access_token = AsyncMock(return_value="token")
-    hub.client.rest_client.async_get_babies = AsyncMock(return_value=babies)
+    hub.async_get_babies_tolerant = AsyncMock(return_value=babies)
     return hub
 
 


### PR DESCRIPTION
## What does this do

Fixes a setup loop for accounts that mix a camera baby with a camera-less baby (a standalone Sound & Light for one child, a camera for another) — the bug flagged in #102. Those accounts could never finish setup: the network coordinator fetched `/babies` through aionanit's strict parser, which raises `KeyError` on a row without a `camera_uid`. The first refresh failed, `async_config_entry_first_refresh` turned that into `ConfigEntryNotReady`, and HA retried setup forever. Nothing on the account got entities, including the healthy camera. Single-baby and camera-less-only accounts were unaffected, which is why this survived the beta cycle.

Three layers, any one of which prevents the loop:

1. **aionanit's parser tolerates camera-less rows**: `camera_uid` defaults to an empty string (matching the hub's raw parse, and now documented on the `Baby` model), and a missing or non-string name no longer fails the whole fetch.
2. **The network coordinator polls through the hub's tolerant fetch** (made public as `async_get_babies_tolerant`), so mixed accounts keep their network sensors and the failed-camera auto-recovery even on published aionanit wheels that still carry the strict parser.
3. **The dead degradation handlers in `_setup_camera` work again**: they caught `NanitAuthError`/`NanitConnectionError`, which `first_refresh` never raises (it reports failure as `ConfigEntryNotReady` and re-raises `ConfigEntryAuthFailed`). Any first-refresh failure, transient cloud hiccups included, tore down the whole entry instead of degrading to disabled sensors as designed. They now catch `ConfigEntryNotReady`, log at warning, and let auth failures propagate to trigger reauth.

## Testing

Six new tests: camera-less and null/missing-field rows through the parser, cloud and network coordinator degradation (verified to fail without the fix), auth propagation as a guardrail against a future over-broad catch, and an end-to-end network poll over a mixed baby list. Existing suites green (261 aionanit, 482 unit, coverage 87%, mypy strict, ruff). Also verified: `ConfigEntryNotReady` and `ConfigEntryAuthFailed` are siblings in HA's hierarchy so the degrade catch cannot swallow auth, every consumer of `camera_uid` is gated against the empty string, and the discarded coordinator holds no scheduled refresh (no leaked poller).

Changelog entry included. Note: will need a trivial rebase if #121 merges first (adjacent hunks in `rest.py`/`test_rest.py`/CHANGELOG).
