### PR TITLE
fix: stop half-started cameras on failed setup, contain reconnect re-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - Transient network failures during token refresh (DNS blips, timeouts, rate limits) no longer trigger a spurious reauthentication prompt. The token refresh loop now refreshes the token before reconnecting, giving retries five minutes of headroom instead of racing hard expiry in the final minute.
 - All REST calls now classify a hung request or response read (the builtin `TimeoutError` aiohttp raises on its total timeout) as a connection error, matching the token refresh fix above, and connection error messages fall back to the exception type name instead of showing up blank. The Sound & Light device token request also gained the standard 15 second timeout it was missing (#113).
 - Accounts mixing a camera baby with a camera-less baby (a standalone Sound & Light for one child, a camera for another) no longer fail setup in an endless retry loop. The babies parser tolerates rows without a camera_uid, and the optional cloud and network coordinators now degrade to disabled sensors when their first refresh fails instead of blocking the whole entry.
+- A camera that fails or times out during setup is now stopped instead of left half-connected: previously its sockets and token refresh loops kept running for the entry's lifetime with no entities attached. Session re-initialization after a reconnect is also contained: a failure inside it now logs and defers to the next health check instead of dying as an unretrieved task exception.
 
 ## [1.8.0] – Unreleased
 

--- a/custom_components/nanit/hub.py
+++ b/custom_components/nanit/hub.py
@@ -9,6 +9,7 @@ setup handles every combination, including speaker-only accounts.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 from collections.abc import Callable, Coroutine
@@ -479,6 +480,20 @@ class NanitHub:
             local_ip=camera_ip,
         )
 
