### PR TITLE
fix: coalesce concurrent 401 token refreshes into one rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - A camera that fails or times out during setup is now stopped instead of left half-connected: previously its sockets and token refresh loops kept running for the entry's lifetime with no entities attached. Session re-initialization after a reconnect is also contained: a failure inside it now logs and defers to the next health check instead of dying as an unretrieved task exception.
 - Data calls (babies, events, device token) now retry once on a mid-token-life 401 by refreshing the access token before surfacing the error (#114).
 - Config flow robustness: re-adding the account with different email casing no longer creates a duplicate entry (emails are treated case-insensitively, matching Nanit), the MFA step recovers when the server re-issues a fresh challenge instead of dead-ending on a stale token, re-authentication works on entries that never stored an email, and saving device IPs no longer wipes options the IP form does not manage.
+- Concurrent 401s now share one token rotation: when several data calls fail on the same access token at once, the first caller refreshes and the rest reuse its result instead of queueing a redundant rotation each. The retry also always sends the freshly rotated token.
 
 ### Removed
 

--- a/custom_components/nanit/aionanit_sl/sound_light.py
+++ b/custom_components/nanit/aionanit_sl/sound_light.py
@@ -214,7 +214,7 @@ class NanitSoundLight:
             try:
                 return await rest_client.async_get_device_token(access, uid)
             except NanitAuthError:
-                await token_manager.async_force_refresh()
+                await token_manager.async_force_refresh(failed_token=access)
                 access = token_manager.access_token
                 return await rest_client.async_get_device_token(access, uid)
 

--- a/packages/aionanit/aionanit/auth.py
+++ b/packages/aionanit/aionanit/auth.py
@@ -91,8 +91,23 @@ class TokenManager:
 
         return self._access_token
 
-    async def async_force_refresh(self) -> None:
+    async def async_force_refresh(self, failed_token: str | None = None) -> None:
+        """Refresh the token pair, coalescing concurrent callers.
+
+        ``failed_token`` is the access token the caller just saw rejected.
+        When several data calls hit a 401 on the same token at once, the
+        first caller through the lock performs the refresh; the rest find
+        the stored token already differs from the one that failed and skip
+        their redundant rotation (without this, N concurrent 401s queue N
+        sequential rotations). Callbacks fire only for the caller that
+        actually refreshed — the skipped callers' tokens were already
+        published by the winner.
+
+        Passing ``None`` refreshes unconditionally.
+        """
         async with self._lock:
+            if failed_token is not None and self._access_token != failed_token:
+                return
             await self._async_refresh()
 
         for callback in self._callbacks:

--- a/packages/aionanit/aionanit/client.py
+++ b/packages/aionanit/aionanit/client.py
@@ -167,7 +167,7 @@ class NanitClient:
             return await call(token)
         except NanitAuthError:
             _LOGGER.debug("Data call got 401; refreshing token and retrying once")
-            await self._token_manager.async_force_refresh()
+            await self._token_manager.async_force_refresh(failed_token=token)
             token = self._token_manager.access_token
             return await call(token)
 

--- a/packages/aionanit/tests/test_auth.py
+++ b/packages/aionanit/tests/test_auth.py
@@ -111,6 +111,81 @@ class TestForceRefresh:
         assert token_manager.refresh_token == "new_refresh"
         mock_rest.async_refresh_token.assert_called_once()
 
+    async def test_force_refresh_with_matching_failed_token_refreshes(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        callback = MagicMock()
+        token_manager.on_tokens_refreshed(callback)
+
+        await token_manager.async_force_refresh(failed_token="initial_access")
+
+        assert token_manager.access_token == "new_access"
+        mock_rest.async_refresh_token.assert_called_once()
+        # The winner MUST publish the fresh pair — callers persist tokens
+        # from this callback, and a silently dropped rotation leaves a dead
+        # refresh token in storage for the next restart.
+        callback.assert_called_once_with("new_access", "new_refresh")
+
+    async def test_force_refresh_skips_when_token_already_rotated(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        """A caller whose failed token was already replaced must not rotate again.
+
+        The skipped caller also must not re-fire callbacks — the caller
+        that performed the refresh already published the fresh pair.
+        """
+        callback = MagicMock()
+        token_manager.on_tokens_refreshed(callback)
+
+        await token_manager.async_force_refresh(failed_token="stale_access")
+
+        assert token_manager.access_token == "initial_access"
+        assert token_manager.refresh_token == "initial_refresh"
+        mock_rest.async_refresh_token.assert_not_called()
+        callback.assert_not_called()
+
+    async def test_concurrent_force_refresh_rotates_once(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        """N callers that all saw the same token fail produce ONE rotation."""
+
+        async def slow_refresh(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return {"access_token": "new_access", "refresh_token": "new_refresh"}
+
+        mock_rest.async_refresh_token.side_effect = slow_refresh
+
+        await asyncio.gather(
+            token_manager.async_force_refresh(failed_token="initial_access"),
+            token_manager.async_force_refresh(failed_token="initial_access"),
+            token_manager.async_force_refresh(failed_token="initial_access"),
+        )
+
+        assert token_manager.access_token == "new_access"
+        assert mock_rest.async_refresh_token.call_count == 1
+
+    async def test_failed_refresh_leaves_next_caller_to_retry(
+        self, token_manager: TokenManager, mock_rest: MagicMock
+    ) -> None:
+        """A winner whose refresh fails must not make later callers skip.
+
+        The failed refresh leaves the token unchanged, so a queued caller
+        holding the same failed token performs its own refresh. Coalescing
+        suppresses redundant successes, never legitimate retries.
+        """
+        mock_rest.async_refresh_token.side_effect = [
+            NanitConnectionError("dns down"),
+            {"access_token": "new_access", "refresh_token": "new_refresh"},
+        ]
+
+        with pytest.raises(NanitConnectionError):
+            await token_manager.async_force_refresh(failed_token="initial_access")
+
+        await token_manager.async_force_refresh(failed_token="initial_access")
+
+        assert token_manager.access_token == "new_access"
+        assert mock_rest.async_refresh_token.call_count == 2
+
 
 class TestUpdateTokens:
     async def test_update_tokens_sets_new_values(self, token_manager: TokenManager) -> None:

--- a/packages/aionanit/tests/test_client.py
+++ b/packages/aionanit/tests/test_client.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiohttp
 import pytest
 
 from aionanit.client import NanitClient
-from aionanit.exceptions import NanitAuthError, NanitMfaRequiredError
+from aionanit.exceptions import NanitAuthError, NanitConnectionError, NanitMfaRequiredError
 from aionanit.models import Baby, CloudEvent
 
 
@@ -345,3 +346,114 @@ class TestRetryOn401:
         client, _ = _make_client()
         with pytest.raises(NanitAuthError, match="Not authenticated"):
             await client.async_get_events("b1")
+
+    async def test_retry_call_uses_fresh_token(self) -> None:
+        """The retry must send the refreshed token, not re-send the failed one."""
+        client = _make_authenticated_client()
+        expected = [Baby(uid="b1", name="B", camera_uid="c1")]
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=[NanitAuthError("Access token invalid"), expected],
+            ) as mock_get_babies,
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fresh_at", "refresh_token": "fresh_rt"},
+            ),
+        ):
+            result = await client.async_get_babies()
+
+        assert result == expected
+        assert mock_get_babies.await_args_list == [call("at"), call("fresh_at")]
+
+    async def test_refresh_connection_error_surfaces_as_connection_error(self) -> None:
+        """A transient refresh failure during the retry is NOT an auth failure.
+
+        Callers map NanitAuthError to a reauth flow, so a DNS blip or
+        timeout during the refresh must surface as NanitConnectionError
+        (retried on the next poll), never force a spurious reauth.
+        """
+        client = _make_authenticated_client()
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=NanitAuthError("Access token invalid"),
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                side_effect=NanitConnectionError("dns down"),
+            ),
+            pytest.raises(NanitConnectionError, match="dns down"),
+        ):
+            await client.async_get_babies()
+
+    async def test_refresh_rejection_propagates_auth_error(self) -> None:
+        """An explicit refresh rejection is a genuine auth failure and surfaces."""
+        client = _make_authenticated_client()
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=NanitAuthError("Access token invalid"),
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                side_effect=NanitAuthError("Refresh token revoked"),
+            ),
+            pytest.raises(NanitAuthError, match="Refresh token revoked"),
+        ):
+            await client.async_get_babies()
+
+    async def test_concurrent_401s_refresh_once(self) -> None:
+        """N data calls that 401 on the same token trigger exactly one rotation."""
+        client = _make_authenticated_client()
+        expected = [Baby(uid="b1", name="B", camera_uid="c1")]
+
+        async def fake_get_babies(token: str) -> list[Baby]:
+            # Yield first so every concurrent caller fetches the stale
+            # token before the first 401 triggers the refresh.
+            await asyncio.sleep(0)
+            if token == "at":
+                raise NanitAuthError("Access token invalid")
+            return expected
+
+        async def slow_refresh(*args: object, **kwargs: object) -> dict[str, str]:
+            # Yield while holding the refresh lock so the other callers
+            # genuinely contend on it, instead of all arriving after the
+            # rotation already completed.
+            await asyncio.sleep(0)
+            return {"access_token": "fresh_at", "refresh_token": "fresh_rt"}
+
+        with (
+            patch.object(
+                client.rest_client,
+                "async_get_babies",
+                new_callable=AsyncMock,
+                side_effect=fake_get_babies,
+            ),
+            patch.object(
+                client.rest_client,
+                "async_refresh_token",
+                new_callable=AsyncMock,
+                side_effect=slow_refresh,
+            ) as mock_refresh,
+        ):
+            results = await asyncio.gather(
+                client.async_get_babies(),
+                client.async_get_babies(),
+                client.async_get_babies(),
+            )
+
+        assert all(r == expected for r in results)
+        mock_refresh.assert_awaited_once()

