### PR TITLE
feat: drop password persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - Accounts mixing a camera baby with a camera-less baby (a standalone Sound & Light for one child, a camera for another) no longer fail setup in an endless retry loop. The babies parser tolerates rows without a camera_uid, and the optional cloud and network coordinators now degrade to disabled sensors when their first refresh fails instead of blocking the whole entry.
 - A camera that fails or times out during setup is now stopped instead of left half-connected: previously its sockets and token refresh loops kept running for the entry's lifetime with no entities attached. Session re-initialization after a reconnect is also contained: a failure inside it now logs and defers to the next health check instead of dying as an unretrieved task exception.
 
+### Removed
+
+- **The "Store email and password" option.** The stored password was never read by anything (re-authentication always prompts for it), so it was a plaintext credential sitting in Home Assistant's storage and every backup for no benefit. Existing entries are scrubbed automatically on upgrade (a disabled entry: when it is next enabled), and completing a re-authentication also clears it.
+
 ## [1.8.0] – Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Copy `custom_components/nanit/` into your HA `config/custom_components/` directo
 3. Enter the MFA code sent to your device (use the latest code — they expire quickly).
 4. Done — all devices on your account (cameras and Sound & Light Machines) are discovered automatically.
 
-> [!TIP]
-> Enable **Store credentials** during setup so re-authentication can happen without re-entering your password.
-
 ## What you get
 
 **Per camera:**

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -23,6 +23,7 @@ from .const import (
     CONF_CAMERA_IPS,
     CONF_CAMERA_UID,
     CONF_SPEAKER_IPS,
+    CONF_STORE_CREDENTIALS,
     DOMAIN,
     LOGGER,
     PLATFORMS,
@@ -96,11 +97,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> bo
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate config entry from v1 (single-camera) to v2 (multi-camera per account).
+    """Migrate config entries to the current version.
 
     v1 stored baby/camera info in entry.data and had unique_id = camera_uid.
     v2 stores only auth info in entry.data, camera IPs in options, and uses
     unique_id = email (account-level).
+    v2.2 drops password persistence: any stored password is scrubbed from
+    entry.data (it was never read by anything — reauth always prompts).
     """
     LOGGER.debug("Migrating Nanit config entry from version %s", config_entry.version)
 
@@ -137,6 +140,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         )
 
         LOGGER.info("Migrated Nanit config entry to version 2 (multi-camera support)")
+
+    if config_entry.version == 2 and config_entry.minor_version < 2:
+        new_data = {**config_entry.data}
+        new_data.pop(CONF_PASSWORD, None)
+        new_data.pop(CONF_STORE_CREDENTIALS, None)
+        hass.config_entries.async_update_entry(config_entry, data=new_data, minor_version=2)
+        LOGGER.info("Migrated Nanit config entry to version 2.2 (stored password removed)")
 
     return True
 

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -42,12 +42,13 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
     """
 
     VERSION = 2
+    # 2.2 drops password persistence (the stored password was never read).
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize."""
         self._email: str = ""
         self._password: str = ""
-        self._store_credentials: bool = False
         self._mfa_token: str = ""
         self._access_token: str = ""
         self._refresh_token: str = ""
@@ -65,7 +66,6 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._email = user_input[CONF_EMAIL]
             self._password = user_input[CONF_PASSWORD]
-            self._store_credentials = user_input.get(CONF_STORE_CREDENTIALS, False)
             result = await self._async_attempt_login(
                 email=self._email,
                 password=self._password,
@@ -83,7 +83,6 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_EMAIL): cv.string,
                     vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Optional(CONF_STORE_CREDENTIALS, default=False): cv.boolean,
                 }
             ),
             errors=errors,
@@ -210,12 +209,8 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         data: dict[str, Any] = {
             CONF_ACCESS_TOKEN: self._access_token,
             CONF_REFRESH_TOKEN: self._refresh_token,
-            CONF_STORE_CREDENTIALS: self._store_credentials,
             CONF_EMAIL: self._email,
         }
-
-        if self._store_credentials:
-            data[CONF_PASSWORD] = self._password
 
         return self.async_create_entry(title=title, data=data)
 
@@ -246,7 +241,6 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
                     access_token=access_token,
                     refresh_token=refresh_token,
                     email=email,
-                    password=password,
                 ),
             )
             if result is not None:
@@ -279,7 +273,6 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         access_token: str,
         refresh_token: str,
         email: str | None = None,
-        password: str | None = None,
     ) -> ConfigFlowResult:
         """Update the reauth entry with fresh credentials/tokens."""
         reauth_entry = self._get_reauth_entry()
@@ -292,8 +285,10 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         new_data = {**reauth_entry.data}
         new_data[CONF_ACCESS_TOKEN] = access_token
         new_data[CONF_REFRESH_TOKEN] = refresh_token