+        try:
+            await self._async_setup_camera_coordinators(camera, baby)
+        except BaseException:
+            # Setup failed or was cancelled (the wait_for timeout): stop the
+            # half-started camera, or its sockets and refresh loops keep
+            # running for the entry's lifetime with no entities attached.
+            # Shield the cleanup so the cancellation that brought us here
+            # can't abort it midway.
+            with contextlib.suppress(Exception):
+                await asyncio.shield(camera.async_stop())
+            raise
+
+    async def _async_setup_camera_coordinators(self, camera: NanitCamera, baby: Baby) -> None:
+        """Start the coordinators for a created camera and register its data."""
         push_coordinator = NanitPushCoordinator(self._hass, self._entry, camera, baby)
         await push_coordinator.async_setup()
 

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -713,8 +713,20 @@ class NanitCamera:
         so that push-based data resumes after a connection drop.
         """
         _LOGGER.info("Re-initializing session after reconnect")
-        await self._async_request_initial_state()
-        await self._async_enable_sensor_push()
+        try:
+            await self._async_request_initial_state()
+            await self._async_enable_sensor_push()
+        except Exception:
+            # This runs as a fire-and-forget task: anything escaping is an
+            # "exception was never retrieved" log and an aborted re-init.
+            # A request that triggers a failed nested reconnect raises
+            # NanitCameraUnavailable (or auth/connection errors) past the
+            # narrow excepts inside the helpers, so contain everything and
+            # let the health check drive the next recovery attempt.
+            _LOGGER.warning(
+                "Session re-init after reconnect failed; retrying on next health check",
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Internal — state management

--- a/packages/aionanit/tests/test_camera_reliability.py
+++ b/packages/aionanit/tests/test_camera_reliability.py
@@ -397,3 +397,22 @@ async def test_token_refresh_auth_rejection_stops_loop() -> None:
         await asyncio.wait_for(camera._token_refresh_loop(), timeout=0.1)
 
     camera._transport.async_force_reconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reinit_failure_is_contained() -> None:
+    """_async_on_reconnected must not leak exceptions out of its task.
+
+    A request inside re-init can trigger a failed nested reconnect and
+    raise NanitCameraUnavailable; before the fix that escaped the task as
+    an "exception was never retrieved" traceback and aborted the re-init.
+    """
+    camera, _ = _make_camera()
+    camera._async_request_initial_state = AsyncMock(
+        side_effect=NanitCameraUnavailable("camera stopped")
+    )
+    camera._async_enable_sensor_push = AsyncMock()
+
+    await camera._async_on_reconnected()
+
+    camera._async_enable_sensor_push.assert_not_awaited()

--- a/tests/unit/test_hub.py
+++ b/tests/unit/test_hub.py
@@ -813,3 +813,90 @@ async def test_network_coordinator_survives_camera_less_row(
 
     coordinator = NanitNetworkCoordinator(hass, entry, hub, cam_baby)
     assert await coordinator._async_update_data() is net
+
+
+async def test_camera_stopped_when_setup_times_out(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A camera whose setup times out must be stopped, not left running.
+
+    Before the fix, the wait_for cancellation orphaned the half-started
+    camera: its sockets and refresh loops ran for the entry's lifetime
+    with no entities attached.
+    """
+    cams: dict[str, MagicMock] = {}
+
+    def _factory(**kw):
+        cam = _make_mock_camera(kw["uid"], kw["baby_uid"])
+        cams[kw["uid"]] = cam
+        return cam
+
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_1, MOCK_BABY_2]
+    mock_nanit_client.camera.side_effect = _factory
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+        patch("custom_components.nanit.hub._CAMERA_SETUP_TIMEOUT", 0.01),
+    ):
+
+        async def _hang_forever():
+            await asyncio.sleep(3600)
+
+        def push_factory(_hass, _entry, camera, _baby):
+            mock = MagicMock()
+            if camera.uid == MOCK_BABY_1.camera_uid:
+                mock.async_setup = _hang_forever
+            else:
+                mock.async_setup = AsyncMock()
+            return mock
+
+        push_cls.side_effect = push_factory
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        await hub.async_setup()
+
+    cams[MOCK_BABY_1.camera_uid].async_stop.assert_awaited_once()
+    cams[MOCK_BABY_2.camera_uid].async_stop.assert_not_awaited()
+    assert MOCK_BABY_2.camera_uid in hub.camera_data
+
+
+async def test_camera_stopped_when_setup_fails(hass: HomeAssistant, mock_nanit_client) -> None:
+    """A camera whose coordinator setup fails must be stopped too."""
+    cams: dict[str, MagicMock] = {}
+
+    def _factory(**kw):
+        cam = _make_mock_camera(kw["uid"], kw["baby_uid"])
+        cams[kw["uid"]] = cam
+        return cam
+
+    mock_nanit_client.async_get_babies.return_value = [MOCK_BABY_1, MOCK_BABY_2]
+    mock_nanit_client.camera.side_effect = _factory
+
+    entry = _make_entry(hass)
+    hub = NanitHub(hass, MagicMock(), entry)
+
+    with (
+        patch("custom_components.nanit.hub.NanitPushCoordinator") as push_cls,
+        patch("custom_components.nanit.hub.NanitCloudCoordinator") as cloud_cls,
+        patch("custom_components.nanit.hub.NanitNetworkCoordinator") as net_cls,
+    ):
+
+        def push_factory(_hass, _entry, camera, _baby):
+            mock = MagicMock()
+            if camera.uid == MOCK_BABY_1.camera_uid:
+                mock.async_setup = AsyncMock(side_effect=NanitConnectionError("unreachable"))
+            else:
+                mock.async_setup = AsyncMock()
+            return mock
+
+        push_cls.side_effect = push_factory
+        cloud_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        net_cls.return_value = MagicMock(async_config_entry_first_refresh=AsyncMock())
+        await hub.async_setup()
+
+    cams[MOCK_BABY_1.camera_uid].async_stop.assert_awaited_once()
+    assert MOCK_BABY_1.camera_uid in hub.failed_camera_uids
+    assert MOCK_BABY_2.camera_uid in hub.camera_data


### PR DESCRIPTION
## What does this do

Two camera lifecycle leaks from the recent audit.

1. **A camera that fails or times out during setup is now stopped instead of abandoned half-started.** `_setup_camera` runs under a 60s `asyncio.wait_for`; on timeout the cancellation (or on failure, the exception) left the already-created `NanitCamera` behind with its websocket, keepalive, and token refresh loops running for the entry's whole lifetime — a live cloud session with no entities attached, cleaned up only at unload. The camera creation is now separated from coordinator startup, and any exit that does not register the camera stops it, with the cleanup shielded so the very cancellation that triggered it cannot abort it midway.
2. **Session re-initialization after a reconnect contains its failures.** `_async_on_reconnected` runs as a fire-and-forget task, but a request inside it that triggers a failed nested reconnect raises `NanitCameraUnavailable` (or auth/connection errors) past the narrow excepts in its helpers. That escaped the task as an "exception was never retrieved" traceback and aborted the re-init, leaving sensor push disabled until the health check happened to recover it. The body now logs the failure and defers to the health check explicitly.

## Testing

Three new regression tests: a camera whose setup hangs past the timeout gets `async_stop` awaited (and its healthy sibling does not), a camera whose coordinator setup raises gets stopped and lands in `failed_camera_uids`, and a re-init failure inside `_async_on_reconnected` stays contained without leaking from the task. Full suites green (484 unit, 262 aionanit, coverage gate passed, mypy strict, ruff).
