### PR TITLE
docs: honest quality scale, action and removal docs, translated errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ All dev and test dependency versions are pinned to minor-version ranges to preve
 - `dev/requirements.txt` — integration dev/test/CI tooling (`>=x.y,<x.(y+1)` ranges)
 - `packages/aionanit/pyproject.toml` `[project.optional-dependencies] dev` — library test deps (`>=x.y,<x.(y+1)` ranges)
 
-**CI Python version**: CI runs Python 3.13. `homeassistant` must stay below `2026.3` (HA 2026.3.0+ requires Python 3.14.2+). The `aiohttp` dev pin must stay below `3.14` (aioresponses 0.7.x incompatible with aiohttp 3.14+).
+**CI Python version**: CI runs Python 3.14, matching current Home Assistant (the `homeassistant` dev pin sits at `>=2026.5,<2026.7`). The `aiohttp` dev pin must stay below `3.14` (aioresponses 0.7.x incompatible with aiohttp 3.14+).
 
 **Runtime dependencies** (`aiohttp`, `protobuf` in `[project] dependencies`) use broader range constraints (e.g., `>=3.9.0,<4`) since exact pins would conflict with Home Assistant's own dependency resolution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - **The speaker's LAN address is now discovered automatically** via mDNS and preferred for sends, with the cloud relay as fallback. Both connections stay open at once. A manually configured speaker IP still works and takes precedence over discovery.
 - **Turning the S&L light off now dims it to zero instead of writing the `noColor` flag**, so the stored color survives and turning the light back on restores it. Previously the light came back white unless a color was re-picked. Turning the light on always re-sends the last color explicitly (the device does not restore color on its own) and, when the device was fully off, keeps sound at "No sound" so the light can't unexpectedly resume audio.
 - **S&L entities now go unavailable when the speaker is unreachable**, matching the camera entities and HA guidance, debounced by a 30 second grace period so brief reconnects don't flash "Unavailable". The connectivity and connection type sensors keep reporting while disconnected.
+- Sound & Light command failures (light, power, sound, track, volume) now surface as translated Home Assistant errors instead of hardcoded English strings.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ humidity_entity_id: sensor.nursery_humidity
 >     type: module
 > ```
 
+## Actions
+
+The integration provides one action:
+
+**`nanit.reset_stream`** targets a Nanit camera entity and discards Home Assistant's cached camera stream, so the next viewer gets a freshly negotiated stream from the Nanit cloud. The bundled dashboard card calls it from its recovery button, and it is useful in automations or scripts when a stream shows a stale or frozen picture. It has no parameters beyond the target.
+
+```yaml
+action: nanit.reset_stream
+target:
+  entity_id: camera.nursery
+```
+
+## Data updates
+
+How each piece of data reaches Home Assistant:
+
+- **Camera sensors** (temperature, humidity, night light, connectivity) arrive as push updates over the camera's WebSocket, so they update in real time.
+- **Motion and sound events** come from the Nanit cloud API, polled every 30 seconds.
+- **Network diagnostics** (WiFi details) are polled every 5 minutes.
+- **Sound & Light state** (power, sound, light, volume) arrives as push updates over the speaker's WebSocket, local or relay. A light 30 second poll reconciles state and refreshes battery and WiFi diagnostics. The firmware version is fetched once per start.
+- **Video** streams on demand over RTMPS when a viewer opens the camera.
+
 ## Local connection (optional)
 
 For faster response times, you can connect directly to your camera over LAN:
@@ -112,6 +134,7 @@ The Sound & Light Machine needs no configuration for this: it is discovered on t
 |---------|----------|
 | MFA code rejected | Codes expire fast — use the latest one. |
 | Stream not playing | Verify HA can reach `rtmps://media-secured.nanit.com` and the Stream integration is enabled. |