--- a/tests/unit/test_sound_light.py
+++ b/tests/unit/test_sound_light.py
@@ -11,10 +11,11 @@ suites against in-process fake servers.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
+from aionanit.exceptions import NanitAuthError
 from custom_components.nanit.aionanit_sl import sound_light as sound_light_mod
 from custom_components.nanit.aionanit_sl.exceptions import NanitTransportError
 from custom_components.nanit.aionanit_sl.models import (
@@ -72,6 +73,40 @@ async def _flushed(sl: NanitSoundLight) -> None:
 @pytest.fixture(autouse=True)
 def _fast_coalesce(monkeypatch):
     monkeypatch.setattr(sound_light_mod, "COMMAND_COALESCE_DELAY", 0.01)
+
+
+class TestDeviceTokenFetcher:
+    """The device-token fetcher the facade wires into the transport."""
+
+    async def test_retry_passes_failed_token_and_uses_fresh_one(self) -> None:
+        """On a 401 the fetcher hands the failed token to the refresh and
+        retries with the freshly rotated one."""
+        token_manager = MagicMock()
+        token_manager.async_get_access_token = AsyncMock(return_value="stale_access")
+        token_manager.async_force_refresh = AsyncMock()
+        token_manager.access_token = "fresh_access"
+
+        rest_client = MagicMock()
+        rest_client.base_url = "https://api.nanit.com"
+        rest_client.async_get_device_token = AsyncMock(
+            side_effect=[NanitAuthError("Access token invalid"), "device_jwt"]
+        )
+
+        sl = NanitSoundLight(
+            speaker_uid="L101TEST",
+            token_manager=token_manager,
+            rest_client=rest_client,
+            session=MagicMock(),
+        )
+
+        token = await sl._api._device_token_fetcher("L101TEST")
+
+        assert token == "device_jwt"
+        token_manager.async_force_refresh.assert_awaited_once_with(failed_token="stale_access")
+        assert rest_client.async_get_device_token.await_args_list == [
+            call("stale_access", "L101TEST"),
+            call("fresh_access", "L101TEST"),
+        ]
 
 
 class TestProperties:


### PR DESCRIPTION
Follow-up hardening for #134 (the #114 retry). The retry semantics are sound, but `async_force_refresh` had no dedupe: when several data calls hit a 401 on the same access token at once (startup gathers camera and speaker setup concurrently, and each baby polls its own events coordinator), each caller queued its own rotation behind the refresh lock, so one revoked token could burn four rotations back to back.

`async_force_refresh` now takes the token the caller saw fail. The first caller through the lock refreshes, and everyone queued behind it finds the stored token already changed and skips its redundant rotation. Passing nothing keeps the old unconditional behavior, so the change is backward compatible for library users. Both retry paths pass their failed token: the client's `_async_with_retry` and the S&L device token fetcher.

One deliberate trade: a skipped caller no longer gets the accidental second refresh attempt it used to burn. If the freshly rotated token is also rejected, that surfaces as an auth error, which is the honest reading of "a token the server just issued is already invalid".

The new tests fill the coverage modes #134 was missing:

- The retry asserts on call args now. Nothing previously checked that the retry used the refreshed token, so a retry that resent the stale token passed the whole suite (verified by mutation against the #134 tree).
- A transient failure inside the retry's refresh surfaces as `NanitConnectionError`, never `NanitAuthError`. This is the false-reauth guard from #112, now with a client-level regression test.
- An explicit refresh rejection still propagates as an auth error.
- Three concurrent 401s produce exactly one rotation, with the refresh yielding mid-flight so the other callers genuinely contend on the lock.
- The winner still fires the token persistence callbacks and a skipped caller does not. Dropping the callback loop entirely passed every existing test, which was uncomfortably close to the stored token pair silently going stale.
- A winner whose refresh fails leaves the token unchanged, so the next caller retries instead of skipping.
- The S&L fetcher's retry closure had no coverage at all. It now has a test pinning both the failed-token handoff and the fresh-token retry.

Every new test was verified to fail against the code without its fix.

Left alone on purpose: `client.async_get_device_token` stays even though the integration's S&L path builds its own fetcher (the facade takes a rest client and token manager rather than the full client). It is published library API as of 1.12.0 and mirrors the other data calls. One small window worth knowing about: a main-tracking install running against the published aionanit 1.12.0 wheel would get a `TypeError` from the new keyword on the S&L retry path, which the transport swallows into a relay fallback. That closes when the next release rewrites the manifest floor, same as previous aionanit surface changes.
