### PR TITLE
feat: retry once on mid-token-life 401 in data calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - All REST calls now classify a hung request or response read (the builtin `TimeoutError` aiohttp raises on its total timeout) as a connection error, matching the token refresh fix above, and connection error messages fall back to the exception type name instead of showing up blank. The Sound & Light device token request also gained the standard 15 second timeout it was missing (#113).
 - Accounts mixing a camera baby with a camera-less baby (a standalone Sound & Light for one child, a camera for another) no longer fail setup in an endless retry loop. The babies parser tolerates rows without a camera_uid, and the optional cloud and network coordinators now degrade to disabled sensors when their first refresh fails instead of blocking the whole entry.
 - A camera that fails or times out during setup is now stopped instead of left half-connected: previously its sockets and token refresh loops kept running for the entry's lifetime with no entities attached. Session re-initialization after a reconnect is also contained: a failure inside it now logs and defers to the next health check instead of dying as an unretrieved task exception.
+- Data calls (babies, events, device token) now retry once on a mid-token-life 401 by refreshing the access token before surfacing the error (#114).
 
 ### Removed
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -38,6 +38,7 @@ from typing import Any
 import aiohttp
 
 from aionanit.auth import TokenManager
+from aionanit.exceptions import NanitAuthError
 from aionanit.rest import NanitRestClient
 
 from .exceptions import NanitTransportError
@@ -210,7 +211,12 @@ class NanitSoundLight:
 
         async def _device_token(uid: str) -> str:
             access = await token_manager.async_get_access_token()
-            return await rest_client.async_get_device_token(access, uid)
+            try:
+                return await rest_client.async_get_device_token(access, uid)
+            except NanitAuthError:
+                await token_manager.async_force_refresh()
+                access = token_manager.access_token
+                return await rest_client.async_get_device_token(access, uid)
 
         self._api = SoundLightTransport(
             access_token_provider=_access_token,

--- a/custom_components/nanit/coordinator.py
+++ b/custom_components/nanit/coordinator.py
@@ -185,11 +185,7 @@ class NanitCloudCoordinator(DataUpdateCoordinator[list[CloudEvent]]):
         """Fetch cloud events from the Nanit API."""
         try:
             client = self._hub.client
-            assert client.token_manager is not None
-            token = await client.token_manager.async_get_access_token()
-            events: list[CloudEvent] = await client.rest_client.async_get_events(
-                token, self.baby.uid
-            )
+            events = await client.async_get_events(self.baby.uid)
             return events
         except NanitAuthError as err:
             raise ConfigEntryAuthFailed(

--- a/packages/aionanit/aionanit/client.py
+++ b/packages/aionanit/aionanit/client.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
 import aiohttp
 
 from .auth import TokenManager
 from .camera import NanitCamera
 from .exceptions import NanitAuthError
-from .models import Baby
+from .models import Baby, CloudEvent
 from .rest import NanitRestClient
 
 _LOGGER = logging.getLogger(__name__)
+_T = TypeVar("_T")
 
 
 class NanitClient:
@@ -119,15 +122,54 @@ class NanitClient:
     async def async_get_babies(self) -> list[Baby]:
         """Fetch babies from the Nanit cloud API.
 
+        Retries once on a mid-token-life 401 by refreshing the token.
+
         Raises:
-            NanitAuthError: If not authenticated or token is invalid.
+            NanitAuthError: If not authenticated or token is invalid after retry.
             NanitConnectionError: If the API is unreachable.
 
+        """
+        return await self._async_with_retry(
+            lambda token: self._rest.async_get_babies(token),
+        )
+
+    async def async_get_events(self, baby_uid: str, limit: int = 20) -> list[CloudEvent]:
+        """Fetch cloud events for a baby.
+
+        Retries once on a mid-token-life 401 by refreshing the token.
+        """
+        return await self._async_with_retry(
+            lambda token: self._rest.async_get_events(token, baby_uid, limit),
+        )
+
+    async def async_get_device_token(self, speaker_uid: str) -> str:
+        """Get a local device token for a Sound & Light speaker.
+
+        Retries once on a mid-token-life 401 by refreshing the token.
+        """
+        return await self._async_with_retry(
+            lambda token: self._rest.async_get_device_token(token, speaker_uid),
+        )
+
+    async def _async_with_retry(
+        self,
+        call: Callable[[str], Awaitable[_T]],
+    ) -> _T:
+        """Get a token, run a data call, and retry once on 401.
+
+        Standard OAuth practice: a mid-token-life server-side revocation
+        should trigger one refresh+retry before surfacing NanitAuthError.
         """
         if self._token_manager is None:
             raise NanitAuthError("Not authenticated — call async_login first")
         token = await self._token_manager.async_get_access_token()
-        return await self._rest.async_get_babies(token)
+        try:
+            return await call(token)
+        except NanitAuthError:
+            _LOGGER.debug("Data call got 401; refreshing token and retrying once")
+            await self._token_manager.async_force_refresh()
+            token = self._token_manager.access_token
+            return await call(token)
 
     # ------------------------------------------------------------------
     # Camera management

--- a/packages/aionanit/tests/test_client.py
+++ b/packages/aionanit/tests/test_client.py
@@ -9,7 +9,7 @@ import pytest
 
 from aionanit.client import NanitClient
 from aionanit.exceptions import NanitAuthError, NanitMfaRequiredError
-from aionanit.models import Baby
+from aionanit.models import Baby, CloudEvent
 
 
 def _make_client() -> tuple[NanitClient, MagicMock]:
@@ -242,3 +242,106 @@ class TestAsyncClose:
         # Should not raise when no cameras exist
         await client.async_close()
         await client.async_close()
+
+
+def _make_authenticated_client() -> NanitClient:
+    """Create a NanitClient with a mocked session and a non-expired token."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = NanitClient(session)
+    # Use the internal TokenManager constructor directly so the token is
+    # not immediately expired (restore_tokens sets expires_in=0).
+    from aionanit.auth import TokenManager
+
+    client._token_manager = TokenManager(client.rest_client, "at", "rt", expires_in=3600.0)
+    return client
+
+
+class TestRetryOn401:
+    async def test_get_babies_retries_on_401(self) -> None:
+        client = _make_authenticated_client()
+        expected = [Baby(uid="b1", name="B", camera_uid="c1")]
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=[NanitAuthError("Access token invalid"), expected],
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fresh_at", "refresh_token": "fresh_rt"},
+            ) as mock_refresh,
+        ):
+            result = await client.async_get_babies()
+
+        assert result == expected
+        mock_refresh.assert_awaited_once()
+
+    async def test_get_events_retries_on_401(self) -> None:
+        client = _make_authenticated_client()
+        expected = [CloudEvent(event_type="MOTION", timestamp=1.0, baby_uid="b1")]
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_events",
+                new_callable=AsyncMock,
+                side_effect=[NanitAuthError("Access token invalid"), expected],
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fresh_at", "refresh_token": "fresh_rt"},
+            ) as mock_refresh,
+        ):
+            result = await client.async_get_events("b1")
+
+        assert result == expected
+        mock_refresh.assert_awaited_once()
+
+    async def test_get_device_token_retries_on_401(self) -> None:
+        client = _make_authenticated_client()
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_device_token",
+                new_callable=AsyncMock,
+                side_effect=[NanitAuthError("Access token invalid"), "device_jwt"],
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fresh_at", "refresh_token": "fresh_rt"},
+            ) as mock_refresh,
+        ):
+            result = await client.async_get_device_token("spk1")
+
+        assert result == "device_jwt"
+        mock_refresh.assert_awaited_once()
+
+    async def test_retry_propagates_if_second_attempt_also_401(self) -> None:
+        client = _make_authenticated_client()
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=NanitAuthError("Access token invalid"),
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fresh_at", "refresh_token": "fresh_rt"},
+            ),
+            pytest.raises(NanitAuthError),
+        ):
+            await client.async_get_babies()
+
+    async def test_no_retry_when_not_authenticated(self) -> None:
+        client, _ = _make_client()
+        with pytest.raises(NanitAuthError, match="Not authenticated"):
+            await client.async_get_events("b1")


### PR DESCRIPTION
Data calls (babies, events, device token) now refresh the access token and retry once on a mid-token-life 401 before surfacing NanitAuthError. Standard OAuth practice, matches what the S&L transport already does.

Closes #114