### PR TITLE
fix: config flow correctness sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 ### Fixed
 
 - Transient network failures during token refresh (DNS blips, timeouts, rate limits) no longer trigger a spurious reauthentication prompt. The token refresh loop now refreshes the token before reconnecting, giving retries five minutes of headroom instead of racing hard expiry in the final minute.
+- Config flow robustness: re-adding the account with different email casing no longer creates a duplicate entry (emails are treated case-insensitively, matching Nanit), the MFA step recovers when the server re-issues a fresh challenge instead of dead-ending on a stale token, re-authentication works on entries that never stored an email, and saving device IPs no longer wipes options the IP form does not manage.
 
 ### Removed
 

--- a/custom_components/nanit/config_flow.py
+++ b/custom_components/nanit/config_flow.py
@@ -64,7 +64,7 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            self._email = user_input[CONF_EMAIL]
+            self._email = user_input[CONF_EMAIL].strip()
             self._password = user_input[CONF_PASSWORD]
             result = await self._async_attempt_login(
                 email=self._email,
@@ -121,7 +121,8 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
             return step_result
         except NanitAuthError:
             errors["base"] = "invalid_auth"
-        except NanitConnectionError:
+        except NanitConnectionError as err:
+            LOGGER.debug("Login connection error: %s", err)
             errors["base"] = "cannot_connect"
         except Exception:
             LOGGER.exception(unknown_error_log)
@@ -154,9 +155,17 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
                 result = await client.async_verify_mfa(
                     self._email, self._password, self._mfa_token, mfa_code
                 )
+            except NanitMfaRequiredError as err:
+                # The server re-challenged with a fresh mfa_token (the held
+                # one went stale). Adopt it so the user's retry verifies
+                # against the new token instead of dead-ending forever.
+                # Must precede NanitAuthError: it is a subclass of it.
+                self._mfa_token = err.mfa_token
+                errors["base"] = "invalid_mfa_code"
             except NanitAuthError:
                 errors["base"] = "invalid_mfa_code"
-            except NanitConnectionError:
+            except NanitConnectionError as err:
+                LOGGER.debug("MFA verification connection error: %s", err)
                 errors["base"] = "cannot_connect"
             except Exception:
                 LOGGER.exception(unknown_error_log)
@@ -189,8 +198,22 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         One entry per account — unique_id is the email address.
         All cameras on the account are auto-discovered during setup.
         """
-        await self.async_set_unique_id(self._email)
+        # Nanit treats emails case-insensitively, so the unique_id must
+        # too, or re-adding the account with different casing creates a
+        # duplicate entry with two hubs fighting over the same devices.
+        normalized_email = self._email.lower()
+        await self.async_set_unique_id(normalized_email)
         self._abort_if_unique_id_configured()
+        # Entries created before normalization may carry a mixed-case
+        # unique_id, and a migrated v1 entry may still carry a camera uid
+        # as its unique_id — match the stored email too so neither can be
+        # added a second time.
+        for entry in self._async_current_entries(include_ignore=False):
+            entry_email = (entry.data.get(CONF_EMAIL) or "").strip().lower()
+            if entry_email == normalized_email or (
+                entry.unique_id and entry.unique_id.lower() == normalized_email
+            ):
+                return self.async_abort(reason="already_configured")
 
         # Determine a friendly title (try to fetch baby names)
         title = "Nanit"
@@ -209,7 +232,7 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         data: dict[str, Any] = {
             CONF_ACCESS_TOKEN: self._access_token,
             CONF_REFRESH_TOKEN: self._refresh_token,
-            CONF_EMAIL: self._email,
+            CONF_EMAIL: normalized_email,
         }
 
         return self.async_create_entry(title=title, data=data)
@@ -229,7 +252,7 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            email = user_input[CONF_EMAIL]
+            email = user_input[CONF_EMAIL].strip()
             password = user_input[CONF_PASSWORD]
             result = await self._async_attempt_login(
                 email=email,
@@ -276,15 +299,21 @@ class NanitConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Update the reauth entry with fresh credentials/tokens."""
         reauth_entry = self._get_reauth_entry()
-        provided_email = email or self._email
+        provided_email = (email or self._email).strip()
 
         # Prevent credential swap: the reauth email must match the original.
-        if provided_email.lower() != reauth_entry.data[CONF_EMAIL].lower():
+        # An entry with no stored email (possible for a migrated v1 entry
+        # that never stored one) has nothing to compare against — accept
+        # and adopt the provided email below instead of crashing.
+        stored_email = reauth_entry.data.get(CONF_EMAIL, "")
+        if stored_email and provided_email.lower() != stored_email.strip().lower():
             return self.async_abort(reason="reauth_email_mismatch")
 
         new_data = {**reauth_entry.data}
         new_data[CONF_ACCESS_TOKEN] = access_token
         new_data[CONF_REFRESH_TOKEN] = refresh_token
+        if not stored_email:
+            new_data[CONF_EMAIL] = provided_email
         # Scrub any password persisted by older versions. It was never read
         # by anything (reauth always prompts), so it was pure liability.
         new_data.pop(CONF_PASSWORD, None)
@@ -406,9 +435,13 @@ class NanitOptionsFlow(OptionsFlow):
                     else:
                         current_speaker_ips.pop(speaker_uid, None)
 
+                # Merge over the existing options rather than replacing
+                # them wholesale, so any option added elsewhere in the
+                # future survives an IP edit.
                 return self.async_create_entry(
                     title="",
                     data={
+                        **self.config_entry.options,
                         CONF_CAMERA_IPS: current_ips,
                         CONF_SPEAKER_IPS: current_speaker_ips,
                     },

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -888,3 +888,192 @@ async def test_options_flow_unresolved_speaker_keeps_legacy_ip(
     result_data = _as_dict(result)
     assert result_data.get("type") is FlowResultType.CREATE_ENTRY
     assert result_data["data"][CONF_SPEAKER_IPS] == {"cam_1": "192.168.1.90"}
+
+
+async def test_credentials_duplicate_email_different_case_aborts(
+    hass: HomeAssistant,
+    mock_config_flow_client,
+) -> None:
+    """Re-adding the account with different email casing must not duplicate."""
+    hass = await _resolve_hass(hass)
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ACCESS_TOKEN: MOCK_ACCESS_TOKEN,
+            CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
+            CONF_EMAIL: MOCK_EMAIL,
+        },
+        unique_id=MOCK_EMAIL,
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EMAIL: "  Test@Example.COM ", CONF_PASSWORD: MOCK_PASSWORD},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.ABORT
+    assert result_data.get("reason") == "already_configured"
+
+
+async def test_credentials_duplicate_of_legacy_mixed_case_unique_id_aborts(
+    hass: HomeAssistant,
+    mock_config_flow_client,
+) -> None:
+    """Entries created before normalization keep mixed-case unique_ids."""
+    hass = await _resolve_hass(hass)
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ACCESS_TOKEN: MOCK_ACCESS_TOKEN,
+            CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
+            CONF_EMAIL: "Test@Example.com",
+        },
+        unique_id="Test@Example.com",
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EMAIL: MOCK_EMAIL, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.ABORT
+    assert result_data.get("reason") == "already_configured"
+
+
+async def test_mfa_rechallenge_adopts_fresh_token(
+    hass: HomeAssistant,
+    mock_config_flow_client,
+) -> None:
+    """A server re-challenge mid-MFA swaps in the fresh token for the retry.
+
+    NanitMfaRequiredError subclasses NanitAuthError; before the fix the MFA
+    handler swallowed the re-challenge as invalid_mfa_code and every retry
+    verified against the stale token forever.
+    """
+    hass = await _resolve_hass(hass)
+    mock_config_flow_client.async_login.side_effect = nanit_config_flow.NanitMfaRequiredError(
+        mfa_token=MOCK_MFA_TOKEN
+    )
+    mock_config_flow_client.async_verify_mfa.side_effect = [
+        nanit_config_flow.NanitMfaRequiredError(mfa_token="fresh_mfa_token"),
+        {"access_token": MOCK_ACCESS_TOKEN, "refresh_token": MOCK_REFRESH_TOKEN},
+    ]
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EMAIL: MOCK_EMAIL, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+    assert result.get("step_id") == "mfa"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MFA_CODE: "111111"},
+    )
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.FORM
+    assert _as_dict(result_data.get("errors")).get("base") == "invalid_mfa_code"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MFA_CODE: "222222"},
+    )
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+
+    second_call = mock_config_flow_client.async_verify_mfa.call_args_list[1]
+    assert second_call.args[2] == "fresh_mfa_token"
+
+
+async def test_reauth_entry_without_stored_email_succeeds_and_adopts(
+    hass: HomeAssistant,
+    mock_config_flow_client,
+) -> None:
+    """Reauth on an entry with no stored email must not KeyError."""
+    hass = await _resolve_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ACCESS_TOKEN: "old_access",
+            CONF_REFRESH_TOKEN: "old_refresh",
+        },
+        unique_id="cam_legacy",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reauth", "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EMAIL: MOCK_EMAIL, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "reauth_successful"
+    assert entry.data[CONF_EMAIL] == MOCK_EMAIL
+    assert entry.data[CONF_ACCESS_TOKEN] == MOCK_ACCESS_TOKEN
+
+
+async def test_options_flow_preserves_unrelated_options(hass: HomeAssistant) -> None:
+    """An IP edit must merge into existing options, not replace them."""
+    hass = await _resolve_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={CONF_CAMERA_IPS: {}, "future_option": "keep-me"},
+    )
+    entry.runtime_data = SimpleNamespace(
+        hub=SimpleNamespace(babies=[MOCK_BABY_1], speaker_uid_map={})
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_CAMERA_IP: "192.168.1.42"},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.CREATE_ENTRY
+    assert result_data["data"]["future_option"] == "keep-me"
+    assert result_data["data"][CONF_CAMERA_IPS] == {MOCK_BABY_1.camera_uid: "192.168.1.42"}
+
+
+async def test_credentials_duplicate_of_legacy_camera_uid_entry_aborts(
+    hass: HomeAssistant,
+    mock_config_flow_client,
+) -> None:
+    """A migrated v1 entry can still carry a camera uid as its unique_id.
+
+    Neither unique_id comparison can see it, so the guard must also match
+    the entry's stored email.
+    """
+    hass = await _resolve_hass(hass)
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ACCESS_TOKEN: MOCK_ACCESS_TOKEN,
+            CONF_REFRESH_TOKEN: MOCK_REFRESH_TOKEN,
+            CONF_EMAIL: "Test@Example.com",
+        },
+        unique_id="cam_legacy_uid",
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EMAIL: MOCK_EMAIL, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+
+    result_data = _as_dict(result)
+    assert result_data.get("type") is FlowResultType.ABORT
+    assert result_data.get("reason") == "already_configured"