+| Stream frozen or stale | Run the `nanit.reset_stream` action on the camera entity (the dashboard card's recovery button does the same). |
 | Sensors unavailable | WebSocket reconnects automatically. Try reloading the integration if it persists. |
 | Local connection failing | Confirm the camera IP is correct and port 442 is reachable from HA. |
 | Re-authentication required | Session expired — click the notification to re-enter credentials. |
@@ -122,6 +145,13 @@ The Sound & Light Machine needs no configuration for this: it is discovered on t
 - Authentication, motion/sound events, and streaming always require the Nanit cloud — no fully offline mode.
 - Motion and sound detection is polled every 30 seconds (up to ~30s delay).
 - Live video requires your HA instance to reach `rtmps://media-secured.nanit.com`.
+
+## Removing the integration
+
+1. Go to **Settings → Devices & Services → Nanit**, open the three dot menu on the entry, and choose **Delete**. This removes all Nanit devices and entities and deletes the stored account tokens.
+2. If you installed through HACS, also remove the repository there: **HACS → Nanit → three dot menu → Remove**, then restart Home Assistant.
+
+The integration keeps no other state on disk. If you use the bundled dashboard card in YAML mode, remove its resource entry as well.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ humidity_entity_id: sensor.nursery_humidity
 
 The integration provides one action:
 
-**`nanit.reset_stream`** targets a Nanit camera entity and discards Home Assistant's cached camera stream, so the next viewer gets a freshly negotiated stream from the Nanit cloud. The bundled dashboard card calls it from its recovery button, and it is useful in automations or scripts when a stream shows a stale or frozen picture. It has no parameters beyond the target.
+**`nanit.reset_stream`** targets a Nanit camera entity and discards Home Assistant's cached camera stream, so the next viewer gets a freshly negotiated stream from the Nanit cloud. The bundled dashboard card calls it automatically when it detects a stalled stream, and it is useful in automations or scripts when a stream shows a stale or frozen picture. It has no parameters beyond the target.
 
 ```yaml
 action: nanit.reset_stream
@@ -117,7 +117,7 @@ How each piece of data reaches Home Assistant:
 - **Camera sensors** (temperature, humidity, night light, connectivity) arrive as push updates over the camera's WebSocket, so they update in real time.
 - **Motion and sound events** come from the Nanit cloud API, polled every 30 seconds.
 - **Network diagnostics** (WiFi details) are polled every 5 minutes.
-- **Sound & Light state** (power, sound, light, volume) arrives as push updates over the speaker's WebSocket, local or relay. A light 30 second poll reconciles state and refreshes battery and WiFi diagnostics. The firmware version is fetched once per start.
+- **Sound & Light state** (power, sound, light, volume) arrives as push updates over the speaker's WebSocket, local or relay. A light 30 second poll reconciles state and refreshes battery and WiFi diagnostics. The firmware version is requested with the poll until known, then left alone.
 - **Video** streams on demand over RTMPS when a viewer opens the camera.
 
 ## Local connection (optional)
@@ -138,7 +138,7 @@ One thing worth knowing: the speaker accepts a single local client at a time. If
 |---------|----------|
 | MFA code rejected | Codes expire fast — use the latest one. |
 | Stream not playing | Verify HA can reach `rtmps://media-secured.nanit.com` and the Stream integration is enabled. |
-| Stream frozen or stale | Run the `nanit.reset_stream` action on the camera entity (the dashboard card's recovery button does the same). |
+| Stream frozen or stale | Run the `nanit.reset_stream` action on the camera entity (the dashboard card does this automatically when it detects a stall). |
 | Sensors unavailable | WebSocket reconnects automatically. Try reloading the integration if it persists. |
 | Local connection failing | Confirm the camera IP is correct and port 442 is reachable from HA. |
 | Re-authentication required | Session expired — click the notification to re-enter credentials. |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Copy `custom_components/nanit/` into your HA `config/custom_components/` directo
 
 Some entities are disabled by default. Enable them in **Settings → Devices & Services → Nanit → Entities**.
 
+> Coming from [nanit-sound-light](https://github.com/com6056/nanit-sound-light)? That integration has merged into this one. Its [migration guide](https://github.com/com6056/nanit-sound-light/blob/main/MIGRATION.md) maps every entity id.
+
 ## Dashboard Card
 
 A companion Lovelace card is **bundled with the integration** — no HACS frontend dependencies or manual JS installation required. After setup, the card appears in your card picker automatically.
@@ -127,6 +129,8 @@ For faster response times, you can connect directly to your camera over LAN:
 The integration will use your local network for sensors and controls, falling back to cloud for auth and events.
 
 The Sound & Light Machine needs no configuration for this: it is discovered on the LAN automatically (mDNS) and the local connection is preferred whenever the speaker is reachable, with the cloud relay as fallback. A manually configured speaker IP takes precedence over discovery.
+
+One thing worth knowing: the speaker accepts a single local client at a time. If the Nanit phone app on the same network holds the local slot, the integration uses the cloud relay and takes the local slot back automatically when it frees up.
 
 ## Troubleshooting
 

--- a/custom_components/nanit/light.py
+++ b/custom_components/nanit/light.py
@@ -27,6 +27,7 @@ from aionanit.models import CameraState, NightLightState
 
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
+from .const import DOMAIN
 from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
 from .entity import NanitEntity, NanitSoundLightEntity
 
@@ -283,7 +284,10 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
 
         except NanitTransportError as err:
             _LOGGER.error("Failed to control Sound & Light light: %s", err)
-            raise HomeAssistantError("Failed to control Sound & Light light") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_light_control_failed",
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
@@ -291,4 +295,7 @@ class NanitSoundLightLight(NanitSoundLightEntity, LightEntity):
             await self.coordinator.sound_light.async_set_light_enabled(False)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn off Sound & Light light: %s", err)
-            raise HomeAssistantError("Failed to turn off Sound & Light light") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_light_off_failed",
+            ) from err

--- a/custom_components/nanit/number.py
+++ b/custom_components/nanit/number.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
+from .const import DOMAIN
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -68,4 +69,7 @@ class NanitSoundMachineVolume(NanitSoundLightEntity, NumberEntity):
             await self.coordinator.sound_light.async_set_volume(value / 100.0)
         except NanitTransportError as err:
             _LOGGER.error("Failed to set sound machine volume: %s", err)
-            raise HomeAssistantError("Failed to set sound machine volume") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_volume_failed",
+            ) from err

--- a/custom_components/nanit/quality_scale.yaml
+++ b/custom_components/nanit/quality_scale.yaml
@@ -11,8 +11,9 @@ rules:
   brands:
     status: done
     comment: >-
-      Served from the in-repo brand/ assets, which HACS treats as a
-      first-class alternative to a home-assistant/brands submission.
+      Brand assets ship in-repo (custom_components/nanit/brand/), which HA
+      core serves for custom integrations without a home-assistant/brands
+      submission.
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done
@@ -65,11 +66,17 @@ rules:
       the LAN. The Sound & Light does advertise via mDNS, but only its local
       transport address is discoverable; an account cannot be set up from it,
       so discovery cannot initiate a config flow.
+  docs-conditions:
+    status: exempt
+    comment: The integration provides no custom conditions.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done
   docs-supported-devices: done
   docs-supported-functions: done
+  docs-triggers:
+    status: exempt
+    comment: The integration provides no custom triggers.
   docs-troubleshooting: done
   docs-use-cases: done
   dynamic-devices:

--- a/custom_components/nanit/quality_scale.yaml
+++ b/custom_components/nanit/quality_scale.yaml
@@ -3,16 +3,21 @@ rules:
   # Bronze
   action-setup:
     status: exempt
-    comment: This integration does not register any actions.
+    comment: >-
+      The only registered action is the reset_stream entity service, which
+      has to be registered by the camera platform (entity services cannot
+      be registered in async_setup).
   appropriate-polling: done
-  brands: done
+  brands:
+    status: done
+    comment: >-
+      Served from the in-repo brand/ assets, which HACS treats as a
+      first-class alternative to a home-assistant/brands submission.
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
-  docs-actions:
-    status: exempt
-    comment: This integration does not register any actions.
+  docs-actions: done
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
@@ -28,8 +33,10 @@ rules:
 
   # Silver
   action-exceptions:
-    status: exempt
-    comment: This integration does not register any actions.
+    status: done
+    comment: >-
+      reset_stream is best-effort cache invalidation with no failure mode to
+      surface. Entity command failures raise translated HomeAssistantError.
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
@@ -38,17 +45,26 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: done
+  test-coverage:
+    status: todo
+    comment: The suite sits at ~87% with the CI gate at 80; the rule wants above 95.
 
   # Gold
   devices: done
   diagnostics: done
   discovery-update-info:
     status: exempt
-    comment: Nanit cameras do not advertise via mDNS/SSDP/DHCP; cloud authentication required.
+    comment: >-
+      Setup is cloud-account based, not host based. The Sound & Light local
+      address is re-resolved via mDNS at runtime by the transport itself,
+      so there is no discovery-sourced config entry data to refresh.
   discovery:
     status: exempt
-    comment: Nanit cameras are cloud-authenticated and do not support local network discovery.
+    comment: >-
+      Setup requires Nanit cloud credentials and cameras do not advertise on
+      the LAN. The Sound & Light does advertise via mDNS, but only its local
+      transport address is discoverable; an account cannot be set up from it,
+      so discovery cannot initiate a config flow.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations: done
@@ -56,7 +72,11 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices: done
+  dynamic-devices:
+    status: todo
+    comment: >-
+      Devices are discovered per baby at setup only; hardware added to the
+      account mid-run needs an integration reload to appear.
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done

--- a/custom_components/nanit/select.py
+++ b/custom_components/nanit/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
-from .const import DEFAULT_SOUND_MACHINE_SOUNDS
+from .const import DEFAULT_SOUND_MACHINE_SOUNDS, DOMAIN
 from .coordinator import NanitSoundLightCoordinator
 from .entity import NanitSoundLightEntity
 
@@ -67,4 +67,8 @@ class NanitSoundSelect(NanitSoundLightEntity, SelectEntity):
             await self.coordinator.sound_light.async_set_track(option)
         except NanitTransportError as err:
             _LOGGER.error("Failed to set sound to %s: %s", option, err)
-            raise HomeAssistantError(f"Failed to set sound to {option}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_track_failed",
+                translation_placeholders={"option": option},
+            ) from err

--- a/custom_components/nanit/strings.json
+++ b/custom_components/nanit/strings.json
@@ -74,6 +74,30 @@
     },
     "cloud_fetch_failed": {
       "message": "Failed to fetch cloud events: {error}"
+    },
+    "sl_light_control_failed": {
+      "message": "Failed to control the Sound & Light light"
+    },
+    "sl_light_off_failed": {
+      "message": "Failed to turn off the Sound & Light light"
+    },
+    "sl_volume_failed": {
+      "message": "Failed to set the sound machine volume"
+    },
+    "sl_power_on_failed": {
+      "message": "Failed to turn on the Sound & Light Machine"
+    },
+    "sl_power_off_failed": {
+      "message": "Failed to turn off the Sound & Light Machine"
+    },
+    "sl_sound_on_failed": {
+      "message": "Failed to turn on the sound"
+    },
+    "sl_sound_off_failed": {
+      "message": "Failed to turn off the sound"
+    },
+    "sl_track_failed": {
+      "message": "Failed to set the sound to {option}"
     }
   },
   "issues": {

--- a/custom_components/nanit/switch.py
+++ b/custom_components/nanit/switch.py
@@ -20,6 +20,7 @@ from aionanit.models import CameraState
 
 from . import NanitConfigEntry
 from .aionanit_sl.exceptions import NanitTransportError
+from .const import DOMAIN
 from .coordinator import NanitPushCoordinator, NanitSoundLightCoordinator
 from .entity import NanitEntity, NanitSoundLightEntity
 
@@ -226,7 +227,10 @@ class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
             await self.coordinator.sound_light.async_set_power(True)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn on S&L device: %s", err)
-            raise HomeAssistantError("Failed to turn on S&L device") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_power_on_failed",
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
@@ -234,7 +238,10 @@ class NanitSLPowerSwitch(NanitSoundLightEntity, SwitchEntity):
             await self.coordinator.sound_light.async_set_power(False)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn off S&L device: %s", err)
-            raise HomeAssistantError("Failed to turn off S&L device") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_power_off_failed",
+            ) from err
 
 
 class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
