### PR TITLE
fix: stop the hub on cancelled setup, classify unhandled HTTP statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to the Nanit Home Assistant integration are documented in th
 - Concurrent 401s now share one token rotation: when several data calls fail on the same access token at once, the first caller refreshes and the rest reuse its result instead of queueing a redundant rotation each. The retry also always sends the freshly rotated token.
 - The camera volume parsed from the protobuf stream is clamped to 0-100 like the night light brightness already was, so a malformed device report can no longer push the media player above 100% volume. Outgoing volume and brightness writes clamp before sending, and the optimistic state now always matches the clamped wire value.
 - Cloud snapshots are checked for image magic bytes (JPEG or PNG) before being returned, so an error page served with HTTP 200 can no longer be published as a camera still.
+- Setup cancelled by Home Assistant partway through (shutdown during startup, a racing reload) now stops any camera and speaker connections the hub had already opened, instead of leaking them for the rest of the process lifetime.
+- HTTP statuses the REST layer does not explicitly handle are now classified as retryable connection errors instead of escaping as raw aiohttp exceptions. A stray 4xx during setup used to hard-fail the entry with no retry, and one during the events poll dumped tracebacks into the log. Deliberately not mapped to auth: the explicit checks already cover every real credential rejection, and Nanit uses 403 for subscription gating, where a reauth prompt could never succeed.
 
 ### Removed
 

--- a/custom_components/nanit/__init__.py
+++ b/custom_components/nanit/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
@@ -44,6 +46,17 @@ class NanitData:
 type NanitConfigEntry = ConfigEntry[NanitData]
 
 
+async def _async_shutdown_hub(hub: NanitHub) -> None:
+    """Close the hub without letting the close mask why setup failed.
+
+    Shielded so a cancellation arriving mid-close cannot abort the
+    cleanup, and suppressed so a close-time error cannot replace the
+    exception that brought us here.
+    """
+    with contextlib.suppress(Exception):
+        await asyncio.shield(hub.async_close())
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> bool:
     """Set up Nanit from a config entry."""
     session = async_get_clientsession(hass)
@@ -52,21 +65,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: NanitConfigEntry) -> boo
     try:
         await hub.async_setup()
     except NanitAuthError as err:
-        await hub.async_close()
+        await _async_shutdown_hub(hub)
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,
             translation_key="auth_failed",
             translation_placeholders={"error": str(err)},
         ) from err
     except NanitConnectionError as err:
-        await hub.async_close()
+        await _async_shutdown_hub(hub)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="connection_failed",
             translation_placeholders={"error": str(err)},
         ) from err
-    except Exception:
-        await hub.async_close()
+    except BaseException:
+        # BaseException also covers CancelledError (HA cancelling setup at
+        # shutdown or during a racing reload), which except Exception missed:
+        # any camera or speaker the hub already started must still be
+        # stopped, or its sockets and refresh loops leak past the cancelled
+        # setup.
+        await _async_shutdown_hub(hub)
         raise
 
     entry.runtime_data = NanitData(hub=hub, cameras=hub.camera_data, speakers=hub.speaker_data)

--- a/packages/aionanit/aionanit/rest.py
+++ b/packages/aionanit/aionanit/rest.py
@@ -18,6 +18,27 @@ from .models import Baby, CloudEvent, NetworkInfo
 DEFAULT_BASE_URL = "https://api.nanit.com"
 _DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=15)
 
+
+def _classify_http_error(resp: aiohttp.ClientResponse, what: str) -> None:
+    """Raise NanitConnectionError for a non-2xx response.
+
+    Every credential rejection the API expresses is already handled by
+    the explicit checks that run before this (401, the refresh 404,
+    error bodies). What reaches here is unexpected: server-side
+    failures, WAF or CDN interference, and Nanit's subscription-gated
+    403s (the probe tooling documents 403 as endpoint-exists-but-
+    subscription-gated, not a credential problem). None of those are
+    fixable by reauthenticating, so everything classifies as a
+    retryable connection error. Mapping any of them to NanitAuthError
+    would stop the coordinator and raise a reauth prompt that can
+    never succeed.
+    """
+    try:
+        resp.raise_for_status()
+    except aiohttp.ClientResponseError as err:
+        raise NanitConnectionError(f"{what} failed with HTTP {err.status}") from err
+
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
@@ -166,7 +187,7 @@ class NanitRestClient:
         if error_msg:
             raise NanitAuthError(error_msg)
 