-        if reauth_entry.data.get(CONF_STORE_CREDENTIALS):
-            new_data[CONF_PASSWORD] = password or self._password
+        # Scrub any password persisted by older versions. It was never read
+        # by anything (reauth always prompts), so it was pure liability.
+        new_data.pop(CONF_PASSWORD, None)
+        new_data.pop(CONF_STORE_CREDENTIALS, None)
         return self.async_update_reload_and_abort(reauth_entry, data=new_data)
 
     # ------------------------------------------------------------------

--- a/custom_components/nanit/const.py
+++ b/custom_components/nanit/const.py
@@ -30,6 +30,8 @@ NETWORK_POLL_INTERVAL = 300
 # Config Keys
 CONF_MFA_CODE = "mfa_code"
 CONF_MFA_TOKEN = "mfa_token"
+# Legacy (dropped in config entry v2.2): referenced only to scrub the key
+# from entries created by older versions.
 CONF_STORE_CREDENTIALS = "store_credentials"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_BABY_UID = "baby_uid"

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -6,8 +6,7 @@
         "description": "Enter your Nanit account credentials. All cameras on this account will be added automatically.",
         "data": {
           "email": "Email",
-          "password": "Password",
-          "store_credentials": "Store email and password (enables easier re-authentication)"
+          "password": "Password"
         }
       },
       "mfa": {

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -6,8 +6,7 @@
         "description": "Enter your Nanit account credentials. All cameras on this account will be added automatically.",
         "data": {
           "email": "Email",
-          "password": "Password",
-          "store_credentials": "Store email and password (enables easier re-authentication)"
+          "password": "Password"
         }
       },
       "mfa": {

--- a/docs/testing-multi-camera.md
+++ b/docs/testing-multi-camera.md
@@ -36,10 +36,9 @@ If this is your first time, you'll go through the HA onboarding wizard (create u
 2. Click **Add Integration** (bottom right)
 3. Search for **Nanit**
 4. Enter your Nanit **email** and **password**
-5. Check **Store email and password** (makes testing easier)
-6. Click **Submit**
-7. If prompted, enter the **MFA code** sent to your phone
-8. The integration is now added. Your camera should appear as a device.
+5. Click **Submit**
+6. If prompted, enter the **MFA code** sent to your phone
+7. The integration is now added. Your camera should appear as a device.
 
 **Verify:**
 - [ ] Go to **Settings → Devices & Services → Nanit** — you see one device

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,15 +32,20 @@ MOCK_BABY_3 = Baby(uid="baby_3", name="Playroom", camera_uid="cam_3")
 
 def mock_entry_data_v2(
     *,
-    store_credentials: bool = True,
+    legacy_stored_password: bool = False,
 ) -> dict:
+    """Entry data in the current (v2.2) shape.
+
+    legacy_stored_password=True produces the pre-2.2 shape with the
+    store_credentials flag and a plaintext password, for migration tests.
+    """
     data = {
         CONF_ACCESS_TOKEN: MOCK_ACCESS_TOKEN,
         CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
-        CONF_STORE_CREDENTIALS: store_credentials,
         CONF_EMAIL: MOCK_EMAIL,
     }
-    if store_credentials:
+    if legacy_stored_password:
+        data[CONF_STORE_CREDENTIALS] = True
         data[CONF_PASSWORD] = MOCK_PASSWORD
     return data
 

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -98,7 +98,6 @@ async def test_credentials_valid_login_creates_entry(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: True,
         },
     )
 