@@ -266,7 +273,10 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
             await self.coordinator.sound_light.async_set_sound_on(True)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn on S&L sound: %s", err)
-            raise HomeAssistantError("Failed to turn on S&L sound") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_sound_on_failed",
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn sound off."""
@@ -274,4 +284,7 @@ class NanitSLSoundSwitch(NanitSoundLightEntity, SwitchEntity):
             await self.coordinator.sound_light.async_set_sound_on(False)
         except NanitTransportError as err:
             _LOGGER.error("Failed to turn off S&L sound: %s", err)
-            raise HomeAssistantError("Failed to turn off S&L sound") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="sl_sound_off_failed",
+            ) from err

--- a/custom_components/nanit/translations/en.json
+++ b/custom_components/nanit/translations/en.json
@@ -74,6 +74,30 @@
     },
     "cloud_fetch_failed": {
       "message": "Failed to fetch cloud events: {error}"
+    },
+    "sl_light_control_failed": {
+      "message": "Failed to control the Sound & Light light"
+    },
+    "sl_light_off_failed": {
+      "message": "Failed to turn off the Sound & Light light"
+    },
+    "sl_volume_failed": {
+      "message": "Failed to set the sound machine volume"
+    },
+    "sl_power_on_failed": {
+      "message": "Failed to turn on the Sound & Light Machine"
+    },
+    "sl_power_off_failed": {
+      "message": "Failed to turn off the Sound & Light Machine"
+    },
+    "sl_sound_on_failed": {
+      "message": "Failed to turn on the sound"
+    },
+    "sl_sound_off_failed": {
+      "message": "Failed to turn off the sound"
+    },
+    "sl_track_failed": {
+      "message": "Failed to set the sound to {option}"
     }
   },
   "issues": {

--- a/tests/unit/test_sl_entities.py
+++ b/tests/unit/test_sl_entities.py
@@ -214,9 +214,10 @@ async def test_light_turn_on_handles_transport_error_gracefully(
     entity = NanitSoundLightLight(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_turn_on()
 
+    assert excinfo.value.translation_key == "sl_light_control_failed"
     assert "Failed to control Sound & Light light" in caplog.text
 
 
@@ -228,9 +229,10 @@ async def test_light_turn_off_handles_transport_error_gracefully(
     entity = NanitSoundLightLight(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_turn_off()
 
+    assert excinfo.value.translation_key == "sl_light_off_failed"
     assert "Failed to turn off Sound & Light light" in caplog.text
 
 
@@ -278,9 +280,11 @@ async def test_select_select_option_handles_transport_error_gracefully(
     entity = NanitSoundSelect(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_select_option("rain")
 
+    assert excinfo.value.translation_key == "sl_track_failed"
+    assert excinfo.value.translation_placeholders == {"option": "rain"}
     assert "Failed to set sound to rain" in caplog.text
 
 
@@ -324,11 +328,13 @@ async def test_sl_power_switch_handles_transport_error_gracefully(
     entity = NanitSLPowerSwitch(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo_on:
         await entity.async_turn_on()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo_off:
         await entity.async_turn_off()
 
+    assert excinfo_on.value.translation_key == "sl_power_on_failed"
+    assert excinfo_off.value.translation_key == "sl_power_off_failed"
     assert "Failed to turn on S&L device" in caplog.text
     assert "Failed to turn off S&L device" in caplog.text
 
@@ -367,11 +373,13 @@ async def test_sl_sound_switch_handles_transport_error_gracefully(
     entity = NanitSLSoundSwitch(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo_on:
         await entity.async_turn_on()
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo_off:
         await entity.async_turn_off()
 
+    assert excinfo_on.value.translation_key == "sl_sound_on_failed"
+    assert excinfo_off.value.translation_key == "sl_sound_off_failed"
     assert "Failed to turn on S&L sound" in caplog.text
     assert "Failed to turn off S&L sound" in caplog.text
 
@@ -928,8 +936,10 @@ async def test_sl_volume_set_value_handles_transport_error() -> None:
     entity = NanitSoundMachineVolume(coordinator)
     _disable_state_writes(entity)
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await entity.async_set_native_value(75.0)
+
+    assert excinfo.value.translation_key == "sl_volume_failed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An audit against the quality scale found quality_scale.yaml making claims the code does not back, and some gaps were cheap to just close. This PR does both: every rule now states the real position, and the closable ones are closed.

What the file claimed vs reality:

- Three rules were exempt as "does not register any actions", but `nanit.reset_stream` exists. `action-setup` stays exempt with the real reason (an entity service must be registered by its platform, the same pattern core integrations use), `action-exceptions` is done with a comment (reset_stream is best-effort invalidation with no failure mode to surface), and `docs-actions` is done because the README now documents the action.
- `docs-removal-instructions` and `docs-data-update` were done with no matching README sections. Both sections exist now (removal steps, and a push vs poll breakdown with the real intervals).
- `exception-translations` was done while 8 `HomeAssistantError` raises in the S&L command entities were hardcoded English. All 8 are translated now, with tests pinning each key.
- `test-coverage` claimed done at roughly 87 percent with the gate at 80; the rule wants above 95. Now an honest todo.
- `dynamic-devices` claimed done, but devices are only discovered at setup. Now an honest todo: hardware added to the account mid-run needs a reload to appear.
- The discovery exemption said Nanit devices do not advertise on the LAN, which the S&L's own mDNS path contradicts. Reworded to the accurate reason: only the transport address is discoverable and setup still requires cloud credentials, so no discovery-initiated flow is possible.
- `docs-conditions` and `docs-triggers` were missing from the file entirely (HA's schema requires every rule key). Added as exempt, the integration provides neither.
- `brands` now cites the in-repo brand assets, which HA core serves for custom integrations without a home-assistant/brands submission.

Also in here: a README pointer for nanit-sound-light users migrating over (its migration guide maps every entity id), the one-local-client-per-speaker note, and AGENTS.md's CI facts caught up with reality (Python 3.14, HA 2026.5 pins).

Ordering note: the migration guide link points at MIGRATION.md in com6056/nanit-sound-light, which ships with that repo's 0.1.2 release. It will be live before this merges.

Two things worth settling while we are in here, no code in this PR: the enforced HA floor is only hacs.json's 2025.12.0 (README says the same, dev pins run 2026.5, and the manifest cannot carry a homeassistant key per hassfest), so if you want a newer floor, hacs.json is the one place to change it. And hacs.json's `render_readme` is a key current HACS no longer reads, droppable whenever hacs.json is next touched.

One reviewer finding worth knowing: hassfest does not validate quality_scale.yaml for custom integrations at all (it returns early for non-core), so nothing enforces this file. That is exactly how it drifted, and why this pass rechecked every claim against the code.

Happy to split any of this into smaller PRs if you'd rather take it piecemeal!
