### PR TITLE
fix: clamp volume from protobuf, verify snapshot bytes are an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - Data calls (babies, events, device token) now retry once on a mid-token-life 401 by refreshing the access token before surfacing the error (#114).
 - Config flow robustness: re-adding the account with different email casing no longer creates a duplicate entry (emails are treated case-insensitively, matching Nanit), the MFA step recovers when the server re-issues a fresh challenge instead of dead-ending on a stale token, re-authentication works on entries that never stored an email, and saving device IPs no longer wipes options the IP form does not manage.
 - Concurrent 401s now share one token rotation: when several data calls fail on the same access token at once, the first caller refreshes and the rest reuse its result instead of queueing a redundant rotation each. The retry also always sends the freshly rotated token.
+- The camera volume parsed from the protobuf stream is clamped to 0-100 like the night light brightness already was, so a malformed device report can no longer push the media player above 100% volume. Outgoing volume and brightness writes clamp before sending, and the optimistic state now always matches the clamped wire value.
+- Cloud snapshots are checked for image magic bytes (JPEG or PNG) before being returned, so an error page served with HTTP 200 can no longer be published as a camera still.
 
 ### Removed
 

--- a/docs/SECURITY_AUDIT_CHECKLIST.md
+++ b/docs/SECURITY_AUDIT_CHECKLIST.md
@@ -436,7 +436,7 @@ Run through the full checklist against all changes since the last release tag.
 - [ ] Publishing only triggered from protected branches
 - [ ] Build artifacts not influenced by PR content
 
-**ha-nanit specific**: `.github/workflows/ci.yaml` and `publish-aionanit.yaml` — verify action pins and secret handling.
+**ha-nanit specific**: `.github/workflows/ci.yaml`, `release.yaml` (aionanit publishes to PyPI from here via OIDC trusted publishing), and `auto-beta.yaml` — verify action pins and secret handling.
 
 ---
 

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -341,6 +341,13 @@ class NanitCamera:
         night_light_brightness: int | None = None,
     ) -> SettingsState:
         """PUT_SETTINGS request. Only provided fields are sent."""
+        # Clamp percentage fields once, up front, so the wire value and the
+        # optimistic merge below can never disagree.
+        if volume is not None:
+            volume = max(0, min(100, volume))
+        if night_light_brightness is not None:
+            night_light_brightness = max(0, min(100, night_light_brightness))
+
         proto_settings = Settings()
         if night_vision is not None:
             proto_settings.night_vision = night_vision
@@ -353,7 +360,7 @@ class NanitCamera:
         if mic_mute_on is not None:
             proto_settings.mic_mute_on = mic_mute_on
         if night_light_brightness is not None:
-            proto_settings.night_light_brightness = max(0, min(100, night_light_brightness))
+            proto_settings.night_light_brightness = night_light_brightness
 
         resp = cast(
             Any,
@@ -559,7 +566,16 @@ class NanitCamera:
                 timeout=aiohttp.ClientTimeout(total=15),
             )
             if resp.status == 200:
-                return await resp.read()
+                data = await resp.read()
+                if data.startswith((b"\xff\xd8\xff", b"\x89PNG\r\n\x1a\n")):
+                    return data
+                _LOGGER.debug(
+                    "Snapshot endpoint returned a non-image payload (%s, %d bytes) for baby %s",
+                    resp.headers.get("Content-Type", "unknown"),
+                    len(data),
+                    self._baby_uid,
+                )
+                return None
             _LOGGER.debug(
                 "Snapshot endpoint returned %s for baby %s",
                 resp.status,

--- a/packages/aionanit/aionanit/camera.py
+++ b/packages/aionanit/aionanit/camera.py
@@ -63,6 +63,23 @@ from .ws.transport import WsTransport
 
 _LOGGER = logging.getLogger(__name__)
 
+# Magic prefixes for the still-image formats the snapshot endpoint could
+# plausibly serve. WebP needs a slice check: the RIFF header carries a
+# 4-byte size between "RIFF" and "WEBP", so startswith cannot match it.
+_IMAGE_MAGIC_PREFIXES = (
+    b"\xff\xd8\xff",  # JPEG
+    b"\x89PNG\r\n\x1a\n",  # PNG
+    b"GIF87a",  # GIF
+    b"GIF89a",  # GIF
+)
+
+
+def _looks_like_image(data: bytes) -> bool:
+    if data.startswith(_IMAGE_MAGIC_PREFIXES):
+        return True
+    return data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+
+
 Control = proto.Control
 GetControl = proto.GetControl
 GetSensorData = proto.GetSensorData
@@ -554,9 +571,12 @@ class NanitCamera:
     # ------------------------------------------------------------------
 
     async def async_get_snapshot(self) -> bytes | None:
-        """Get a JPEG snapshot from the cloud REST endpoint.
+        """Get a still image snapshot from the cloud REST endpoint.
 
-        Returns None if the endpoint is unavailable or returns an error.
+        The endpoint has served JPEG; common still formats (PNG, WebP,
+        GIF) are accepted too in case that ever changes server-side.
+        Returns None if the endpoint is unavailable, returns an error,
+        or serves something that is not an image.
         """
         try:
             token = await self._token_manager.async_get_access_token()
@@ -567,7 +587,7 @@ class NanitCamera:
             )
             if resp.status == 200:
                 data = await resp.read()
-                if data.startswith((b"\xff\xd8\xff", b"\x89PNG\r\n\x1a\n")):
+                if _looks_like_image(data):
                     return data
                 _LOGGER.debug(
                     "Snapshot endpoint returned a non-image payload (%s, %d bytes) for baby %s",

--- a/packages/aionanit/aionanit/parsers.py
+++ b/packages/aionanit/aionanit/parsers.py
@@ -111,7 +111,7 @@ def _parse_settings_from_proto(settings: object) -> SettingsState:
 
     return SettingsState(
         night_vision=settings.night_vision if settings.HasField("night_vision") else None,
-        volume=settings.volume if settings.HasField("volume") else None,
+        volume=max(0, min(100, settings.volume)) if settings.HasField("volume") else None,
         sleep_mode=settings.sleep_mode if settings.HasField("sleep_mode") else None,
         status_light_on=settings.status_light_on if settings.HasField("status_light_on") else None,
         mic_mute_on=settings.mic_mute_on if settings.HasField("mic_mute_on") else None,

--- a/packages/aionanit/tests/test_camera.py
+++ b/packages/aionanit/tests/test_camera.py
@@ -1024,6 +1024,20 @@ class TestSnapshot:
         result = await cam.async_get_snapshot()
         assert result == png
 
+    async def test_snapshot_accepts_webp(self) -> None:
+        """WebP magic is RIFF....WEBP with a size between, not a prefix."""
+        cam, tm, session = _make_camera()
+        tm.async_get_access_token = AsyncMock(return_value="snap_token")
+
+        webp = b"RIFF\x24\x00\x00\x00WEBPVP8 fake"
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=webp)
+        session.get = AsyncMock(return_value=mock_resp)
+
+        result = await cam.async_get_snapshot()
+        assert result == webp
+
     async def test_snapshot_returns_none_on_exception(self) -> None:
         cam, tm, session = _make_camera()
         tm.async_get_access_token = AsyncMock(side_effect=aiohttp.ClientError("network error"))

--- a/packages/aionanit/tests/test_camera.py
+++ b/packages/aionanit/tests/test_camera.py
@@ -59,6 +59,7 @@ from aionanit.proto import (
     SensorType as ProtoSensorType,
 )
 from aionanit.rest import NanitRestClient
+from aionanit.ws.protocol import decode_message
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -420,6 +421,16 @@ class TestParseSettings:
         proto_settings = Settings(night_light_brightness=-5)
         result = _parse_settings_from_proto(proto_settings)
         assert result.night_light_brightness == 0
+
+    def test_volume_clamped_above_100(self) -> None:
+        proto_settings = Settings(volume=200)
+        result = _parse_settings_from_proto(proto_settings)
+        assert result.volume == 100
+
+    def test_volume_clamped_below_0(self) -> None:
+        proto_settings = Settings(volume=-5)
+        result = _parse_settings_from_proto(proto_settings)
+        assert result.volume == 0
 
 
 class TestParseControl:
@@ -827,6 +838,33 @@ class TestSetSettings:
         assert result.volume == 50  # preserved
         assert cam.state.settings.night_light_brightness == 75
 
+    async def test_set_settings_clamps_out_of_range_values(self) -> None:
+        """Out-of-range percentages are clamped on the wire AND in the
+        optimistic merge, so published state can never disagree with what
+        was actually sent."""
+        cam, *_ = _make_camera()
+        cam._transport = MagicMock()
+        cam._transport.connected = True
+        cam._transport.idle_seconds = 0.0
+
+        resp = Response(status_code=200)
+        sent_frames: list[bytes] = []
+
+        async def _fake_send(data: bytes) -> None:
+            sent_frames.append(data)
+            cam._pending.resolve(1, resp)
+
+        cam._transport.async_send = AsyncMock(side_effect=_fake_send)
+
+        result = await cam.async_set_settings(volume=250, night_light_brightness=-10)
+
+        assert result.volume == 100
+        assert result.night_light_brightness == 0
+        msg = decode_message(sent_frames[0])
+        sent = msg.request.settings
+        assert sent.volume == 100
+        assert sent.night_light_brightness == 0
+
 
 class TestSetControl:
     async def test_updates_state_when_response_has_control(self) -> None:
@@ -936,11 +974,11 @@ class TestSnapshot:
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.read = AsyncMock(return_value=b"\xff\xd8fake_jpeg")
+        mock_resp.read = AsyncMock(return_value=b"\xff\xd8\xff\xe0fake_jpeg")
         session.get = AsyncMock(return_value=mock_resp)
 
         result = await cam.async_get_snapshot()
-        assert result == b"\xff\xd8fake_jpeg"
+        assert result == b"\xff\xd8\xff\xe0fake_jpeg"
 
         session.get.assert_called_once_with(
             "https://api.nanit.com/babies/baby_uid_1/snapshot",
@@ -958,6 +996,33 @@ class TestSnapshot:
 
         result = await cam.async_get_snapshot()
         assert result is None
+
+    async def test_snapshot_returns_none_on_non_image_payload(self) -> None:
+        """A 200 carrying an error page must not be published as an image."""
+        cam, tm, session = _make_camera()
+        tm.async_get_access_token = AsyncMock(return_value="snap_token")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.headers = {"Content-Type": "text/html"}
+        mock_resp.read = AsyncMock(return_value=b"<html>maintenance page</html>")
+        session.get = AsyncMock(return_value=mock_resp)
+
+        result = await cam.async_get_snapshot()
+        assert result is None
+
+    async def test_snapshot_accepts_png(self) -> None:
+        cam, tm, session = _make_camera()
+        tm.async_get_access_token = AsyncMock(return_value="snap_token")
+
+        png = b"\x89PNG\r\n\x1a\nfake_png"
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=png)
+        session.get = AsyncMock(return_value=mock_resp)
+
+        result = await cam.async_get_snapshot()
+        assert result == png
 
     async def test_snapshot_returns_none_on_exception(self) -> None:
         cam, tm, session = _make_camera()


### PR DESCRIPTION
Follow-ups from the security checklist audit, all in the aionanit library.

- The checklist claims volume is clamped at parse time and before sending. It was not: only night_light_brightness was. A malformed device report could push volume past 100 and the media player's volume_level above 1.0 (its contract is 0.0 to 1.0, and the dashboard card renders the value straight into a slider width). Volume now clamps to 0-100 at parse time like brightness, and async_set_settings clamps both percentage fields once up front so the wire value and the optimistic merge can never disagree. Previously an out-of-range brightness was clamped on the wire but stored raw in optimistic state, a small inconsistency this removes.
- Cloud snapshots were returned as-is on any HTTP 200, so an error page served with 200 would be published as a camera still. The bytes are now checked for image magic (JPEG, PNG, GIF, or WebP) before being returned, with a debug log carrying the Content-Type when something else shows up. The accepted set is deliberately wider than the JPEG the endpoint has served, because the failure mode of over-rejecting is a silently blank still.
- The checklist's workflow reference pointed at the deleted publish-aionanit.yaml; it now names release.yaml (the OIDC trusted publishing path) and auto-beta.yaml.

Every fix carries tests verified to fail against the unfixed code, including one that decodes the actual sent frame, so a clamp that only fixed the optimistic state could not pass.

Separate question, no code in this PR: with the manifest pinning aionanit>=1.12.0, whose parser tolerates camera-less rows, the hub's raw /babies fallback looks nearly dead. The one case where it still does anything is a row missing uid entirely (the fallback skips malformed rows instead of failing the scan), which has never been observed in the wild. Removing it would be a sizeable simplification including its tests, but the network coordinator consumes the tolerant path too, so it is your call whether the defensive value is worth the code. Happy to do the removal PR either way!