### PR DESCRIPTION
## What does this do

Four correctness fixes in the config and options flows, all from the recent audit.

1. **Duplicate accounts can no longer be added.** Nanit treats emails case-insensitively but the entry unique_id comparison was exact, so re-adding the account as `Foo@x.com` over `foo@x.com` bypassed `already_configured` and created a second entry with two hubs fighting over the same devices. Emails are now stripped and lowercased before becoming the unique_id, and the guard also matches existing entries case-insensitively by unique_id **and** by stored email — the latter closes the same hole for migrated v1 entries that still carry a camera uid as their unique_id (reproduced during review: those produced a duplicate through every other guard).
2. **The MFA step recovers from a server re-challenge.** When the held `mfa_token` goes stale the server re-issues a fresh one, but `NanitMfaRequiredError` subclasses `NanitAuthError` and the handler caught the parent first, so the fresh token was discarded and every retry dead-ended against the stale token with "Invalid verification code", forever. The re-challenge now swaps the fresh token in, so the next code entry works. The shared handler fixes the reauth MFA path too.
3. **Reauth works on entries without a stored email.** A migrated v1 entry that never stored one crashed reauth with a raw `KeyError`; the provided email is now adopted into the entry instead, and the email-mismatch guard arms itself from then on. Reauth input is also stripped, matching the credentials step.
4. **Saving device IPs merges into existing options** instead of rewriting them wholesale, so any option added elsewhere in the future survives an IP edit. The `cannot_connect` branches also log the underlying error at debug (previously silent).

## Testing

Six new regression tests, each verified to fail with its fix individually reverted: different-casing duplicate, legacy mixed-case unique_id duplicate, legacy camera-uid unique_id duplicate (matched via stored email), MFA re-challenge token adoption (asserts the second verify call uses the fresh token), email-less reauth, and options preservation. Full suites green (487 unit, 259 aionanit, coverage 86.8%, mypy strict, ruff). Also verified during review: the duplicate guard cannot self-match the in-progress flow, cannot fire on reauth paths (structurally unreachable), and excluding ignored entries matches Home Assistant's own convention.
