### PR TITLE
ci: hassfest and HACS validation, least privilege, pinned lint, gated artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter: stacked PRs (base = another PR's branch) must
+  # run CI too, or they merge into their base unvalidated.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -22,7 +26,9 @@ jobs:
           python-version: "3.14"
 
       - name: Install ruff
-        run: pip install ruff
+        # Same pinned range devs use, so a new ruff minor can't redden CI
+        # without a repo change.
+        run: pip install "$(grep -m1 -E '^ruff[<>=~]' dev/requirements.txt)"
 
       - name: Ruff check
         run: ruff check .
@@ -116,3 +122,27 @@ jobs:
 
       - name: Run mypy on integration
         run: mypy custom_components/nanit --config-file pyproject.toml --python-version 3.14
+
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Deliberately unpinned: hassfest validates against current Home
+      # Assistant rules, and freezing it would freeze the rule set.
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs-validation:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Deliberately unpinned, same reasoning as hassfest.
+      - uses: hacs/action@main
+        with:
+          category: integration
+          # topics: repository topics are a GitHub setting (maintainer).
+          # brands passes: the committed brand/ assets satisfy it.
+          ignore: topics

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${{ env.TAG }}"
+          tag="$TAG"
           version="${tag#v}"
 
           if [[ "$version" == *-beta.* ]]; then
@@ -77,9 +77,8 @@ jobs:
           python-version: "3.14"
 
       - name: Install dependencies
-        run: |
-          pip install ruff
-          pip install -r dev/requirements.txt
+        # dev/requirements.txt carries the pinned ruff range.
+        run: pip install -r dev/requirements.txt
 
       - name: Ruff check
         run: ruff check .
@@ -180,7 +179,10 @@ jobs:
 
   attach-artifact:
     name: Attach Release Artifact
-    needs: [resolve]
+    needs: [resolve, ci-gate]
+    # Betas skip ci-gate (result "skipped"); stable assets require it green
+    # so a release can never ship an artifact off a red gate.
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && (needs.resolve.outputs.is_stable == 'false' || needs.ci-gate.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -209,7 +211,8 @@ jobs:
       - name: Upload release asset
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.resolve.outputs.tag }}" nanit.zip --clobber
+          TAG_REF: ${{ needs.resolve.outputs.tag }}
+        run: gh release upload "$TAG_REF" nanit.zip --clobber
 
   update-main-version:
     name: Update Main Branch Version

--- a/custom_components/nanit/manifest.json
+++ b/custom_components/nanit/manifest.json
@@ -1,10 +1,9 @@
 {
   "domain": "nanit",
   "name": "Nanit",
-  "version": "1.10.0",
-  "homeassistant": "2026.5.0",
-  "documentation": "https://github.com/wealthystudent/ha-nanit",
-  "issue_tracker": "https://github.com/wealthystudent/ha-nanit/issues",
+  "after_dependencies": [
+    "zeroconf"
+  ],
   "codeowners": [
     "@wealthystudent"
   ],
@@ -13,16 +12,16 @@
     "http",
     "lovelace"
   ],
-  "after_dependencies": [
-    "zeroconf"
-  ],
-  "iot_class": "cloud_push",
+  "documentation": "https://github.com/wealthystudent/ha-nanit",
   "integration_type": "hub",
-  "requirements": [
-    "aionanit>=1.10.0"
-  ],
+  "iot_class": "cloud_push",
+  "issue_tracker": "https://github.com/wealthystudent/ha-nanit/issues",
   "loggers": [
     "custom_components.nanit",
     "aionanit"
-  ]
+  ],
+  "requirements": [
+    "aionanit>=1.10.0"
+  ],
+  "version": "1.10.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,15 +71,5 @@ ignore_errors = true
 module = "aionanit.camera"
 disable_error_code = ["attr-defined"]
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
-disallow_untyped_decorators = false
-
-[[tool.mypy.overrides]]
-module = "custom_components.nanit.*"
-disallow_subclassing_any = false
-disallow_untyped_decorators = false
-
 [tool.coverage.run]
 omit = ["custom_components/nanit/aionanit_sl/*"]


### PR DESCRIPTION
## What does this do

Adds the two validation jobs this repo has been missing and tightens the release pipeline. Both new jobs were verified by running the actual containers locally before opening this: hassfest is red on the base branch and green here, and the HACS action passes all checks.

1. **hassfest job**, plus the manifest fixes that make it pass: the `homeassistant` key is removed (it is not a valid manifest key, nothing in HA or this repo reads it, and the enforced HA floor lives in `hacs.json`), and the keys are reordered to the domain, name, then alphabetical order hassfest requires. Without those two fixes the job fails immediately, which is exactly the class of drift it exists to catch.
2. **HACS validation job** (`category: integration`). Only `topics` is ignored: repository topics are a GitHub setting only the repo owner can add. Everything else passes, including `brands` (the committed `brand/` assets satisfy it, so it stays guarded).
3. **Least privilege and pinned lint**: `permissions: contents: read` at the workflow level, and the lint job installs the same pinned ruff range from `dev/requirements.txt` that developers use, so a new ruff minor can no longer redden CI without a repo change (that happened once already during the #112 cycle). The release ci-gate drops its redundant unpinned `pip install ruff`.
4. **Stable release assets now require a green ci-gate**: `attach-artifact` previously ran with `needs: [resolve]` only, so a stable release could ship its zip even when the gate was red. Betas are unaffected (they skip the gate, and the condition fails closed if the stability output were ever missing).
5. **Tag values reach `run:` scripts via env** instead of `${{ }}` expression interpolation, removing a script-injection shape from the workflow.
6. **Dead mypy config deleted**: two override sections never matched anything (mypy resolves the component as `nanit.*` since `custom_components/` has no `__init__.py`, and tests are never typechecked by any invocation). Strict mypy passes without them, and the `warn_unused_configs` note is gone.

## For the maintainer

- Adding repository topics (for example `home-assistant`, `hacs`, `nanit`, `baby-monitor`) lets us drop the last `ignore` from the HACS job.
- With the invalid manifest key gone, the only enforced Home Assistant floor is `hacs.json`'s `2025.12.0`, which matches the README, while the dev/test pins run against 2026.5+. If 2026.5 is the real minimum, `hacs.json` is the place to say so.

## Stacked on #122

Based on `fix/hacs-zip-release` since both touch the same packaging surface. GitHub retargets this PR to main automatically when #122 merges.

## Testing

hassfest container: exit 1 on base (`extra keys not allowed @ data['homeassistant']`, then the ordering error beneath it), exit 0 on this branch. HACS action container: all checks passed, and with the ignore emptied only `topics` fails, confirming the ignore list is exactly right. Skipped-needs semantics for the artifact gate verified against the GitHub Actions docs. YAML and JSON validated, both test suites and ruff green (478 + 259, coverage 86.8%), mypy strict clean with no unused-config note.