-        resp.raise_for_status()
+        _classify_http_error(resp, "Login")
 
         return {
             "access_token": body["access_token"],
@@ -212,7 +233,7 @@ class NanitRestClient:
         if error_msg:
             raise NanitAuthError(error_msg)
 
-        resp.raise_for_status()
+        _classify_http_error(resp, "Token refresh")
 
         return {
             "access_token": body["access_token"],
@@ -238,7 +259,7 @@ class NanitRestClient:
         if resp.status >= 500:
             raise NanitConnectionError(f"Babies fetch failed with HTTP {resp.status}")
 
-        resp.raise_for_status()
+        _classify_http_error(resp, "Babies fetch")
         try:
             body = await resp.json()
         except (TimeoutError, aiohttp.ClientError, ValueError) as err:
@@ -293,7 +314,7 @@ class NanitRestClient:
         if resp.status == 401:
             raise NanitAuthError("Access token invalid")
 
-        resp.raise_for_status()
+        _classify_http_error(resp, "Device token fetch")
         try:
             body = await resp.json(content_type=None)
         except (TimeoutError, aiohttp.ClientError, ValueError) as err:
@@ -322,7 +343,7 @@ class NanitRestClient:
         if resp.status == 401:
             raise NanitAuthError("Access token invalid")
 
-        resp.raise_for_status()
+        _classify_http_error(resp, "Events fetch")
         try:
             body = await resp.json()
         except (TimeoutError, aiohttp.ClientError, ValueError) as err:

--- a/packages/aionanit/tests/test_rest.py
+++ b/packages/aionanit/tests/test_rest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from aiohttp import ClientConnectionError, ClientSession
+from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
 from aioresponses import aioresponses
 
 from aionanit.exceptions import (
@@ -575,3 +575,88 @@ class TestGetDeviceToken:
 
             with pytest.raises(NanitConnectionError, match="Invalid udtokens response"):
                 await client.async_get_device_token("acc123", "spk001")
+
+
+class TestHttpErrorClassification:
+    """Statuses the explicit checks don't catch must still classify.
+
+    Everything maps to NanitConnectionError: the explicit checks that run
+    first already cover every real credential rejection, and Nanit uses
+    403 for subscription gating (per the probe tooling), not credentials,
+    so auth mapping here would raise a reauth prompt that can never
+    succeed. Nothing may escape as a raw aiohttp exception: an
+    unclassified 4xx used to hard-fail setup with no retry (or spam
+    tracebacks from the events poll).
+    """
+
+    async def test_login_forbidden_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(LOGIN_URL, status=403, payload={})
+            with pytest.raises(NanitConnectionError, match="HTTP 403"):
+                await client.async_login("user@test.com", "pass123")
+
+    async def test_login_unexpected_4xx_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(LOGIN_URL, status=418, payload={})
+            with pytest.raises(NanitConnectionError, match="HTTP 418"):
+                await client.async_login("user@test.com", "pass123")
+
+    async def test_refresh_forbidden_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.post(REFRESH_URL, status=403, payload={})
+            with pytest.raises(NanitConnectionError, match="HTTP 403"):
+                await client.async_refresh_token("acc", "ref")
+
+    async def test_refresh_unexpected_4xx_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.post(REFRESH_URL, status=400, payload={})
+            with pytest.raises(NanitConnectionError, match="HTTP 400"):
+                await client.async_refresh_token("acc", "ref")
+
+    async def test_get_babies_forbidden_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(BABIES_URL, status=403)
+            with pytest.raises(NanitConnectionError, match="HTTP 403"):
+                await client.async_get_babies("token")
+
+    async def test_get_babies_unexpected_4xx_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(BABIES_URL, status=404)
+            with pytest.raises(NanitConnectionError, match="HTTP 404") as excinfo:
+                await client.async_get_babies("token")
+
+        assert isinstance(excinfo.value.__cause__, ClientResponseError)
+
+    async def test_get_events_forbidden_is_connection_error(self, client: NanitRestClient) -> None:
+        with aioresponses() as m:
+            m.get(EVENTS_URL, status=403)
+            with pytest.raises(NanitConnectionError, match="HTTP 403"):
+                await client.async_get_events("token", "baby123")
+
+    async def test_get_events_unexpected_4xx_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(EVENTS_URL, status=404)
+            with pytest.raises(NanitConnectionError, match="HTTP 404"):
+                await client.async_get_events("token", "baby123")
+
+    async def test_get_device_token_forbidden_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(DEVICE_TOKEN_URL, status=403)
+            with pytest.raises(NanitConnectionError, match="HTTP 403"):
+                await client.async_get_device_token("token", "spk001")
+
+    async def test_get_device_token_unexpected_4xx_is_connection_error(
+        self, client: NanitRestClient
+    ) -> None:
+        with aioresponses() as m:
+            m.get(DEVICE_TOKEN_URL, status=404)
+            with pytest.raises(NanitConnectionError, match="HTTP 404"):
+                await client.async_get_device_token("token", "spk001")

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -86,6 +87,52 @@ async def test_async_setup_entry_connection_error_raises(
     entry.add_to_hass(hass)
 
     with pytest.raises(ConfigEntryNotReady):
+        await async_setup_entry(hass, entry)
+
+
+async def test_async_setup_entry_cancelled_still_closes_hub(
+    hass: HomeAssistant,
+    mock_nanit_client,
+) -> None:
+    """HA cancelling setup must still stop whatever the hub already started.
+
+    CancelledError is not an Exception, so the generic cleanup handler used
+    to miss it and leak live camera and speaker connections past the
+    cancelled setup.
+    """
+    mock_nanit_client.async_get_babies.side_effect = asyncio.CancelledError()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+
+    with pytest.raises(asyncio.CancelledError):
+        await async_setup_entry(hass, entry)
+
+    mock_nanit_client.async_close.assert_awaited_once()
+
+
+async def test_close_failure_does_not_mask_setup_error(
+    hass: HomeAssistant,
+    mock_nanit_client,
+) -> None:
+    """A close-time error must not replace the exception setup failed with."""
+    mock_nanit_client.async_get_babies.side_effect = NanitAuthError("token expired")
+    mock_nanit_client.async_close.side_effect = RuntimeError("close boom")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_entry_data_v2(),
+        version=2,
+        unique_id=MOCK_EMAIL,
+    )
+    entry.add_to_hass(hass)
+
+    with pytest.raises(ConfigEntryAuthFailed):
         await async_setup_entry(hass, entry)
 
 


### PR DESCRIPTION
Two deferred items from the #121 and #127 review notes.

- async_setup_entry's cleanup handler caught Exception, but a cancelled setup raises CancelledError, which is a BaseException. Home Assistant cancelling setup partway (shutdown during startup, a reload racing setup) skipped hub.async_close and leaked every camera and speaker connection the hub had already opened, sockets and token refresh loops included, for the rest of the process lifetime. All three failure handlers now close through one helper that catches BaseException, shields the close against a second cancellation, and keeps a close-time error from masking why setup failed. Same pattern #127 put inside the hub for half-started cameras.
- The REST layer's bare raise_for_status calls let any status the explicit checks did not cover escape as a raw aiohttp exception. A stray 4xx on /babies during setup hard-failed the entry with no retry, and one on /messages dumped tracebacks from the events poll. Those now classify through one helper as NanitConnectionError, which the callers retry. Deliberately not mapped to auth: the explicit checks that run first already cover every credential rejection the API expresses, and our probing showed Nanit uses 403 for subscription gating, where a reauth prompt could never succeed.

Every change carries a regression test verified to fail against the unfixed code.