@@ -107,7 +106,8 @@ async def test_credentials_valid_login_creates_entry(
     assert result_data["result"].version == 2
     assert result_data["result"].unique_id == MOCK_EMAIL
     assert result_data["data"][CONF_EMAIL] == MOCK_EMAIL
-    assert result_data["data"][CONF_PASSWORD] == MOCK_PASSWORD
+    assert CONF_PASSWORD not in result_data["data"]
+    assert CONF_STORE_CREDENTIALS not in result_data["data"]
 
 
 async def test_credentials_mfa_required_goes_to_mfa(
@@ -128,7 +128,6 @@ async def test_credentials_mfa_required_goes_to_mfa(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
 
@@ -154,7 +153,6 @@ async def test_credentials_invalid_auth_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
 
@@ -182,7 +180,6 @@ async def test_credentials_connection_error_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
 
@@ -208,7 +205,6 @@ async def test_credentials_unknown_error_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
 
@@ -236,7 +232,6 @@ async def test_mfa_valid_code_creates_entry(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: True,
         },
     )
     assert result.get("step_id") == "mfa"
@@ -272,7 +267,6 @@ async def test_mfa_invalid_code_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
     result = await hass.config_entries.flow.async_configure(
@@ -307,7 +301,6 @@ async def test_mfa_connection_error_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
     result = await hass.config_entries.flow.async_configure(
@@ -340,7 +333,6 @@ async def test_mfa_unknown_error_shows_error(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
     result = await hass.config_entries.flow.async_configure(
@@ -371,7 +363,6 @@ async def test_duplicate_email_aborts(
         {
             CONF_EMAIL: MOCK_EMAIL,
             CONF_PASSWORD: MOCK_PASSWORD,
-            CONF_STORE_CREDENTIALS: False,
         },
     )
 
@@ -417,7 +408,8 @@ async def test_reauth_valid_login_success_updates_entry(
     assert entry.data[CONF_ACCESS_TOKEN] == MOCK_ACCESS_TOKEN
     assert entry.data[CONF_REFRESH_TOKEN] == MOCK_REFRESH_TOKEN
     assert entry.data[CONF_EMAIL] == MOCK_EMAIL
-    assert entry.data[CONF_PASSWORD] == MOCK_PASSWORD
+    assert CONF_PASSWORD not in entry.data
+    assert CONF_STORE_CREDENTIALS not in entry.data
 
 
 async def test_reauth_mfa_success_updates_entry(
@@ -465,6 +457,7 @@ async def test_reauth_mfa_success_updates_entry(
     assert entry.data[CONF_REFRESH_TOKEN] == MOCK_REFRESH_TOKEN
     assert entry.data[CONF_EMAIL] == MOCK_EMAIL
     assert CONF_PASSWORD not in entry.data
+    assert CONF_STORE_CREDENTIALS not in entry.data
 
 
 async def test_reauth_invalid_auth_shows_error(

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -4,6 +4,7 @@ import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -348,6 +349,53 @@ async def test_migrate_version_gt_2_returns_false(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     assert not await async_migrate_entry(hass, entry)
+
+
+async def test_migrate_v2_2_scrubs_stored_password(hass: HomeAssistant) -> None:
+    """Entries created with the old store-credentials option lose the password."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(legacy_stored_password=True),
+        version=2,
+        minor_version=1,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.minor_version == 2
+    assert "password" not in entry.data
+    assert "store_credentials" not in entry.data
+    assert entry.data[CONF_ACCESS_TOKEN] == mock_entry_data_v2()[CONF_ACCESS_TOKEN]
+
+
+async def test_migrate_v2_2_clean_entry_only_bumps_minor(hass: HomeAssistant) -> None:
+    """An entry without stored credentials migrates to 2.2 unchanged."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        minor_version=1,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.minor_version == 2
+    assert dict(entry.data) == mock_entry_data_v2()
+
+
+async def test_migrate_v1_also_scrubs_stored_password(hass: HomeAssistant) -> None:
+    """A v1 entry runs both migrations in one pass and ends clean at 2.2."""
+    entry = MockConfigEntry(domain=DOMAIN, data=mock_entry_data_v1(), version=1, unique_id="cam_1")
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.minor_version == 2
+    assert "password" not in entry.data
+    assert "store_credentials" not in entry.data
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this do

Removes the "Store email and password" option, completing the decision from the #102 open-decisions round.

An audit confirmed the stored password is write-only dead data: nothing in the integration or aionanit ever reads it. Setup restores authentication purely from tokens, and re-authentication always prompts for the password, so the option's promise of easier re-authentication was never implemented. What it actually did was park a plaintext credential in `.storage/core.config_entries` and every Home Assistant backup.

- The checkbox is gone from the credentials form (strings and translations updated, the README tip and a testing-doc step removed).
- Config entries migrate to v2.2: any stored password and the `store_credentials` flag are scrubbed from entry data. The minor version is used deliberately: a 2.2 entry still loads on older integration code, so downgrades keep working (a `VERSION` bump to 3 would hard-fail them with `MIGRATION_ERROR`).
- Completing a re-authentication also scrubs the legacy keys, covering entries that reauth before they migrate.
- `TO_REDACT` in diagnostics still lists `password`, so not-yet-migrated entries stay redacted.
- `CONF_STORE_CREDENTIALS` remains in `const.py` only for the cleanup code, marked legacy.

One caveat worth knowing: a disabled config entry does not run migrations until it is re-enabled, so its stored password lingers until then. That is Home Assistant framework behavior with no hook available.

## Testing

Three new migration tests (legacy entry scrubbed, clean entry only bumps the minor version, v1 entry runs both migrations in one pass and ends clean) plus updated flow tests asserting no password ever lands in new or reauthed entries. All of them were revert-checked: they fail against the previous code. Downgrade safety was verified empirically against the pre-PR code: a v2.2 entry loads and keeps its data. Full suites green (481 unit, 259 aionanit, coverage 86.8%, mypy strict, ruff).
